### PR TITLE
fix: stabilize PR272 new-session UX, profiles gating, and env safety

### DIFF
--- a/sources/app/(app)/session/[id]/info.tsx
+++ b/sources/app/(app)/session/[id]/info.tsx
@@ -20,7 +20,7 @@ import { CodeView } from '@/components/CodeView';
 import { Session } from '@/sync/storageTypes';
 import { useHappyAction } from '@/hooks/useHappyAction';
 import { HappyError } from '@/utils/errors';
-import { getBuiltInProfile } from '@/sync/profileUtils';
+import { getBuiltInProfile, getBuiltInProfileNameKey } from '@/sync/profileUtils';
 
 // Animated status dot component
 function StatusDot({ color, isPulsing, size = 8 }: { color: string; isPulsing?: boolean; size?: number }) {
@@ -79,7 +79,10 @@ function SessionInfoContent({ session }: { session: Session }) {
         if (typeof profileId !== 'string') return t('status.unknown');
 
         const builtIn = getBuiltInProfile(profileId);
-        if (builtIn) return builtIn.name;
+        if (builtIn) {
+            const key = getBuiltInProfileNameKey(profileId);
+            return key ? t(key) : builtIn.name;
+        }
 
         const custom = profiles.find(p => p.id === profileId);
         return custom?.name ?? t('status.unknown');

--- a/sources/sync/profileUtils.test.ts
+++ b/sources/sync/profileUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getProfilePrimaryCli } from './profileUtils';
+import { getBuiltInProfileNameKey, getProfilePrimaryCli } from './profileUtils';
 
 describe('getProfilePrimaryCli', () => {
     it('ignores unknown compatibility keys', () => {
@@ -11,3 +11,16 @@ describe('getProfilePrimaryCli', () => {
     });
 });
 
+describe('getBuiltInProfileNameKey', () => {
+    it('returns the translation key for known built-in profile ids', () => {
+        expect(getBuiltInProfileNameKey('anthropic')).toBe('profiles.builtInNames.anthropic');
+        expect(getBuiltInProfileNameKey('deepseek')).toBe('profiles.builtInNames.deepseek');
+        expect(getBuiltInProfileNameKey('zai')).toBe('profiles.builtInNames.zai');
+        expect(getBuiltInProfileNameKey('openai')).toBe('profiles.builtInNames.openai');
+        expect(getBuiltInProfileNameKey('azure-openai')).toBe('profiles.builtInNames.azureOpenai');
+    });
+
+    it('returns null for unknown ids', () => {
+        expect(getBuiltInProfileNameKey('unknown')).toBeNull();
+    });
+});

--- a/sources/sync/profileUtils.ts
+++ b/sources/sync/profileUtils.ts
@@ -2,6 +2,15 @@ import { AIBackendProfile } from './settings';
 
 export type ProfilePrimaryCli = 'claude' | 'codex' | 'gemini' | 'multi' | 'none';
 
+export type BuiltInProfileId = 'anthropic' | 'deepseek' | 'zai' | 'openai' | 'azure-openai';
+
+export type BuiltInProfileNameKey =
+    | 'profiles.builtInNames.anthropic'
+    | 'profiles.builtInNames.deepseek'
+    | 'profiles.builtInNames.zai'
+    | 'profiles.builtInNames.openai'
+    | 'profiles.builtInNames.azureOpenai';
+
 const ALLOWED_PROFILE_CLIS = new Set(['claude', 'codex', 'gemini']);
 
 export function getProfilePrimaryCli(profile: AIBackendProfile | null | undefined): ProfilePrimaryCli {
@@ -14,6 +23,23 @@ export function getProfilePrimaryCli(profile: AIBackendProfile | null | undefine
     if (supported.length === 0) return 'none';
     if (supported.length === 1) return supported[0];
     return 'multi';
+}
+
+export function getBuiltInProfileNameKey(id: string): BuiltInProfileNameKey | null {
+    switch (id as BuiltInProfileId) {
+        case 'anthropic':
+            return 'profiles.builtInNames.anthropic';
+        case 'deepseek':
+            return 'profiles.builtInNames.deepseek';
+        case 'zai':
+            return 'profiles.builtInNames.zai';
+        case 'openai':
+            return 'profiles.builtInNames.openai';
+        case 'azure-openai':
+            return 'profiles.builtInNames.azureOpenai';
+        default:
+            return null;
+    }
 }
 
 /**

--- a/sources/text/translations/ca.ts
+++ b/sources/text/translations/ca.ts
@@ -962,6 +962,13 @@ export const ca: TranslationStructure = {
         deleteConfirm: ({ name }: { name: string }) => `Segur que vols eliminar el perfil "${name}"?`,
         nameRequired: 'El nom del perfil és obligatori',
         builtIn: 'Integrat',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: 'Preferits',
             custom: 'Els teus perfils',

--- a/sources/text/translations/en.ts
+++ b/sources/text/translations/en.ts
@@ -985,6 +985,13 @@ export const en = {
         editProfile: 'Edit Profile',
         addProfileTitle: 'Add New Profile',
         builtIn: 'Built-in',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: 'Favorites',
             custom: 'Your Profiles',

--- a/sources/text/translations/es.ts
+++ b/sources/text/translations/es.ts
@@ -972,6 +972,13 @@ export const es: TranslationStructure = {
         editProfile: 'Editar Perfil',
         addProfileTitle: 'Agregar Nuevo Perfil',
         builtIn: 'Integrado',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: 'Favoritos',
             custom: 'Tus perfiles',

--- a/sources/text/translations/it.ts
+++ b/sources/text/translations/it.ts
@@ -103,6 +103,13 @@ export const it: TranslationStructure = {
         editProfile: 'Modifica profilo',
         addProfileTitle: 'Aggiungi nuovo profilo',
         builtIn: 'Integrato',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: 'Preferiti',
             custom: 'I tuoi profili',

--- a/sources/text/translations/ja.ts
+++ b/sources/text/translations/ja.ts
@@ -96,6 +96,13 @@ export const ja: TranslationStructure = {
         editProfile: 'プロファイルを編集',
         addProfileTitle: '新しいプロファイルを追加',
         builtIn: '組み込み',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: 'お気に入り',
             custom: 'あなたのプロファイル',

--- a/sources/text/translations/pl.ts
+++ b/sources/text/translations/pl.ts
@@ -995,6 +995,13 @@ export const pl: TranslationStructure = {
         editProfile: 'Edytuj Profil',
         addProfileTitle: 'Dodaj Nowy Profil',
         builtIn: 'Wbudowane',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: 'Ulubione',
             custom: 'Twoje profile',

--- a/sources/text/translations/pt.ts
+++ b/sources/text/translations/pt.ts
@@ -962,6 +962,13 @@ export const pt: TranslationStructure = {
         deleteConfirm: ({ name }: { name: string }) => `Tem certeza de que deseja excluir o perfil "${name}"?`,
         nameRequired: 'O nome do perfil é obrigatório',
         builtIn: 'Integrado',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: 'Favoritos',
             custom: 'Seus perfis',

--- a/sources/text/translations/ru.ts
+++ b/sources/text/translations/ru.ts
@@ -994,6 +994,13 @@ export const ru: TranslationStructure = {
         editProfile: 'Редактировать Профиль',
         addProfileTitle: 'Добавить Новый Профиль',
         builtIn: 'Встроенный',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: 'Избранное',
             custom: 'Ваши профили',

--- a/sources/text/translations/zh-Hans.ts
+++ b/sources/text/translations/zh-Hans.ts
@@ -964,6 +964,13 @@ export const zhHans: TranslationStructure = {
         deleteConfirm: ({ name }: { name: string }) => `确定要删除配置文件“${name}”吗？`,
         nameRequired: '配置文件名称为必填项',
         builtIn: '内置',
+        builtInNames: {
+            anthropic: 'Anthropic (Default)',
+            deepseek: 'DeepSeek (Reasoner)',
+            zai: 'Z.AI (GLM-4.6)',
+            openai: 'OpenAI (GPT-5)',
+            azureOpenai: 'Azure OpenAI',
+        },
         groups: {
             favorites: '收藏',
             custom: '你的配置文件',


### PR DESCRIPTION
PR 272
fix: stabilize PR272 new-session UX, profiles gating, and env safety

## Context / Goal

This PR is a follow-up to `slopus/happy#272`, which introduced a large new-session + profiles + env-var/settings/sync surface.
The goal here is to keep the feature work, but restore the pre-#272 “standard New Session” UX and make the new profiles/env work coherent + safe.

I’m trying to keep this factual (no blame): this is mostly stabilization work after a very large merge.

## Summary (what this PR does)

- Restores the pre-272 “New Session” experience (modal + prompt-first workflow) while keeping the new wizard/profiles as opt-in.
- Keep PR272’s new features, but make them **optional + coherent**
  - Added separate feature settings: users can choose to use profiles with "standard" new session screen and/or new wizard independently of eachother
  - Reduce duplication by **reusing existing UI primitives**
  - Make search for machines & paths opt-in in features settings
- Fix key **non-UI regressions / safety issues** introduced or made risky by PR272 (tool results, settings parsing, logging, env var handling)
- Makes profile editing/navigation unmount-safe and prevents invalid profiles from being persisted.
- Removes dead/duplicative env resolution work and ensures env previews do not fetch secret values into UI memory.
- Cleans up i18n structure by separating translation types from translation content.
- Wizard improvements/fixes
  - Reuse existing UI components instead of duplicated ones introduced by 272
  - Improves search & favorites display in wizard
  - Add favorites feature for profiles
  - Add AI Backend wizard step
  - Codex profiles correctly enabled if Codex is detected on machine (see below)
  - Add optional AI Model selection step
    - Right now, only Gemini, as we only support changing AI model for Gemini (following #376 merge)
- Profiles improvements/fixes
  - Allow to select which AI Backend applies to a profile in the profile settings
  - Prevent user closing the edit screen with unsaved changes
- Integrate profiles in standard "new session" modal (opt-in, gated by feature setting)
  - Add a chip + picker for profiles
  - Add a chip + modal for env vars preview
  - Add clear message to AI Backend chip if the user clicks on it but cannot change it because of the currently selected profile
    - Previously nothing would happen when users clicked on the chip and the profile didn't allow switching AI backend

---

## What #272 introduced (and what we’re fixing here)

### Profiles/editor correctness
- Profile edit screen could create/persist an invalid profile with `id: ''`.
  - Fixed via id-based navigation + UUID-backed “empty profile” creation

### Navigation coherence (web + native + unmount safety)
- Hybrid approach (module-level callbacks + URL-serialized JSON) was used for profile editing, while other pickers used params.
- Fixed by switching profile edit to id-based routing and removing the callback/URL-JSON pattern.

### Global daemon env fetch (and secret exposure risk)
- Was using a global `envVarRefs/daemonEnv` fetch in `/new` that queried the daemon for *all* `${VAR}` references across *all profiles* (including secrets).
- This can pull secret values into JS memory unnecessarily (even if only used for small previews).
- Fixed by removing the global query and keeping env resolution scoped with secret-like filtering in preview paths.

### New Session (standard flow) regressions
- New Session was effectively treated as a **screen** rather than the prior **modal** presentation.
- The prompt-first input area was changed to show an oversized “context card” (machine/path), losing the compact chip UI.
- Placeholder/keyboard offset behavior drifted from the pre-merge UX.

### Wizard + pickers inconsistent with existing UI
- Wizard sections (working directory, permission mode) and pickers (machine/path) used new layouts/styles that didn’t match existing Happy patterns and duplicated logic.

### Profiles “leaked” into default behavior
- Profiles & env vars could affect session spawning, even when they were disabled in the settings
- Profiles management UI diverged from existing settings layout conventions.

### Non-UI safety/reliability issues (PR272 logic surface)
- **Sensitive settings/logging risk**: decrypted settings can now include profile env vars / keys; existing logs became unsafe.
- **Tool result dropping risk**: PR272’s message normalization could reject tool results when output is structured JSON (common for Codex/Gemini), causing messages to be dropped.
- **Settings parse fragility**: “whole settings parse fails → defaults” becomes much more dangerous once settings include user-edited profiles/env vars.
- **New env-var querying hooks** had edge cases (whitespace trimming, unset vs empty ambiguity).
- **Dead/placeholder code** added (e.g. `profileSync.ts`, `NewSessionWizard) that wasn’t actually wired.

### Even if Codex was detected on the machines, the Codex profiles stayed disabled 
- We can even see it in the PR 272 demo itself:
IMAGE

---

## What we implemented to fix/improve it (what’s in this branch)

### 1) New Session UX restored (pre-PR272 feel, still compatible with new features)
- Restored **modal presentation** for New Session.
- Restored **prompt-first “standard” flow** layout and compact chips.
- Restored original translated placeholder (`t('session.inputPlaceholder')`) and legacy keyboard behavior.

### 2) Wizard + pickers refactored to reduce duplication and improve coherence
- Extracted reusable selectors and used them in both:
  - wizard flow
  - modal pickers

### 3) Profiles made truly optional (separate feature flag) + coherent selection UX
- Introduced **independent `useProfiles` flag** (separate from `useEnhancedSessionWizard`).
- Gated:
  - profiles settings entry
  - profiles UI in New Session (standard and wizard)
  - profile selection/persistence logic
  - profile env var injection
- Added a **lightweight profile picker modal** for standard flow (chip opens picker; no forced wizard).

### 4) Profile identity persisted/displayed safely
- Sessions now persist `profileId` and show a read-only chip in session UI.
- Handles missing/unknown profile IDs gracefully.


---

## Non-UI “logic hardening” improvements tied to PR272’s new surface area

These changes are limited to files added/modified by PR272, and fix real issues introduced or made risky by PR272’s new data/features.

### A) Prevent leaking secrets via logs
- Removed/limited logging of full decrypted settings (can contain API keys / profile env vars).
- Avoid logging raw full message payloads on validation errors.
- Gated noisy CLI detection logs to `__DEV__`.

### B) Fix tool-result robustness (don’t drop messages; don’t break on structured outputs)
- Tool results can be strings **or structured objects** (esp. Codex/Gemini). PR272’s schema/normalization could reject these, dropping messages.
- Updated tool-result parsing/normalization so non-string outputs are accepted and safely stringified for display.

### C) Make settings parsing tolerant (avoid “one bad profile nukes all settings”)
- PR272 expanded settings and added profiles/env-var editing. A single invalid field should not reset known settings to defaults.
- Updated `settingsParse()` to parse fields individually and filter invalid profile entries rather than failing the entire settings object.

### D) Unify env-var template parsing + preserve correctness in remote env querying
- Standardized supported template syntax to `${VAR}` and `${VAR:-default}` consistently.
- Improved env var fetching:
  - avoid trimming stdout (which can corrupt values)
  - distinguish **unset** vs **empty string** using a JSON protocol via `node` when available (fallback remains safe)
  - fixed a TS template-literal escape bug in fallback

### E) Remove unused placeholder sync service & component added by PR272
- `profileSync.ts` & `components/NewSessionWizard.tsx` were added but not referenced; removed to prevent future confusion.

### F) Conservative security: avoid querying remote values for secret-like vars
- Strengthened secret heuristics to include `PASS|PASSWORD|COOKIE` in addition to token/key/secret/auth.
- This prevents accidental remote querying/display of sensitive env vars.

---

## Links to the detailled issues in slopus/happy#272 (links go to the PR diff)

1. /new is no longer presented as a modal (becomes a normal screen)

- sources/app/(app)/_layout.tsx defines name="new/index" without presentation: 'modal':
  https://github.com/slopus/happy/pull/272/files#diff-30e51abcbe846d95abc7b9de0aee916aa6a7489e72486ec06388b9ac612f7e6bR322

2. Prompt placeholder is hardcoded (loses i18n key)

- sources/app/(app)/new/index.tsx:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1147
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1897

3. Profiles/env injection is on the default spawn path (no opt-in gate)

- Persists lastUsedProfile unconditionally:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1007
- Uses selected profile to build environmentVariables and passes them to spawn:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1012

4. Global daemon env fetch in /new queries ${VAR} refs across all profiles (no secret filtering)

- Collects refs from allProfiles then calls useEnvironmentVariables(selectedMachineId, envVarRefs):
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R481
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R491

5. Profile editor env-var cards tell you to “select a machine”, but Profiles settings editor has no machine picker

- Profiles settings renders ProfileEditForm with machineId={null}:
  https://github.com/slopus/happy/pull/272/files#diff-03a554e2004f08654732692f1487a20f748f4ed90e7e187d90678e7d24abb232R401
- Env var card message:
  https://github.com/slopus/happy/pull/272/files#diff-388510a51fa84edaf57a36644f1a084aeb18ee8bd265a798133f48dc5cee281cR257

6. Secret-handling messaging mismatch

- Card says secrets “not retrieved for security”:
  https://github.com/slopus/happy/pull/272/files#diff-388510a51fa84edaf57a36644f1a084aeb18ee8bd265a798133f48dc5cee281cR270
- But /new global env fetch (above) can still query secret-like ${VAR} into UI memory because it doesn’t filter.

7. Profile editor route can create a new profile with id: ''

- Fallback object uses id: '':
  https://github.com/slopus/happy/pull/272/files#diff-0275aef060275b84215b2726a2b6c016e929a644b469df6b77915fbf3fa8de48R32

8. Profile edit navigation uses URL-serialized JSON payloads + module-level callbacks (unmount/deeplink fragile)

- profileData JSON in URL (push):
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R780
- Module-level callbacks pattern:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R43
- profile-edit parses URL JSON:
  https://github.com/slopus/happy/pull/272/files#diff-0275aef060275b84215b2726a2b6c016e929a644b469df6b77915fbf3fa8de48R25
- profile-edit returns via callback:
  https://github.com/slopus/happy/pull/272/files#diff-0275aef060275b84215b2726a2b6c016e929a644b469df6b77915fbf3fa8de48R46

9. Startup Bash Script is stored/edited, but not part of spawn RPC (unwired)

- Settings schema stores it:
  https://github.com/slopus/happy/pull/272/files#diff-92a4e9f2312662ce954da5d3c480da187552b897c564bc19e45db5e2b5c5cdabR110
- Profile editor UI saves it:
  https://github.com/slopus/happy/pull/272/files#diff-cbde5d803bb1053919f1167c4eb4f7a56b48dd93f77e75d0ebef73e4fe1f3f92R92
- Spawn RPC only supports environmentVariables (no startup script field):
  https://github.com/slopus/happy/pull/272/files#diff-15dcee897d504b4753e80c45148ed21f31394550cf02721bd2641929b4be06b1R136

10. CLI detection + profile availability gating can false-negative Codex/Gemini

- Detection is a command -v string (non-login shell behavior):
  https://github.com/slopus/happy/pull/272/files#diff-01c0b6096ea1c61ee49415456c4d662f513a21a3e3295d7882fde9b94305137aR62
- Profiles can be marked unavailable if required CLI is “not detected”:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R563
- UI shows Codex “Not Detected” banner:
  https://github.com/slopus/happy/pull/272/files#diff-f4b041fa0826ef7d66e7e872b4e23bd490d2dc755c0c879551045a005731f401R1346

11. Tool-result normalization can drop structured tool outputs

- Canonical tool_result.content is restricted to string | text[]:
  https://github.com/slopus/happy/pull/272/files#diff-21ea1e7b314af287b486e284fe47fa9681dc76a38cb14c0e2395d7467a7556e0R48
- But hyphenated tool-call-result.output (z.any()) is assigned to canonical content:
  https://github.com/slopus/happy/pull/272/files#diff-21ea1e7b314af287b486e284fe47fa9681dc76a38cb14c0e2395d7467a7556e0R148

12. Settings parsing is “whole-object” safeParse (invalid settings fall back to defaults for all known fields)

- settingsParse() fallback branch:
  https://github.com/slopus/happy/pull/272/files#diff-92a4e9f2312662ce954da5d3c480da187552b897c564bc19e45db5e2b5c5cdabR372

13. useEnvironmentVariables trims stdout + collapses empty-string to null

- stdout.trim() parsing:
  https://github.com/slopus/happy/pull/272/files#diff-7077cf5c55232633bf3a22097c51d59b3eb25db37a642f78e128197f3425e8c2R86
- value || null (empty → null):
  https://github.com/slopus/happy/pull/272/files#diff-7077cf5c55232633bf3a22097c51d59b3eb25db37a642f78e128197f3425e8c2R92

14. profileSync.ts is effectively a placeholder (TODOs for actual daemon RPCs)

- TODO marker:
  https://github.com/slopus/happy/pull/272/files#diff-9b2dcf6707736bef944b8a005ff7ff6b4f5856defbe446710027e1ebc25b17d1R143

15. tmux “empty sessionName means current/most recent” is stated in UI

- Profile edit form comment:
  https://github.com/slopus/happy/pull/272/files#diff-cbde5d803bb1053919f1167c4eb4f7a56b48dd93f77e75d0ebef73e4fe1f3f92R84
  (This is relevant because PR107’s tmux util does not implement “current/most recent” when name is empty—see below.)

16. i18n English duplication (“dedicated en file” + tooling imports it)

- translations/en.ts claims dedicated English file architecture:
  https://github.com/slopus/happy/pull/272/files#diff-a2f78b18918804b89391c64e0942948bfbd600834e789295a93fec0328365e38R14
- Tooling imports translations/en:
  https://github.com/slopus/happy/pull/272/files#diff-f754c8a677da1cc9a08309fa83d216afe0b6d2c47561cb89b32fc97c6c970153R12
  (Runtime import of English from _default.ts is in sources/text/index.ts, but that file wasn’t changed in #272 so it can’t be linked via the PR /files view.)

17. Large wizard component introduced but unused

- NewSessionWizard.tsx added as a large new componen (but not wired anywhere, the actual wizard code being in the `new` page):
  https://github.com/slopus/happy/pull/272/files#diff-51775e520e07fb30ce518a991ca21278568a253304b102071fce5fb4c6e41effR1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full profile management UI: pick, create, edit, duplicate, favorite, preview
  * Machine & path pickers: search, favorites, recents, improved flows
  * Gemini model selection (Gemini 2.5 variants) in session UI
  * Environment variables: machine-aware preview modal, per-variable preview, add/validation, secret masking
  * New search header and improved list selectors across pickers

* **Improvements**
  * Unified permission/model handling across AI providers and clearer AI profile display
  * Various UI polish and stability fixes in settings and session flows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->