### PR TITLE
fix(server): remove invalid PrismaJson import from @prisma/client

### DIFF
--- a/apps/server/sources/app/api/routes/session/pendingRoutes.ts
+++ b/apps/server/sources/app/api/routes/session/pendingRoutes.ts
@@ -1,4 +1,3 @@
-import type { PrismaJson } from "@prisma/client";
 import { z } from "zod";
 import { type Fastify } from "../../types";
 import { buildNewMessageUpdate, buildPendingChangedUpdate, eventRouter } from "@/app/events/eventRouter";

--- a/apps/server/sources/app/api/routes/session/registerSessionMessageRoutes.ts
+++ b/apps/server/sources/app/api/routes/session/registerSessionMessageRoutes.ts
@@ -1,4 +1,4 @@
-import type { Prisma, PrismaJson } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { z } from "zod";
 
 import { buildNewMessageUpdate, eventRouter } from "@/app/events/eventRouter";


### PR DESCRIPTION
PrismaJson is a global namespace declared in sources/storage/types.ts via 'declare global { namespace PrismaJson { ... } }'. It is not exported from @prisma/client and the import caused TypeScript build failures in Docker.

Remove the erroneous import from pendingRoutes.ts and registerSessionMessageRoutes.ts; the namespace is already globally available through tsconfig include.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal type imports in server modules to maintain code hygiene.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->