### PR TITLE
fix(ui): auto-seed same-origin server profile for self-hosted web deployments

### DIFF
--- a/apps/ui/sources/sync/domains/server/serverProfiles.test.ts
+++ b/apps/ui/sources/sync/domains/server/serverProfiles.test.ts
@@ -97,6 +97,32 @@ describe('serverProfiles', () => {
         expect(profiles.listServerProfiles().some((p) => p.serverUrl === 'https://api.happier.dev')).toBe(false);
     });
 
+    it('seeds a same-origin server profile on web when no preconfigured env exists', async () => {
+        const scope = randomScope();
+        process.env.EXPO_PUBLIC_HAPPY_STORAGE_SCOPE = scope;
+        delete process.env.EXPO_PUBLIC_HAPPY_SERVER_URL;
+        delete process.env.EXPO_PUBLIC_HAPPY_PRECONFIGURED_SERVERS;
+        stubWebRuntime('https://selfhost.example.test');
+
+        const profiles = await importFresh();
+        expect(profiles.listServerProfiles().some((p) => p.serverUrl === 'https://selfhost.example.test')).toBe(true);
+        expect(profiles.getActiveServerUrl()).toBe('https://selfhost.example.test');
+        expect(profiles.getActiveServerId()).toBeTruthy();
+    });
+
+    it('does not seed a same-origin server profile when EXPO_PUBLIC_HAPPY_SERVER_URL is set', async () => {
+        const scope = randomScope();
+        process.env.EXPO_PUBLIC_HAPPY_STORAGE_SCOPE = scope;
+        process.env.EXPO_PUBLIC_HAPPY_SERVER_URL = 'https://configured.example.test';
+        delete process.env.EXPO_PUBLIC_HAPPY_PRECONFIGURED_SERVERS;
+        stubWebRuntime('https://selfhost.example.test');
+
+        const profiles = await importFresh();
+        const all = profiles.listServerProfiles();
+        expect(all.some((p) => p.serverUrl === 'https://configured.example.test')).toBe(true);
+        expect(all.some((p) => p.serverUrl === 'https://selfhost.example.test')).toBe(false);
+    });
+
     it('derives deterministic filesystem-safe ids from server URLs', async () => {
         const scope = randomScope();
         process.env.EXPO_PUBLIC_HAPPY_STORAGE_SCOPE = scope;

--- a/apps/ui/sources/sync/domains/server/serverProfiles.ts
+++ b/apps/ui/sources/sync/domains/server/serverProfiles.ts
@@ -136,10 +136,10 @@ function parsePreconfiguredServersFromEnv(): PreconfiguredServer[] {
     // On web with no explicitly configured server, fall back to same-origin so that
     // self-hosted deployments (e.g. https://happier.example.com) get a server profile
     // without needing EXPO_PUBLIC_HAPPY_SERVER_URL set at build time.
-    if (entries.length === 0 && typeof window !== 'undefined' && window.location?.origin) {
-        const originUrl = normalizeUrl(String(window.location.origin));
-        if (originUrl && originUrl !== 'null') {
-            append(originUrl, '', 'url');
+    if (entries.length === 0) {
+        const origin = getWebSameOriginServerUrl();
+        if (origin) {
+            append(origin, '', 'url');
         }
     }
 


### PR DESCRIPTION
## Summary
When the web app is deployed at a custom domain (e.g. https://happier.example.com) without `EXPO_PUBLIC_HAPPY_SERVER_URL` set at build time, `parsePreconfiguredServersFromEnv()` returned no servers. This left `activeServerId` as `''` which caused `applyMachines()` to skip populating `machineListByServerId`, so the `/new` session page always showed the "connect machine" onboarding guidance even when machines were online.

## Solution
Fall back to the web same-origin URL when no server is explicitly configured and no entries have been parsed from env vars. This ensures self-hosted deployments get a server profile without requiring build-time env var configuration.

## Changes
- Modified `apps/ui/sources/sync/domains/server/serverProfiles.ts` to implement fallback logic for same-origin server URL seeding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic server profile detection based on the web origin. Self-hosted deployments are now automatically recognized when served from the same origin, eliminating the need for build-time server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->