### PR TITLE
Fix: useFeatureDecision import wrong function name

### DIFF
--- a/apps/ui/sources/hooks/server/useFeatureDecision.ts
+++ b/apps/ui/sources/hooks/server/useFeatureDecision.ts
@@ -3,7 +3,7 @@ import type { FeatureDecision, FeatureId } from '@happier-dev/protocol';
 
 import { useSettings } from '@/sync/domains/state/storage';
 import {
-    resolveFeatureDecision,
+    resolveRuntimeFeatureDecisionFromSnapshot,
     useServerFeaturesRuntimeSnapshot,
 } from '@/sync/domains/features/featureDecisionRuntime';
 
@@ -13,7 +13,7 @@ export function useFeatureDecision(featureId: FeatureId): FeatureDecision | null
 
     return React.useMemo(
         () =>
-            resolveFeatureDecision({
+            resolveRuntimeFeatureDecisionFromSnapshot({
                 featureId,
                 settings,
                 snapshot,


### PR DESCRIPTION
The useFeatureDecision hook was importing resolveFeatureDecision, but the actual export in featureDecisionRuntime.ts is named resolveRuntimeFeatureDecisionFromSnapshot.

This caused a runtime error:
"resolveFeatureDecision is not a function (it is undefined)"

Fixed by importing the correct function name and updating the call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal feature decision resolution system for improved runtime performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->