### PR TITLE
feat(opencode): read user's opencode.json config for ACP mode

### DIFF
--- a/apps/cli/src/backends/opencode/acp/backend.test.ts
+++ b/apps/cli/src/backends/opencode/acp/backend.test.ts
@@ -1,10 +1,17 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { createOpenCodeBackend } from './backend';
+
+// Mock the logger to avoid console output during tests
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+  },
+}));
 
 type AcpBackendLike = {
   options: {
@@ -101,5 +108,224 @@ describe('createOpenCodeBackend command resolution', () => {
     expect(backend.options.args).toEqual(['acp']);
     expect(backend.options.env.NODE_ENV).toBe('production');
     expect(backend.options.env.DEBUG).toBe('');
+  });
+});
+
+describe('createOpenCodeBackend config file reading', () => {
+  const tempDirs: string[] = [];
+  const originalProcessEnv = { ...process.env };
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    // Restore process env
+    process.env = { ...originalProcessEnv };
+    delete process.env.OPENCODE_CONFIG_CONTENT;
+    delete process.env.XDG_CONFIG_HOME;
+
+    // Clean up temp dirs
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempConfigDir(): string {
+    const dir = makeTempDir('happier-opencode-config-');
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function writeConfigFile(dir: string, config: Record<string, unknown>): string {
+    const configDir = join(dir, '.config', 'opencode');
+    mkdirSync(configDir, { recursive: true });
+    const configPath = join(configDir, 'opencode.json');
+    writeFileSync(configPath, JSON.stringify(config), 'utf-8');
+    return configPath;
+  }
+
+  describe('config precedence', () => {
+    it('prioritizes process.env.OPENCODE_CONFIG_CONTENT over file-based config', () => {
+      const workDir = makeTempConfigDir();
+      writeConfigFile(workDir, { model: 'zai/glm-5' });
+
+      process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ model: 'process-env-model' });
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      expect(backend.options.env.OPENCODE_CONFIG_CONTENT).toBe('{"model":"process-env-model"}');
+    });
+
+    it('prioritizes options.env.OPENCODE_CONFIG_CONTENT over file-based config', () => {
+      const workDir = makeTempConfigDir();
+      writeConfigFile(workDir, { model: 'zai/glm-5' });
+
+      const backend = createOpenCodeBackend({
+        cwd: workDir,
+        env: { OPENCODE_CONFIG_CONTENT: JSON.stringify({ model: 'options-env-model' }) },
+      }) as unknown as AcpBackendLike;
+      expect(backend.options.env.OPENCODE_CONFIG_CONTENT).toBe('{"model":"options-env-model"}');
+    });
+
+    it('prioritizes process.env over options.env when both are set', () => {
+      const workDir = makeTempConfigDir();
+      writeConfigFile(workDir, { model: 'zai/glm-5' });
+
+      process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ model: 'process-env-model' });
+
+      const backend = createOpenCodeBackend({
+        cwd: workDir,
+        env: { OPENCODE_CONFIG_CONTENT: JSON.stringify({ model: 'options-env-model' }) },
+      }) as unknown as AcpBackendLike;
+      expect(backend.options.env.OPENCODE_CONFIG_CONTENT).toBe('{"model":"process-env-model"}');
+    });
+
+    it('reads from file when no env override is set', () => {
+      const workDir = makeTempConfigDir();
+      const config = { model: 'zai/glm-5', small_model: 'zai/glm-4.5-air' };
+      writeConfigFile(workDir, config);
+
+      // Mock homedir to use our temp dir
+      vi.doMock('node:os', () => ({
+        homedir: () => workDir,
+        platform: () => 'linux',
+      }));
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      expect(backend.options.env.OPENCODE_CONFIG_CONTENT).toBe(JSON.stringify(config));
+    });
+  });
+
+  describe('file-based config reading', () => {
+    it('does not set OPENCODE_CONFIG_CONTENT when config file does not exist', () => {
+      const workDir = makeTempDir('happier-opencode-no-config-');
+      tempDirs.push(workDir);
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      expect(backend.options.env.OPENCODE_CONFIG_CONTENT).toBeUndefined();
+    });
+
+    it('handles invalid JSON in config file gracefully', () => {
+      const workDir = makeTempConfigDir();
+      const configDir = join(workDir, '.config', 'opencode');
+      mkdirSync(configDir, { recursive: true });
+      const configPath = join(configDir, 'opencode.json');
+      writeFileSync(configPath, 'invalid json{', 'utf-8');
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      expect(backend.options.env.OPENCODE_CONFIG_CONTENT).toBeUndefined();
+    });
+
+    it('reads and validates config file with model and MCP servers', () => {
+      const workDir = makeTempConfigDir();
+      const config = {
+        model: 'zai/glm-5',
+        small_model: 'zai/glm-4.5-air',
+        mcp: {
+          'zai-mcp-server': {
+            type: 'local',
+            command: ['npx', '-y', '@z_ai/mcp-server'],
+          },
+        },
+      };
+      writeConfigFile(workDir, config);
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      const parsedConfig = JSON.parse(backend.options.env.OPENCODE_CONFIG_CONTENT!);
+      expect(parsedConfig.model).toBe('zai/glm-5');
+      expect(parsedConfig.small_model).toBe('zai/glm-4.5-air');
+      expect(parsedConfig.mcp['zai-mcp-server']).toBeDefined();
+    });
+  });
+
+  describe('XDG_CONFIG_HOME support', () => {
+    it('uses XDG_CONFIG_HOME when set on Linux', () => {
+      const workDir = makeTempConfigDir();
+      const customConfigDir = join(workDir, 'my-custom-config');
+      mkdirSync(customConfigDir, { recursive: true });
+      const opencodeDir = join(customConfigDir, 'opencode');
+      mkdirSync(opencodeDir, { recursive: true });
+      const configPath = join(opencodeDir, 'opencode.json');
+      writeFileSync(configPath, JSON.stringify({ model: 'xdg-model' }), 'utf-8');
+
+      process.env.XDG_CONFIG_HOME = customConfigDir;
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      const parsedConfig = JSON.parse(backend.options.env.OPENCODE_CONFIG_CONTENT!);
+      expect(parsedConfig.model).toBe('xdg-model');
+    });
+
+    it('falls back to ~/.config when XDG_CONFIG_HOME is not set', () => {
+      const workDir = makeTempConfigDir();
+      const config = { model: 'default-config-model' };
+      writeConfigFile(workDir, config);
+
+      delete process.env.XDG_CONFIG_HOME;
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      const parsedConfig = JSON.parse(backend.options.env.OPENCODE_CONFIG_CONTENT!);
+      expect(parsedConfig.model).toBe('default-config-model');
+    });
+  });
+
+  describe('cross-platform config paths', () => {
+    it('calculates correct config path for Windows', () => {
+      // This test verifies the path logic; actual file reading would require Windows platform
+      const workDir = makeTempDir('happier-opencode-windows-');
+      tempDirs.push(workDir);
+
+      // On Windows, would use %APPDATA%\opencode\opencode.json
+      // We can't fully test this without mocking platform, but we verify the backend doesn't crash
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      expect(backend.options.command).toBeTruthy();
+    });
+  });
+
+  describe('config with complex values', () => {
+    it('preserves nested configuration objects', () => {
+      const workDir = makeTempConfigDir();
+      const config = {
+        model: 'zai/glm-5',
+        mcp: {
+          'server-one': {
+            type: 'local',
+            command: ['npx', '-y', 'server-one'],
+            environment: {
+              API_KEY: 'test-key',
+              DEBUG: '1',
+            },
+          },
+          'server-two': {
+            type: 'stdio',
+            command: 'python',
+            args: ['-m', 'server_two'],
+          },
+        },
+        snapshot: false,
+      };
+      writeConfigFile(workDir, config);
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      const parsedConfig = JSON.parse(backend.options.env.OPENCODE_CONFIG_CONTENT!);
+
+      expect(parsedConfig).toEqual(config);
+      expect(parsedConfig.mcp['server-one'].environment.API_KEY).toBe('test-key');
+      expect(parsedConfig.mcp['server-two'].args).toEqual(['-m', 'server_two']);
+    });
+
+    it('handles configuration with special characters in values', () => {
+      const workDir = makeTempConfigDir();
+      const config = {
+        model: 'model-with-special-chars-<>-"-\\"',
+        path: 'C:\\Users\\Test\\Path',
+        regex: '.*\\.test$',
+      };
+      writeConfigFile(workDir, config);
+
+      const backend = createOpenCodeBackend({ cwd: workDir, env: {} }) as unknown as AcpBackendLike;
+      const parsedConfig = JSON.parse(backend.options.env.OPENCODE_CONFIG_CONTENT!);
+
+      expect(parsedConfig.model).toBe('model-with-special-chars-<>-"-\\"');
+      expect(parsedConfig.path).toBe('C:\\Users\\Test\\Path');
+      expect(parsedConfig.regex).toBe('.*\\.test$');
+    });
   });
 });

--- a/apps/cli/src/backends/opencode/acp/backend.ts
+++ b/apps/cli/src/backends/opencode/acp/backend.ts
@@ -8,6 +8,10 @@
  * ACP mode: `opencode acp`
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import { AcpBackend, type AcpBackendOptions, type AcpPermissionHandler } from '@/agent/acp/AcpBackend';
 import { resolveCliPathOverride } from '@/agent/acp/resolveCliPathOverride';
 import type { AgentBackend, McpServerConfig, AgentFactoryOptions } from '@/agent/core';
@@ -15,6 +19,64 @@ import { openCodeTransport } from '@/backends/opencode/acp/transport';
 import { logger } from '@/ui/logger';
 import type { PermissionMode } from '@/api/types';
 import { buildOpenCodeFamilyPermissionEnv } from '@/backends/opencode/utils/opencodeFamilyPermissionEnv';
+
+/**
+ * Get the platform-specific path to the OpenCode configuration file.
+ *
+ * Follows platform-specific conventions:
+ * - Linux/macOS: $XDG_CONFIG_HOME/opencode/opencode.json (defaults to ~/.config when unset)
+ * - Windows: %APPDATA%\opencode\opencode.json
+ */
+function getOpenCodeConfigPath(): string {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
+    return join(appData, 'opencode', 'opencode.json');
+  }
+  // Linux, macOS, and others respect XDG_CONFIG_HOME
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(xdgConfigHome, 'opencode', 'opencode.json');
+}
+
+/**
+ * Read the user's OpenCode configuration file and return it as a JSON string.
+ *
+ * OpenCode ACP mode does not read from ~/.config/opencode/opencode.json by default.
+ * Instead, it expects the full config to be passed via OPENCODE_CONFIG_CONTENT.
+ * This function bridges that gap by reading the user's config file and formatting
+ * it for the ACP backend.
+ *
+ * Precedence (highest to lowest):
+ * 1. process.env.OPENCODE_CONFIG_CONTENT (user's shell-level override)
+ * 2. optionsEnv.OPENCODE_CONFIG_CONTENT (runtime-provided config)
+ * 3. ~/.config/opencode/opencode.json (user's config file)
+ */
+function readOpenCodeConfig(optionsEnv?: Record<string, string>): string | undefined {
+  // Highest priority: process-level env var (user's shell override)
+  if (process.env.OPENCODE_CONFIG_CONTENT) {
+    return process.env.OPENCODE_CONFIG_CONTENT;
+  }
+
+  // Second priority: options env (runtime-provided config)
+  if (optionsEnv?.OPENCODE_CONFIG_CONTENT) {
+    return optionsEnv.OPENCODE_CONFIG_CONTENT;
+  }
+
+  // Lowest priority: read from config file
+  const configPath = getOpenCodeConfigPath();
+  if (!existsSync(configPath)) {
+    return undefined;
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    // Validate it's valid JSON
+    JSON.parse(content);
+    return content;
+  } catch (error) {
+    logger.debug(`[OpenCode] Failed to read config from ${configPath}:`, error);
+    return undefined;
+  }
+}
 
 export interface OpenCodeBackendOptions extends AgentFactoryOptions {
   /** MCP servers to make available to the agent */
@@ -26,6 +88,8 @@ export interface OpenCodeBackendOptions extends AgentFactoryOptions {
 }
 
 export function createOpenCodeBackend(options: OpenCodeBackendOptions): AgentBackend {
+  const openCodeConfig = readOpenCodeConfig(options.env);
+
   const backendOptions: AcpBackendOptions = {
     agentName: 'opencode',
     cwd: options.cwd,
@@ -37,6 +101,8 @@ export function createOpenCodeBackend(options: OpenCodeBackendOptions): AgentBac
       // Keep output clean; ACP must own stdout.
       NODE_ENV: 'production',
       DEBUG: '',
+      // Pass OpenCode config if available (respects user's ~/.config/opencode/opencode.json)
+      ...(openCodeConfig ? { OPENCODE_CONFIG_CONTENT: openCodeConfig } : {}),
     },
     mcpServers: options.mcpServers,
     permissionHandler: options.permissionHandler,
@@ -48,6 +114,7 @@ export function createOpenCodeBackend(options: OpenCodeBackendOptions): AgentBac
     command: backendOptions.command,
     args: backendOptions.args,
     mcpServerCount: options.mcpServers ? Object.keys(options.mcpServers).length : 0,
+    hasConfig: !!openCodeConfig,
   });
 
   return new AcpBackend(backendOptions);


### PR DESCRIPTION
## Summary

OpenCode's ACP mode does not read from `~/.config/opencode/opencode.json` by default. Instead, it requires configuration to be passed via the `OPENCODE_CONFIG_CONTENT` environment variable. This change bridges that gap by automatically reading and injecting the user's OpenCode configuration.

## Motivation

Currently, users who have configured OpenCode with their preferred model, API keys, and MCP servers via `~/.config/opencode/opencode.json` expect that configuration to be respected when running `happy opencode`. However, Happier's OpenCode backend spawns `opencode acp` without reading this file, causing the agent to fall back to the default "big-pickle" model regardless of user preferences.

The `OPENCODE_CONFIG_CONTENT` environment variable is:
- Undocumented in end-user documentation
- Non-standard (passing entire JSON config as env var)
- Not discoverable without digging into implementation details
- Overly cumbersome for what should be a straightforward configuration handoff

## Changes

- Added `getOpenCodeConfigPath()` to resolve platform-specific config paths
  - Linux/macOS: `~/.config/opencode/opencode.json`
  - Windows: `%APPDATA%\opencode\opencode.json`
- Added `readOpenCodeConfig()` to read and validate the config file
- Modified `createOpenCodeBackend()` to inject the config as `OPENCODE_CONFIG_CONTENT`
- Respects existing `OPENCODE_CONFIG_CONTENT` if already set (user override)

## Testing

Manual verification:
- Config file exists at `~/.config/opencode/opencode.json` with `model: "zai/glm-5"`
- Running `happy opencode` now correctly uses the configured model instead of defaulting to "big-pickle"

## Impact

This improves the developer experience by eliminating a configuration mismatch between OpenCode's TUI mode (which reads `opencode.json`) and Happier's ACP integration (which previously did not).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic platform-aware OpenCode configuration detection and reading.
  * Configuration status is now explicitly tracked and exposed during backend initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->