### PR TITLE
fix(sync): restore session permission mode from last message across devices

### DIFF
--- a/sources/-session/SessionView.tsx
+++ b/sources/-session/SessionView.tsx
@@ -22,6 +22,7 @@ import { isRunningOnMac } from '@/utils/platform';
 import { useDeviceType, useHeaderHeight, useIsLandscape, useIsTablet } from '@/utils/responsive';
 import { formatPathRelativeToHome, getSessionAvatarId, getSessionName, useSessionStatus } from '@/utils/sessionUtils';
 import { isVersionSupported, MINIMUM_CLI_VERSION } from '@/utils/versionUtils';
+import type { PermissionMode } from '@/constants/PermissionModes';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import * as React from 'react';
@@ -189,7 +190,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     }, [machineId, cliVersion, acknowledgedCliVersions]);
 
     // Function to update permission mode
-    const updatePermissionMode = React.useCallback((mode: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo') => {
+    const updatePermissionMode = React.useCallback((mode: PermissionMode) => {
         storage.getState().updateSessionPermissionMode(sessionId, mode);
     }, [sessionId]);
 

--- a/sources/components/PermissionModeSelector.tsx
+++ b/sources/components/PermissionModeSelector.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { Text, Pressable, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Typography } from '@/constants/Typography';
+import type { PermissionMode } from '@/constants/PermissionModes';
 import { hapticsLight } from './haptics';
 
-export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo';
+export type { PermissionMode } from '@/constants/PermissionModes';
 
 export type ModelMode = 'default' | 'adaptiveUsage' | 'sonnet' | 'opus' | 'gpt-5-codex-high' | 'gpt-5-codex-medium' | 'gpt-5-codex-low' | 'gpt-5-minimal' | 'gpt-5-low' | 'gpt-5-medium' | 'gpt-5-high';
 

--- a/sources/constants/PermissionModes.ts
+++ b/sources/constants/PermissionModes.ts
@@ -1,0 +1,12 @@
+export const PERMISSION_MODES = [
+    'default',
+    'acceptEdits',
+    'bypassPermissions',
+    'plan',
+    'read-only',
+    'safe-yolo',
+    'yolo',
+] as const;
+
+export type PermissionMode = (typeof PERMISSION_MODES)[number];
+

--- a/sources/sync/apiSocket.ts
+++ b/sources/sync/apiSocket.ts
@@ -1,6 +1,7 @@
 import { io, Socket } from 'socket.io-client';
 import { TokenStorage } from '@/auth/tokenStorage';
 import { Encryption } from './encryption/encryption';
+import { observeServerTimestamp } from './time';
 
 //
 // Types
@@ -180,10 +181,26 @@ class ApiSocket {
             ...options?.headers
         };
 
-        return fetch(url, {
+        const response = await fetch(url, {
             ...options,
             headers
         });
+
+        // Best-effort server time calibration using the HTTP Date header ("server now").
+        // This avoids deriving "now" from potentially stale resource timestamps (e.g. session.updatedAt).
+        try {
+            const dateHeader = response.headers.get('date');
+            if (dateHeader) {
+                const serverNow = Date.parse(dateHeader);
+                if (!Number.isNaN(serverNow)) {
+                    observeServerTimestamp(serverNow);
+                }
+            }
+        } catch {
+            // Best-effort only
+        }
+
+        return response;
     }
 
     //

--- a/sources/sync/persistence.ts
+++ b/sources/sync/persistence.ts
@@ -3,7 +3,7 @@ import { Settings, settingsDefaults, settingsParse, SettingsSchema } from './set
 import { LocalSettings, localSettingsDefaults, localSettingsParse } from './localSettings';
 import { Purchases, purchasesDefaults, purchasesParse } from './purchases';
 import { Profile, profileDefaults, profileParse } from './profile';
-import type { PermissionMode } from '@/components/PermissionModeSelector';
+import type { PermissionMode } from '@/constants/PermissionModes';
 
 const mmkv = new MMKV();
 const NEW_SESSION_DRAFT_KEY = 'new-session-draft-v1';
@@ -193,10 +193,17 @@ export function loadSessionPermissionModeUpdatedAts(): Record<string, number> {
     if (raw) {
         try {
             const parsed = JSON.parse(raw);
-            if (!parsed || typeof parsed !== 'object') {
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
                 return {};
             }
-            return parsed;
+
+            const result: Record<string, number> = {};
+            for (const [sessionId, value] of Object.entries(parsed as Record<string, unknown>)) {
+                if (typeof value === 'number' && Number.isFinite(value)) {
+                    result[sessionId] = value;
+                }
+            }
+            return result;
         } catch (e) {
             console.error('Failed to parse session permission mode updated timestamps', e);
             return {};

--- a/sources/sync/settings.ts
+++ b/sources/sync/settings.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { PERMISSION_MODES } from '@/constants/PermissionModes';
 
 //
 // Configuration Profile Schema (for environment variable profiles)
@@ -116,7 +117,7 @@ export const AIBackendProfileSchema = z.object({
     defaultSessionType: z.enum(['simple', 'worktree']).optional(),
 
     // Default permission mode for this profile
-    defaultPermissionMode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'read-only', 'safe-yolo', 'yolo']).optional(),
+    defaultPermissionMode: z.enum(PERMISSION_MODES).optional(),
 
     // Default model mode for this profile
     defaultModelMode: z.string().optional(),

--- a/sources/sync/storageTypes.ts
+++ b/sources/sync/storageTypes.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { PERMISSION_MODES } from "@/constants/PermissionModes";
+import type { PermissionMode } from "@/constants/PermissionModes";
 
 //
 // Agent states
@@ -21,7 +23,10 @@ export const MetadataSchema = z.object({
     homeDir: z.string().optional(), // User's home directory on the machine
     happyHomeDir: z.string().optional(), // Happy configuration directory 
     hostPid: z.number().optional(), // Process ID of the session
-    flavor: z.string().nullish() // Session flavor/variant identifier
+    flavor: z.string().nullish(), // Session flavor/variant identifier
+    // Published by happy-cli so the app can seed permission state even before there are messages.
+    permissionMode: z.enum(PERMISSION_MODES).optional(),
+    permissionModeUpdatedAt: z.number().optional(),
 });
 
 export type Metadata = z.infer<typeof MetadataSchema>;
@@ -69,7 +74,7 @@ export interface Session {
         id: string;
     }>;
     draft?: string | null; // Local draft message, not synced to server
-    permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo' | null; // Local permission mode, not synced to server
+    permissionMode?: PermissionMode | null; // Local permission mode, not synced to server
     permissionModeUpdatedAt?: number | null; // Local timestamp to coordinate inferred (from last message) vs user-selected mode, not synced to server
     modelMode?: 'default' | null; // Local model mode, not synced to server (models configured in CLI)
     // IMPORTANT: latestUsage is extracted from reducerState.latestUsage after message processing.

--- a/sources/sync/sync.ts
+++ b/sources/sync/sync.ts
@@ -31,6 +31,7 @@ import { voiceHooks } from '@/realtime/hooks/voiceHooks';
 import { Message } from './typesMessage';
 import { EncryptionCache } from './encryption/encryptionCache';
 import { systemPrompt } from './prompt/systemPrompt';
+import { nowServerMs } from './time';
 import { fetchArtifact, fetchArtifacts, createArtifact, updateArtifact } from './apiArtifacts';
 import { DecryptedArtifact, Artifact, ArtifactCreateRequest, ArtifactUpdateRequest } from './artifactTypes';
 import { ArtifactEncryption } from './encryption/artifactEncryption';
@@ -270,7 +271,7 @@ class Sync {
         const encryptedRawRecord = await encryption.encryptRawRecord(content);
 
         // Add to messages - normalize the raw record
-        const createdAt = Date.now();
+        const createdAt = nowServerMs();
         const normalizedMessage = normalizeRawMessage(localId, localId, createdAt, content);
         if (normalizedMessage) {
             this.applyMessages(sessionId, [normalizedMessage]);
@@ -1392,7 +1393,7 @@ class Sync {
             throw new Error(`Session encryption not ready for ${sessionId}`);
         }
 
-        // Request
+        // Request (apiSocket.request calibrates server time best-effort from the HTTP Date header)
         const response = await apiSocket.request(`/v1/sessions/${sessionId}/messages`);
         const data = await response.json();
 

--- a/sources/sync/time.ts
+++ b/sources/sync/time.ts
@@ -1,0 +1,17 @@
+let serverTimeOffsetMs = 0;
+
+export function observeServerTimestamp(serverTimestampMs: number | null | undefined) {
+    if (typeof serverTimestampMs !== 'number' || !Number.isFinite(serverTimestampMs)) {
+        return;
+    }
+    serverTimeOffsetMs = serverTimestampMs - Date.now();
+}
+
+/**
+ * Best-effort server-aligned "now" for clock-safe ordering across devices.
+ * Falls back to Date.now() until we observe at least one server timestamp.
+ */
+export function nowServerMs(): number {
+    return Date.now() + serverTimeOffsetMs;
+}
+

--- a/sources/sync/typesMessageMeta.ts
+++ b/sources/sync/typesMessageMeta.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
+import { PERMISSION_MODES } from '@/constants/PermissionModes';
 
 // Shared message metadata schema
 export const MessageMetaSchema = z.object({
     sentFrom: z.string().optional(), // Source identifier
-    permissionMode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'read-only', 'safe-yolo', 'yolo']).optional(), // Permission mode for this message
+    permissionMode: z.enum(PERMISSION_MODES).optional(), // Permission mode for this message
     model: z.string().nullable().optional(), // Model name for this message (null = reset)
     fallbackModel: z.string().nullable().optional(), // Fallback model for this message (null = reset)
     customSystemPrompt: z.string().nullable().optional(), // Custom system prompt for this message (null = reset)

--- a/sources/sync/typesRaw.ts
+++ b/sources/sync/typesRaw.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 import { MessageMetaSchema, MessageMeta } from './typesMessageMeta';
+import { PERMISSION_MODES } from '@/constants/PermissionModes';
 
 //
 // Raw types
@@ -52,7 +53,7 @@ const rawToolResultContentSchema = z.object({
     permissions: z.object({
         date: z.number(),
         result: z.enum(['approved', 'denied']),
-        mode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'read-only', 'safe-yolo', 'yolo']).optional(),
+        mode: z.enum(PERMISSION_MODES).optional(),
         allowedTools: z.array(z.string()).optional(),
         decision: z.enum(['approved', 'approved_for_session', 'denied', 'abort']).optional(),
     }).optional(),


### PR DESCRIPTION
## Summary

Permission mode (yolo/bypassPermissions/etc) is now preserved when switching between devices. The app infers the permission mode from the most recent session's user message metadata, ensuring consistent behavior across mobile and desktop.

**How it works:**
- When a message is sent, the current permission mode is stored in message metadata
- When loading a session on another device, the mode is inferred from the most recent user message
- Local UI toggles are protected from older messages but yield to newer ones

## Fixes

- Closes slopus/happy#206 - 'yolo' mode not sticking in happy app
- Closes slopus/happy#29 - YOLO mode not working
- Closes slopus/happy#229 - Permissions shown in terminal only
- Closes slopus/happy#446 - Yolo mode not always working
- Closes slopus/happy-cli#11 - local mode doesn't continue session from remote mode

## Related

- Related to slopus/happy#46 - Context lost when switching devices
- Related to slopus/happy#102 - improve cross-device experience

## Test plan

- [ ] Set yolo mode on Device A, send message, verify Device B picks up yolo
- [ ] Toggle mode on Device B without sending message, verify it persists on re-sync
- [ ] Send message from Device A after Device B toggle, verify Device A's mode wins
- [ ] Restart app, verify permission mode is restored from persistence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-session permission modes now persist with server-aligned timestamps and survive reloads; inferred modes from recent user messages are applied when newer than local state.
  * Message timing uses server-calibrated timestamps for consistent ordering.
  * Message metadata expanded (display text, allowed/disallowed tools, appended prompts) for richer previews.

* **Bug Fixes**
  * Older in-message inferences no longer overwrite user-chosen modes.
  * User updates to permission mode now timestamp, persist, and clear on session deletion.

* **Style**
  * Permission mode options unified and exposed in the UI selector.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->