### PR TITLE
fix(ui): prevent markdown table flex issues on Android

### DIFF
--- a/apps/ui/sources/components/markdown/MarkdownView.tsx
+++ b/apps/ui/sources/components/markdown/MarkdownView.tsx
@@ -527,7 +527,8 @@ const style = StyleSheet.create((theme) => ({
         overflow: 'hidden',
     },
     tableScrollView: {
-        flexGrow: 1,
+        flexGrow: 0,
+        flexShrink: 0,
     },
     tableContent: {
         flexDirection: 'row',


### PR DESCRIPTION
## Summary

- Fix markdown tables rendering incorrectly on Android by changing `tableScrollView` flex properties
- `flexGrow: 1` caused the table's scroll container to expand beyond its intrinsic height, resulting in the last row rendering with visual artifacts and content after the table being clipped or hidden
- Changed to `flexGrow: 0` and added `flexShrink: 0` so the table only occupies its natural height

Note: I've only tested this fix with an Android device. Please also make sure this does not cause breaking changes for iOS.

## Changes

**`apps/ui/sources/components/markdown/MarkdownView.tsx`**

```diff
 tableScrollView: {
-    flexGrow: 1,
+    flexGrow: 0,
+    flexShrink: 0,
 },
```

Example Screenshots (before):
![Screenshot_2026-02-21-02-00-32-44_525a54620047c02969a399eb2dfc6116](https://github.com/user-attachments/assets/f05e9c82-dfb5-4d5f-a881-6b6677a44b6d)
![Screenshot_2026-02-21-02-00-43-67_525a54620047c02969a399eb2dfc6116](https://github.com/user-attachments/assets/65036eef-e676-43d5-a015-4f35c8b06a4a)

After implementing the fix:
<img width="1080" height="2376" alt="image" src="https://github.com/user-attachments/assets/512d992c-310c-4ed4-9660-eac2b4b7d58c" />

I still have issues with horizontal scrolling in the table when the text is too long. Will identify a fix for it.

## Test plan

- [ ] Build APK
- [ ] Render a markdown message containing a table on an Android device/emulator
- [ ] Verify the last row of the table renders correctly without visual artifacts
- [ ] Verify text/content after the table is fully visible and not clipped
- [ ] Verify table horizontal scrolling still works for wide tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)