### PR TITLE
fix(ui): batch machine-activity updates to prevent session list flickering

### DIFF
--- a/apps/ui/sources/sync/engine/socket/socket.newMachineUpdates.test.ts
+++ b/apps/ui/sources/sync/engine/socket/socket.newMachineUpdates.test.ts
@@ -85,7 +85,7 @@ describe('socket update handling: machine-activity for unknown machine', () => {
         storage.setState(initialStorageState, true);
     });
 
-    it('creates a placeholder machine so active status is not dropped', () => {
+    it('routes update to addMachineActivityUpdate callback without directly writing to storage', () => {
         const addMachineActivityUpdate = vi.fn();
         expect(storage.getState().machines['m_unknown']).toBeUndefined();
 

--- a/apps/ui/sources/sync/engine/socket/socket.ts
+++ b/apps/ui/sources/sync/engine/socket/socket.ts
@@ -3,7 +3,7 @@ import type { Encryption } from '@/sync/encryption/encryption';
 import type { NormalizedMessage } from '@/sync/typesRaw';
 import type { Session } from '@/sync/domains/state/storageTypes';
 import type { Machine } from '@/sync/domains/state/storageTypes';
-import type { MachineActivityUpdate } from '../../reducer/machineActivityAccumulator';
+import type { MachineActivityUpdate } from '@/sync/reducer/machineActivityAccumulator';
 import { storage } from '@/sync/domains/state/storage';
 import { projectManager } from '@/sync/runtime/orchestration/projectManager';
 import { scmStatusSync } from '@/scm/scmStatusSync';
@@ -487,8 +487,8 @@ export function flushMachineActivityUpdates(params: {
 
 export function handleEphemeralSocketUpdate(params: {
     update: unknown;
-    addActivityUpdate: (update: any) => void;
-    addMachineActivityUpdate: (update: { id: string; active: boolean; activeAt: number }) => void;
+    addActivityUpdate: (update: ApiEphemeralActivityUpdate) => void;
+    addMachineActivityUpdate: (update: MachineActivityUpdate) => void;
 }): void {
     const { update, addActivityUpdate, addMachineActivityUpdate } = params;
 
@@ -498,10 +498,8 @@ export function handleEphemeralSocketUpdate(params: {
     // Process activity updates through smart debounce accumulator
     if (updateData.type === 'activity') {
         addActivityUpdate(updateData);
-    }
-
-    // Handle machine activity updates through batching accumulator
-    if (updateData.type === 'machine-activity') {
+    } else if (updateData.type === 'machine-activity') {
+        // Handle machine activity updates through batching accumulator
         addMachineActivityUpdate({ id: updateData.id, active: updateData.active, activeAt: updateData.activeAt });
     }
 

--- a/apps/ui/sources/sync/reducer/machineActivityAccumulator.ts
+++ b/apps/ui/sources/sync/reducer/machineActivityAccumulator.ts
@@ -45,6 +45,9 @@ export class MachineActivityAccumulator {
             clearTimeout(this.timeoutId);
             this.timeoutId = null;
         }
+        // Pending updates are intentionally dropped without flushing.
+        // Only safe when the corresponding storage state is also being discarded
+        // (e.g. via resetServerScopedRuntimeState).
         this.pendingUpdates.clear();
     }
 

--- a/apps/ui/sources/sync/sync.ts
+++ b/apps/ui/sources/sync/sync.ts
@@ -10,7 +10,7 @@ import type { ApiEphemeralActivityUpdate } from './api/types/apiTypes';
 import { Session, Machine, MetadataSchema, type Metadata } from './domains/state/storageTypes';
 import { InvalidateSync } from '@/utils/sessions/sync';
 import { ActivityUpdateAccumulator } from './reducer/activityUpdateAccumulator';
-import { MachineActivityAccumulator } from './reducer/machineActivityAccumulator';
+import { MachineActivityAccumulator, type MachineActivityUpdate } from './reducer/machineActivityAccumulator';
 import { randomUUID } from '@/platform/randomUUID';
 import { Platform, AppState } from 'react-native';
 import { resolveSentFrom } from './domains/messages/sentFrom';
@@ -2028,9 +2028,7 @@ class Sync {
         flushActivityUpdatesEngine({ updates, applySessions: (sessions) => this.applySessions(sessions) });
     }
 
-    private flushMachineActivityUpdates = (
-        updates: Map<string, import('./reducer/machineActivityAccumulator').MachineActivityUpdate>
-    ) => {
+    private flushMachineActivityUpdates = (updates: Map<string, MachineActivityUpdate>) => {
         flushMachineActivityUpdatesEngine({ updates, applyMachines: (machines) => storage.getState().applyMachines(machines) });
     }
 


### PR DESCRIPTION
## Summary
- **Problem:** When the app resumes from background, machine-activity WebSocket ephemerals fire individually for each machine, each triggering a full `buildSessionListViewData()` rebuild. With N machines this causes N re-renders = visible status flickering (issue #43).
- **Solution:** Add `MachineActivityAccumulator` (following existing `ActivityUpdateAccumulator` pattern) to batch machine-activity updates into a single `applyMachines()` call. Significant state changes (active↔inactive) still flush immediately but are batched with any pending updates.
- **Effect:** N machines = 1 rebuild + 1 re-render instead of N rebuilds + N re-renders.

## Changes
| File | Change |
|------|--------|
| **NEW** `sync/reducer/machineActivityAccumulator.ts` | Accumulator class with 300ms debounce, immediate flush on state transitions |
| `sync/engine/socket/socket.ts` | Extract `flushMachineActivityUpdates()`, route machine-activity through callback |
| `sync/sync.ts` | Wire accumulator instance, flush handler, and callback |
| `socket.newMachineUpdates.test.ts` | Update tests for callback pattern, add flush function test |

## Test plan
- [ ] Verify existing machine-activity test passes (`socket.newMachineUpdates.test.ts`)
- [ ] Open app → background → resume → observe session list transitions smoothly without flickering
- [ ] Verify machine online/offline state changes still appear promptly (immediate flush on significant change)

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Machine activity tracking now batches per-machine updates with debounced flushes and explicit flush support for more efficient, accurate sync and reduced write churn.

* **Tests**
  * Added tests covering routing and batched processing of machine-activity updates, immediate flush behavior, and storage-application validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->