### PR TITLE
fix(oauth): pass through iss parameter in OIDC callback for RFC 9207

### DIFF
--- a/apps/server/sources/app/api/routes/connect/oauthExternal/registerOAuthCallbackRoute.ts
+++ b/apps/server/sources/app/api/routes/connect/oauthExternal/registerOAuthCallbackRoute.ts
@@ -34,6 +34,7 @@ export function registerOAuthCallbackRoute(app: Fastify) {
                 .object({
                     state: z.string(),
                     code: z.string().optional(),
+                    iss: z.string().optional(),
                     error: z.string().optional(),
                     error_description: z.string().optional(),
                 })
@@ -50,7 +51,7 @@ export function registerOAuthCallbackRoute(app: Fastify) {
             return reply.redirect(buildRedirectUrl(webAppUrl, { error: "unsupported-provider" }));
         }
 
-        const { code, state } = request.query;
+        const { code, state, iss } = request.query;
         const oauthError = (request.query as any)?.error?.toString?.().trim?.() || "";
 
         const oauthState = await auth.verifyOauthStateToken(state);
@@ -132,6 +133,7 @@ export function registerOAuthCallbackRoute(app: Fastify) {
                 env: process.env,
                 code,
                 state,
+                iss,
                 pkceCodeVerifier: attemptParsed.data.pkceCodeVerifier,
                 expectedNonce: attemptParsed.data.nonce,
             });

--- a/apps/server/sources/app/oauth/providers/oidc/oidcOAuthProvider.ts
+++ b/apps/server/sources/app/oauth/providers/oidc/oidcOAuthProvider.ts
@@ -30,7 +30,7 @@ export function createOidcOAuthProvider(instance: OidcAuthProviderInstanceConfig
             });
             return url.toString();
         },
-        exchangeCodeForAccessToken: async ({ code, state, pkceCodeVerifier, expectedNonce }): Promise<OAuthTokenExchangeResult> => {
+        exchangeCodeForAccessToken: async ({ code, state, iss, pkceCodeVerifier, expectedNonce }): Promise<OAuthTokenExchangeResult> => {
             if (!instance.clientId || !instance.clientSecret || !instance.redirectUrl || !instance.issuer) {
                 throw new Error("oauth_not_configured");
             }
@@ -39,6 +39,9 @@ export function createOidcOAuthProvider(instance: OidcAuthProviderInstanceConfig
             callbackUrl.searchParams.set("code", code);
             if (typeof state === "string" && state) {
                 callbackUrl.searchParams.set("state", state);
+            }
+            if (typeof iss === "string" && iss) {
+                callbackUrl.searchParams.set("iss", iss);
             }
 
             const tokens = await oidcClient.authorizationCodeGrant(cfg, callbackUrl, {

--- a/apps/server/sources/app/oauth/providers/types.ts
+++ b/apps/server/sources/app/oauth/providers/types.ts
@@ -28,6 +28,7 @@ export type OAuthFlowProvider = Readonly<{
         env: NodeJS.ProcessEnv;
         code: string;
         state?: string;
+        iss?: string;
         pkceCodeVerifier?: string;
         expectedNonce?: string;
     }) => Promise<OAuthTokenExchangeResult>;


### PR DESCRIPTION
OIDC providers that support RFC 9207 (Authorization Response Issuer Identification) include an `iss` parameter in the callback URL. The openid-client library validates this parameter when present in the provider's discovery metadata. Happier was reconstructing the callback URL with only `code` and `state`, causing authorizationCodeGrant to reject the response before making the token exchange request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OAuth authentication flow to support issuer identification, enabling better compatibility with additional identity providers and authentication protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->