### PR TITLE
fix(web): alert modals not clickable when shown above expo-router modals

### DIFF
--- a/sources/modal/components/BaseModal.tsx
+++ b/sources/modal/components/BaseModal.tsx
@@ -57,9 +57,15 @@ export function BaseModal({
             animationType={animationType}
             onRequestClose={onClose}
         >
-            <KeyboardAvoidingView 
+            <KeyboardAvoidingView
                 style={styles.container}
                 behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                // On web, stop events from propagating to expo-router's modal overlay
+                {...(Platform.OS === 'web' ? {
+                    onStartShouldSetResponder: () => true,
+                    onClick: (e: { stopPropagation: () => void }) => e.stopPropagation(),
+                    onPointerDown: (e: { stopPropagation: () => void }) => e.stopPropagation()
+                } : {})}
             >
                 <TouchableWithoutFeedback onPress={handleBackdropPress}>
                     <Animated.View 
@@ -100,7 +106,9 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         justifyContent: 'center',
-        alignItems: 'center'
+        alignItems: 'center',
+        // On web, ensure modal can receive pointer events when body has pointer-events: none
+        ...Platform.select({ web: { pointerEvents: 'auto' as const } })
     },
     backdrop: {
         ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
On web, when an alert modal is shown while an expo-router modal (like "new session") is open, the alert's OK button was unclickable. This happened because expo-router sets pointer-events: none on body and pointer-events: auto on its own overlay, which intercepted clicks meant for our alert modal.

Fix:
- Add pointerEvents: 'auto' to modal container to enable interactions
- Stop event propagation on web to prevent clicks from reaching expo-router's overlay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal interactions on web so keyboard and pointer events no longer propagate to underlying navigation overlays.
  * Ensured modals receive pointer events even when parent elements block interaction, restoring reliable click and touch behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->