### PR TITLE
fix: stabilize PR272 new-session UX, profiles gating, and env safety

### DIFF
--- a/sources/app/(app)/new/pick/profile.tsx
+++ b/sources/app/(app)/new/pick/profile.tsx
@@ -164,7 +164,7 @@ export default React.memo(function ProfilePickerScreen() {
 	                            name="checkmark-circle"
 	                            size={24}
 	                            color={theme.colors.text}
-	                            style={{ opacity: isSelected ? 1 : 0 }}
+	                            style={isSelected ? styles.selectedIndicatorVisible : styles.selectedIndicatorHidden}
                         />
 	                    </View>
 	                    <ItemRowActions
@@ -208,7 +208,7 @@ export default React.memo(function ProfilePickerScreen() {
                         name="checkmark-circle"
                         size={24}
                         color={theme.colors.text}
-                        style={{ opacity: isSelected ? 1 : 0 }}
+                        style={isSelected ? styles.selectedIndicatorVisible : styles.selectedIndicatorHidden}
                     />
                 </View>
                 <ItemRowActions
@@ -234,7 +234,7 @@ export default React.memo(function ProfilePickerScreen() {
                 }}
             />
 
-            <ItemList style={{ paddingTop: 0 }}>
+            <ItemList style={styles.itemList}>
                 {!useProfiles ? (
                     <ItemGroup footer={t('settingsFeatures.profilesDisabled')}>
                         <Item
@@ -322,24 +322,24 @@ export default React.memo(function ProfilePickerScreen() {
                                     showDivider={nonFavoriteBuiltInProfiles.length > 0}
                                 />
                             )}
-                            {nonFavoriteBuiltInProfiles.map((profile, index) => {
-                                const isSelected = selectedId === profile.id;
-                                const isLast = index === nonFavoriteBuiltInProfiles.length - 1;
-                                const isFavorite = favoriteProfileIdSet.has(profile.id);
-                                return (
-	                                    <Item
-	                                        key={profile.id}
-	                                        title={profile.name}
-	                                        subtitle={getProfileSubtitle(profile)}
-	                                        icon={renderProfileIcon(profile)}
-	                                        onPress={() => setProfileParamAndClose(profile.id)}
-		                                        showChevron={false}
-		                                        selected={isSelected}
-	                                        rightElement={renderProfileRowRightElement(profile, isSelected, isFavorite)}
-	                                        showDivider={!isLast}
-	                                    />
-                                );
-                            })}
+	                            {nonFavoriteBuiltInProfiles.map((profile, index) => {
+	                                const isSelected = selectedId === profile.id;
+	                                const isLast = index === nonFavoriteBuiltInProfiles.length - 1;
+	                                const isFavorite = favoriteProfileIdSet.has(profile.id);
+	                                return (
+		                                    <Item
+		                                        key={profile.id}
+		                                        title={profile.name}
+		                                        subtitle={getProfileSubtitle(profile)}
+		                                        icon={renderProfileIcon(profile)}
+		                                        onPress={() => handleProfileRowPress(profile.id)}
+			                                        showChevron={false}
+			                                        selected={isSelected}
+		                                        rightElement={renderProfileRowRightElement(profile, isSelected, isFavorite)}
+		                                        showDivider={!isLast}
+		                                    />
+	                                );
+	                            })}
                         </ItemGroup>
 
                         <ItemGroup>
@@ -358,6 +358,9 @@ export default React.memo(function ProfilePickerScreen() {
 });
 
 const stylesheet = StyleSheet.create(() => ({
+    itemList: {
+        paddingTop: 0,
+    },
     rowRightElement: {
         flexDirection: 'row',
         alignItems: 'center',
@@ -367,5 +370,11 @@ const stylesheet = StyleSheet.create(() => ({
         width: 24,
         alignItems: 'center',
         justifyContent: 'center',
+    },
+    selectedIndicatorVisible: {
+        opacity: 1,
+    },
+    selectedIndicatorHidden: {
+        opacity: 0,
     },
 }));

--- a/sources/components/AgentInput.tsx
+++ b/sources/components/AgentInput.tsx
@@ -554,7 +554,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
         }
         return false; // Key was not handled
-    }, [suggestions, moveUp, moveDown, selected, handleSuggestionSelect, props.showAbortButton, props.onAbort, isAborting, handleAbortPress, agentInputEnterToSend, props.value, props.onSend, props.permissionMode, props.onPermissionModeChange]);
+    }, [suggestions, moveUp, moveDown, selected, handleSuggestionSelect, props.showAbortButton, props.onAbort, isAborting, handleAbortPress, agentInputEnterToSend, props.value, props.onSend, props.permissionMode, props.onPermissionModeChange, isCodex, isGemini]);
 
 
 

--- a/sources/components/newSession/MachineSelector.tsx
+++ b/sources/components/newSession/MachineSelector.tsx
@@ -35,13 +35,19 @@ export function MachineSelector({
     showRecent = true,
     showSearch = true,
     searchPlacement = 'header',
-    searchPlaceholder = t('newSession.machinePicker.searchPlaceholder'),
-    recentSectionTitle = t('newSession.machinePicker.recentTitle'),
-    favoritesSectionTitle = t('newSession.machinePicker.favoritesTitle'),
-    allSectionTitle = t('newSession.machinePicker.allTitle'),
-    noItemsMessage = t('newSession.machinePicker.emptyMessage'),
+    searchPlaceholder: searchPlaceholderProp,
+    recentSectionTitle: recentSectionTitleProp,
+    favoritesSectionTitle: favoritesSectionTitleProp,
+    allSectionTitle: allSectionTitleProp,
+    noItemsMessage: noItemsMessageProp,
 }: MachineSelectorProps) {
     const { theme } = useUnistyles();
+
+    const searchPlaceholder = searchPlaceholderProp ?? t('newSession.machinePicker.searchPlaceholder');
+    const recentSectionTitle = recentSectionTitleProp ?? t('newSession.machinePicker.recentTitle');
+    const favoritesSectionTitle = favoritesSectionTitleProp ?? t('newSession.machinePicker.favoritesTitle');
+    const allSectionTitle = allSectionTitleProp ?? t('newSession.machinePicker.allTitle');
+    const noItemsMessage = noItemsMessageProp ?? t('newSession.machinePicker.emptyMessage');
 
     return (
         <SearchableListSelector<Machine>

--- a/sources/text/translations/ja.ts
+++ b/sources/text/translations/ja.ts
@@ -7,16 +7,6 @@
 
 import type { TranslationStructure } from '../_types';
 
-/**
- * Japanese plural helper function
- * Japanese doesn't have grammatical plurals, so this just returns the appropriate form
- * @param options - Object containing count, singular, and plural forms
- * @returns The appropriate form based on count
- */
-function plural({ count, singular, plural }: { count: number; singular: string; plural: string }): string {
-    return count === 1 ? singular : plural;
-}
-
 export const ja: TranslationStructure = {
     tabs: {
         // Tab navigation labels

--- a/sources/utils/promptUnsavedChangesAlert.test.ts
+++ b/sources/utils/promptUnsavedChangesAlert.test.ts
@@ -1,64 +1,54 @@
 import { describe, expect, it } from 'vitest';
 import type { AlertButton } from '@/modal/types';
-import { promptUnsavedChangesAlert } from './promptUnsavedChangesAlert';
+import { promptUnsavedChangesAlert } from '@/utils/promptUnsavedChangesAlert';
+
+const basePromptOptions = {
+    title: 'Discard changes',
+    message: 'You have unsaved changes.',
+    discardText: 'Discard',
+    saveText: 'Save',
+    keepEditingText: 'Keep editing',
+} as const;
+
+function createPromptHarness() {
+    let lastButtons: AlertButton[] | undefined;
+
+    const alert = (_title: string, _message?: string, buttons?: AlertButton[]) => {
+        lastButtons = buttons;
+    };
+
+    const promise = promptUnsavedChangesAlert(alert, basePromptOptions);
+
+    function press(text: string) {
+        const button = lastButtons?.find((b) => b.text === text);
+        expect(button).toBeDefined();
+        button?.onPress?.();
+    }
+
+    return { promise, press };
+}
 
 describe('promptUnsavedChangesAlert', () => {
     it('resolves to save when the Save button is pressed', async () => {
-        let lastButtons: AlertButton[] | undefined;
+        const { promise, press } = createPromptHarness();
 
-        const alert = (_title: string, _message?: string, buttons?: AlertButton[]) => {
-            lastButtons = buttons;
-        };
-
-        const promise = promptUnsavedChangesAlert(alert, {
-            title: 'Discard changes',
-            message: 'You have unsaved changes.',
-            discardText: 'Discard',
-            saveText: 'Save',
-            keepEditingText: 'Keep editing',
-        });
-
-        lastButtons?.find((b) => b.text === 'Save')?.onPress?.();
+        press('Save');
 
         await expect(promise).resolves.toBe('save');
     });
 
     it('resolves to discard when the Discard button is pressed', async () => {
-        let lastButtons: AlertButton[] | undefined;
+        const { promise, press } = createPromptHarness();
 
-        const alert = (_title: string, _message?: string, buttons?: AlertButton[]) => {
-            lastButtons = buttons;
-        };
-
-        const promise = promptUnsavedChangesAlert(alert, {
-            title: 'Discard changes',
-            message: 'You have unsaved changes.',
-            discardText: 'Discard',
-            saveText: 'Save',
-            keepEditingText: 'Keep editing',
-        });
-
-        lastButtons?.find((b) => b.text === 'Discard')?.onPress?.();
+        press('Discard');
 
         await expect(promise).resolves.toBe('discard');
     });
 
     it('resolves to keepEditing when the Keep editing button is pressed', async () => {
-        let lastButtons: AlertButton[] | undefined;
+        const { promise, press } = createPromptHarness();
 
-        const alert = (_title: string, _message?: string, buttons?: AlertButton[]) => {
-            lastButtons = buttons;
-        };
-
-        const promise = promptUnsavedChangesAlert(alert, {
-            title: 'Discard changes',
-            message: 'You have unsaved changes.',
-            discardText: 'Discard',
-            saveText: 'Save',
-            keepEditingText: 'Keep editing',
-        });
-
-        lastButtons?.find((b) => b.text === 'Keep editing')?.onPress?.();
+        press('Keep editing');
 
         await expect(promise).resolves.toBe('keepEditing');
     });


### PR DESCRIPTION
### Context / Goal

This PR is a follow-up to `slopus/happy#272`, which introduced a large new-session + profiles + env-var/settings/sync surface.
The goal here is to keep the feature work, but restore the pre-#272 “standard New Session” UX and make the new profiles/env work coherent + safe.

I’m trying to keep this factual (no blame): this is mostly stabilization work after a very large merge.

## Summary (what this PR does)

- Restores the pre-#272 “New Session” experience (modal + prompt-first workflow) while keeping the new wizard/profiles as opt-in.
- Keep PR272’s new features, but make them **optional + coherent**
  - Added separate feature settings: users can choose to use profiles with "standard" new session screen and/or new wizard independently of eachother
  - Reduce duplication by **reusing existing UI primitives**
  - Make search for machines & paths opt-in in features settings
- Fix key **non-UI regressions / safety issues** introduced or made risky by PR272 (tool results, settings parsing, logging, env var handling)
- Makes profile editing/navigation unmount-safe and prevents invalid profiles from being persisted.
- Removes dead/duplicative env resolution work and ensures env previews do not fetch secret values into UI memory.
- Cleans up i18n structure by separating translation types from translation content.
- Wizard improvements/fixes
  - Reuse existing UI components instead of duplicated ones introduced by #272
  - Improves search & favorites display in wizard
  - Add favorites feature for profiles
  - Add AI Backend wizard step
  - Codex profiles correctly enabled if Codex is detected on machine (see below)
  - Add optional AI Model selection step
    - Right now, only Gemini, as we only support changing AI model for Gemini (following #376 merge)
- Profiles improvements/fixes
  - Allow to select which AI Backend applies to a profile in the profile settings
- Integrate profiles in standard "new session" modal (opt-in, gated by feature setting)
  - Add a chip + picker for profiles
  - Add a chip + modal for env vars preview
  - Add clear message to AI Backend chip if the user clicks on it but cannot change it because of the currently selected profile
    - Previously nothing would happen when users clicked on the chip and that the profile did not allow AI backend change

---

# What #272 introduced (and what we’re fixing here)

### Profiles/editor correctness
- #272’s profile edit screen could create/persist an invalid profile with `id: ''`.
  - Fixed via id-based navigation + UUID-backed “empty profile” creation

### Navigation coherence (web + native + unmount safety)
- #272 used a hybrid approach (module-level callbacks + URL-serialized JSON) for profile editing, while other pickers used params.
- Fixed by switching profile edit to id-based routing and removing the callback/URL-JSON pattern.

### Global daemon env fetch (and secret exposure risk)
- #272 introduced a global `envVarRefs/daemonEnv` fetch in `/new` that queried the daemon for *all* `${VAR}` references across *all profiles* (including secrets).
- This can pull secret values into JS memory unnecessarily (even if only used for small previews).
- Fixed by removing the global query and keeping env resolution scoped with secret-like filtering in preview paths.

#### New Session (standard flow) regressions
- New Session was effectively treated as a **screen** rather than the prior **modal** presentation.
- The prompt-first input area was changed to show an oversized “context card” (machine/path), losing the compact chip UI.
- Placeholder/keyboard offset behavior drifted from the pre-merge UX.

#### Wizard + pickers inconsistent with existing UI
- Wizard sections (working directory, permission mode) and pickers (machine/path) used new layouts/styles that didn’t match existing Happy patterns and duplicated logic.

#### Profiles “leaked” into default behavior
- Profiles & env vars could affect session spawning, even when disabled in the settings
- Profiles management UI diverged from existing settings layout conventions.

#### Non-UI safety/reliability issues (PR272 logic surface)
- **Sensitive settings/logging risk**: decrypted settings can now include profile env vars / keys; existing logs became unsafe.
- **Tool result dropping risk**: PR272’s message normalization could reject tool results when output is structured JSON (common for Codex/Gemini), causing messages to be dropped.
- **Settings parse fragility**: “whole settings parse fails → defaults” becomes much more dangerous once settings include user-edited profiles/env vars.
- **New env-var querying hooks** had edge cases (whitespace trimming, unset vs empty ambiguity).
- **Dead/placeholder code** added (e.g. `profileSync.ts`, `NewSessionWizard) that wasn’t actually wired.

#### Even if Codex was detected on the machines, the Codex profiles stayed disabled 
- We can even see it in the PR #272 demo itself:
IMAGE

---

### What we implemented to fix/improve it (what’s in this branch)

#### 1) New Session UX restored (pre-PR272 feel, still compatible with new features)
- Restored **modal presentation** for New Session.
- Restored **prompt-first “standard” flow** layout and compact chips.
- Restored original translated placeholder (`t('session.inputPlaceholder')`) and legacy keyboard behavior.

#### 2) Wizard + pickers refactored to reduce duplication and improve coherence
- Extracted reusable selectors and used them in both:
  - wizard flow
  - modal pickers

#### 3) Profiles made truly optional (separate feature flag) + coherent selection UX
- Introduced **independent `useProfiles` flag** (separate from `useEnhancedSessionWizard`).
- Gated:
  - profiles settings entry
  - profiles UI in New Session (standard and wizard)
  - profile selection/persistence logic
  - profile env var injection
- Added a **lightweight profile picker modal** for standard flow (chip opens picker; no forced wizard).

#### 4) Profile identity persisted/displayed safely
- Sessions now persist `profileId` and show a read-only chip in session UI.
- Handles missing/unknown profile IDs gracefully.


---

### Non-UI “logic hardening” improvements tied to PR272’s new surface area

These changes are limited to files added/modified by PR272, and fix real issues introduced or made risky by PR272’s new data/features.

#### A) Prevent leaking secrets via logs
- Removed/limited logging of full decrypted settings (can contain API keys / profile env vars).
- Avoid logging raw full message payloads on validation errors.
- Gated noisy CLI detection logs to `__DEV__`.

#### B) Fix tool-result robustness (don’t drop messages; don’t break on structured outputs)
- Tool results can be strings **or structured objects** (esp. Codex/Gemini). PR272’s schema/normalization could reject these, dropping messages.
- Updated tool-result parsing/normalization so non-string outputs are accepted and safely stringified for display.

#### C) Make settings parsing tolerant (avoid “one bad profile nukes all settings”)
- PR272 expanded settings and added profiles/env-var editing. A single invalid field should not reset known settings to defaults.
- Updated `settingsParse()` to parse fields individually and filter invalid profile entries rather than failing the entire settings object.

#### D) Unify env-var template parsing + preserve correctness in remote env querying
- Standardized supported template syntax to `${VAR}` and `${VAR:-default}` consistently.
- Improved env var fetching:
  - avoid trimming stdout (which can corrupt values)
  - distinguish **unset** vs **empty string** using a JSON protocol via `node` when available (fallback remains safe)
  - fixed a TS template-literal escape bug in fallback

#### E) Remove unused placeholder sync service added by PR272
- `profileSync.ts` was added but not referenced; removed to prevent future confusion.

#### F) Conservative security: avoid querying remote values for secret-like vars
- Strengthened secret heuristics to include `PASS|PASSWORD|COOKIE` in addition to token/key/secret/auth.
- This prevents accidental remote querying/display of sensitive env vars.

---

## Links to the detailled issues in slopus/happy#272 (links go to the PR diff)

1. /new is no longer presented as a modal (becomes a normal screen)

- sources/app/(app)/_layout.tsx defines name="new/index" without presentation: 'modal':
  https://github.com/slopus/happy/pull/272/files#diff-30e51abcbe846d95abc7b9de0aee916aa6a7489e72486ec06388b9ac612f7e6bR322

2. Prompt placeholder is hardcoded (loses i18n key)

- sources/app/(app)/new/index.tsx:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1147
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1897

3. Profiles/env injection is on the default spawn path (no opt-in gate)

- Persists lastUsedProfile unconditionally:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1007
- Uses selected profile to build environmentVariables and passes them to spawn:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1012

4. Global daemon env fetch in /new queries ${VAR} refs across all profiles (no secret filtering)

- Collects refs from allProfiles then calls useEnvironmentVariables(selectedMachineId, envVarRefs):
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R481
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R491

5. Profile editor env-var cards tell you to “select a machine”, but Profiles settings editor has no machine picker

- Profiles settings renders ProfileEditForm with machineId={null}:
  https://github.com/slopus/happy/pull/272/files#diff-03a554e2004f08654732692f1487a20f748f4ed90e7e187d90678e7d24abb232R401
- Env var card message:
  https://github.com/slopus/happy/pull/272/files#diff-388510a51fa84edaf57a36644f1a084aeb18ee8bd265a798133f48dc5cee281cR257

6. Secret-handling messaging mismatch

- Card says secrets “not retrieved for security”:
  https://github.com/slopus/happy/pull/272/files#diff-388510a51fa84edaf57a36644f1a084aeb18ee8bd265a798133f48dc5cee281cR270
- But /new global env fetch (above) can still query secret-like ${VAR} into UI memory because it doesn’t filter.

7. Profile editor route can create a new profile with id: ''

- Fallback object uses id: '':
  https://github.com/slopus/happy/pull/272/files#diff-0275aef060275b84215b2726a2b6c016e929a644b469df6b77915fbf3fa8de48R32

8. Profile edit navigation uses URL-serialized JSON payloads + module-level callbacks (unmount/deeplink fragile)

- profileData JSON in URL (push):
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R780
- Module-level callbacks pattern:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R43
- profile-edit parses URL JSON:
  https://github.com/slopus/happy/pull/272/files#diff-0275aef060275b84215b2726a2b6c016e929a644b469df6b77915fbf3fa8de48R25
- profile-edit returns via callback:
  https://github.com/slopus/happy/pull/272/files#diff-0275aef060275b84215b2726a2b6c016e929a644b469df6b77915fbf3fa8de48R46

9. Startup Bash Script is stored/edited, but not part of spawn RPC (unwired)

- Settings schema stores it:
  https://github.com/slopus/happy/pull/272/files#diff-92a4e9f2312662ce954da5d3c480da187552b897c564bc19e45db5e2b5c5cdabR110
- Profile editor UI saves it:
  https://github.com/slopus/happy/pull/272/files#diff-cbde5d803bb1053919f1167c4eb4f7a56b48dd93f77e75d0ebef73e4fe1f3f92R92
- Spawn RPC only supports environmentVariables (no startup script field):
  https://github.com/slopus/happy/pull/272/files#diff-15dcee897d504b4753e80c45148ed21f31394550cf02721bd2641929b4be06b1R136

10. CLI detection + profile availability gating can false-negative Codex/Gemini

- Detection is a command -v string (non-login shell behavior):
  https://github.com/slopus/happy/pull/272/files#diff-01c0b6096ea1c61ee49415456c4d662f513a21a3e3295d7882fde9b94305137aR62
- Profiles can be marked unavailable if required CLI is “not detected”:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R563
- UI shows Codex “Not Detected” banner:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1346

11. Tool-result normalization can drop structured tool outputs

- Canonical tool_result.content is restricted to string | text[]:
  https://github.com/slopus/happy/pull/272/files#diff-21ea1e7b314af287b486e284fe47fa9681dc76a38cb14c0e2395d7467a7556e0R48
- But hyphenated tool-call-result.output (z.any()) is assigned to canonical content:
  https://github.com/slopus/happy/pull/272/files#diff-21ea1e7b314af287b486e284fe47fa9681dc76a38cb14c0e2395d7467a7556e0R148

12. Settings parsing is “whole-object” safeParse (invalid settings fall back to defaults for all known fields)

- settingsParse() fallback branch:
  https://github.com/slopus/happy/pull/272/files#diff-92a4e9f2312662ce954da5d3c480da187552b897c564bc19e45db5e2b5c5cdabR372

13. useEnvironmentVariables trims stdout + collapses empty-string to null

- stdout.trim() parsing:
  https://github.com/slopus/happy/pull/272/files#diff-7077cf5c55232633bf3a22097c51d59b3eb25db37a642f78e128197f3425e8c2R86
- value || null (empty → null):
  https://github.com/slopus/happy/pull/272/files#diff-7077cf5c55232633bf3a22097c51d59b3eb25db37a642f78e128197f3425e8c2R92

14. profileSync.ts is effectively a placeholder (TODOs for actual daemon RPCs)

- TODO marker:
  https://github.com/slopus/happy/pull/272/files#diff-9b2dcf6707736bef944b8a005ff7ff6b4f5856defbe446710027e1ebc25b17d1R143

15. tmux “empty sessionName means current/most recent” is stated in UI

- Profile edit form comment:
  https://github.com/slopus/happy/pull/272/files#diff-cbde5d803bb1053919f1167c4eb4f7a56b48dd93f77e75d0ebef73e4fe1f3f92R84
  (This is relevant because PR107’s tmux util does not implement “current/most recent” when name is empty—see below.)

16. i18n English duplication (“dedicated en file” + tooling imports it)

- translations/en.ts claims dedicated English file architecture:
  https://github.com/slopus/happy/pull/272/files#diff-a2f78b18918804b89391c64e0942948bfbd600834e789295a93fec0328365e38R14
- Tooling imports translations/en:
  https://github.com/slopus/happy/pull/272/files#diff-f754c8a677da1cc9a08309fa83d216afe0b6d2c47561cb89b32fc97c6c970153R12
  (Runtime import of English from _default.ts is in sources/text/index.ts, but that file wasn’t changed in #272 so it can’t be linked via the PR /files view.)

17. Large wizard component introduced but unused

- NewSessionWizard.tsx added as a large new componen (but not wired anywhere, the actual wizard code being in the `new` page):
  https://github.com/slopus/happy/pull/272/files#diff-51775e520e07fb30ce518a991ca21278568a253304b102071fce5fb4c6e41effR1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile manager with favorites, create/edit/duplicate/delete flows; profile picker & editor screens
  * Improved machine & path pickers: search, recent/favorites, persistent toggles
  * Environment variables editor, preview modal and machine-backed resolution
  * Gemini model-mode selection exposed in UI; new Gemini tool views and model options

* **Refactor**
  * Modularized picker/item UI, reusable search header and action menus; web/modal behavior improvements

* **Bug Fixes**
  * Tighter env-var substitution and more robust resolution; improved permission-mode mapping across agents

* **Tests & Docs**
  * New unit tests and expanded translations across many languages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->