### PR TITLE
fix: add timeout to SDK metadata extraction

### DIFF
--- a/apps/cli/src/backends/claude/sdk/metadataExtractor.test.ts
+++ b/apps/cli/src/backends/claude/sdk/metadataExtractor.test.ts
@@ -125,27 +125,35 @@ describe.sequential('claude sdk metadata extractor', () => {
     await withEnv(
       {
         HAPPIER_CLAUDE_PATH: fakeClaude,
-        HAPPIER_CLAUDE_SDK_METADATA_EXTRACTION_TIMEOUT_MS: '75',
+        // Allow enough time for the subprocess to start under load, but keep the test fast.
+        HAPPIER_CLAUDE_SDK_METADATA_EXTRACTION_TIMEOUT_MS: '500',
       },
       async () => {
         const { extractSDKMetadata } = await import('./metadataExtractor');
         const resultPromise = extractSDKMetadata();
 
-        await waitForFile(pidFile, 1_000);
-        const pid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
+        // Best-effort: if the child starts before the timeout triggers, ensure it exits.
+        let pid: number | null = null;
+        try {
+          await waitForFile(pidFile, 2_000);
+          pid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
+        } catch {
+          // ignore (abort may fire before the child starts)
+        }
 
         try {
-          await expect(withTimeout(resultPromise, 750, 'extractSDKMetadata to timeout')).resolves.toEqual({});
+          await expect(withTimeout(resultPromise, 3_000, 'extractSDKMetadata to timeout')).resolves.toEqual({});
         } finally {
-          try {
-            process.kill(pid, 'SIGTERM');
-          } catch {
-            // ignore
+          if (pid) {
+            try {
+              process.kill(pid, 'SIGTERM');
+            } catch {
+              // ignore
+            }
+            await waitForPidToExit(pid, 2_000);
           }
-          await waitForPidToExit(pid, 2_000);
         }
       },
     );
   });
 });
-

--- a/apps/cli/src/backends/claude/sdk/metadataExtractor.test.ts
+++ b/apps/cli/src/backends/claude/sdk/metadataExtractor.test.ts
@@ -1,0 +1,151 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function withEnv(vars: Record<string, string | undefined>, fn: () => Promise<void>): Promise<void> {
+  const prev: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    prev[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  return fn().finally(() => {
+    for (const [key, value] of Object.entries(prev)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+async function waitForFile(path: string, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    if (existsSync(path)) return;
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for file: ${path}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function waitForPidToExit(pid: number, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for PID ${pid} to exit`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timeoutId: NodeJS.Timeout | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(`Timed out waiting for ${label} after ${timeoutMs}ms`)), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  });
+}
+
+describe.sequential('claude sdk metadata extractor', () => {
+  let tmpRoot = '';
+
+  beforeEach(() => {
+    vi.resetModules();
+    if (tmpRoot) {
+      rmSync(tmpRoot, { recursive: true, force: true });
+      tmpRoot = '';
+    }
+  });
+
+  it('aborts the claude process after capturing init metadata (no leak)', { timeout: 20_000 }, async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'happier-claude-metadata-extractor-init-'));
+    const pidFile = join(tmpRoot, 'pid.txt');
+    const fakeClaude = join(tmpRoot, 'fake-claude.js');
+    writeFileSync(
+      fakeClaude,
+      `
+        const { writeFileSync } = require('node:fs');
+        const pidFile = ${JSON.stringify(pidFile)};
+        writeFileSync(pidFile, String(process.pid), 'utf8');
+
+        process.stdout.write(JSON.stringify({
+          type: 'system',
+          subtype: 'init',
+          tools: ['tool-a'],
+          slash_commands: ['/cmd'],
+        }) + '\\n');
+
+        process.on('SIGTERM', () => process.exit(0));
+        setInterval(() => {}, 1000);
+      `,
+      'utf8',
+    );
+
+    await withEnv(
+      {
+        HAPPIER_CLAUDE_PATH: fakeClaude,
+      },
+      async () => {
+        const { extractSDKMetadata } = await import('./metadataExtractor');
+        const metadata = await withTimeout(extractSDKMetadata(), 2_000, 'extractSDKMetadata to resolve');
+        expect(metadata).toEqual({ tools: ['tool-a'], slashCommands: ['/cmd'] });
+
+        await waitForFile(pidFile, 1_000);
+        const pid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
+        await waitForPidToExit(pid, 2_000);
+      },
+    );
+  });
+
+  it('respects a configurable extraction timeout and aborts on hang', { timeout: 20_000 }, async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'happier-claude-metadata-extractor-timeout-'));
+    const pidFile = join(tmpRoot, 'pid.txt');
+    const fakeClaude = join(tmpRoot, 'fake-claude.js');
+    writeFileSync(
+      fakeClaude,
+      `
+        const { writeFileSync } = require('node:fs');
+        const pidFile = ${JSON.stringify(pidFile)};
+        writeFileSync(pidFile, String(process.pid), 'utf8');
+        process.on('SIGTERM', () => process.exit(0));
+        setInterval(() => {}, 1000);
+      `,
+      'utf8',
+    );
+
+    await withEnv(
+      {
+        HAPPIER_CLAUDE_PATH: fakeClaude,
+        HAPPIER_CLAUDE_SDK_METADATA_EXTRACTION_TIMEOUT_MS: '75',
+      },
+      async () => {
+        const { extractSDKMetadata } = await import('./metadataExtractor');
+        const resultPromise = extractSDKMetadata();
+
+        await waitForFile(pidFile, 1_000);
+        const pid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
+
+        try {
+          await expect(withTimeout(resultPromise, 750, 'extractSDKMetadata to timeout')).resolves.toEqual({});
+        } finally {
+          try {
+            process.kill(pid, 'SIGTERM');
+          } catch {
+            // ignore
+          }
+          await waitForPidToExit(pid, 2_000);
+        }
+      },
+    );
+  });
+});
+

--- a/apps/cli/src/backends/claude/sdk/metadataExtractor.ts
+++ b/apps/cli/src/backends/claude/sdk/metadataExtractor.ts
@@ -12,23 +12,37 @@ export interface SDKMetadata {
     slashCommands?: string[]
 }
 
-/** Maximum time to wait for SDK metadata extraction before giving up. */
-const METADATA_EXTRACTION_TIMEOUT_MS = 10_000
+const DEFAULT_METADATA_EXTRACTION_TIMEOUT_MS = 10_000
+const MIN_METADATA_EXTRACTION_TIMEOUT_MS = 10
+const MAX_METADATA_EXTRACTION_TIMEOUT_MS = 120_000
+
+function resolveMetadataExtractionTimeoutMs(): number {
+    const raw = typeof process.env.HAPPIER_CLAUDE_SDK_METADATA_EXTRACTION_TIMEOUT_MS === 'string'
+        ? process.env.HAPPIER_CLAUDE_SDK_METADATA_EXTRACTION_TIMEOUT_MS.trim()
+        : ''
+    const parsed = Number.parseInt(raw, 10)
+    if (!Number.isFinite(parsed)) return DEFAULT_METADATA_EXTRACTION_TIMEOUT_MS
+    return Math.max(MIN_METADATA_EXTRACTION_TIMEOUT_MS, Math.min(MAX_METADATA_EXTRACTION_TIMEOUT_MS, parsed))
+}
 
 /**
  * Extract SDK metadata by running a minimal query and capturing the init message.
  *
- * Times out after METADATA_EXTRACTION_TIMEOUT_MS to prevent indefinite hangs
+ * Times out after the configured extraction timeout to prevent indefinite hangs
  * when the spawned SDK process blocks (e.g. on slow or inaccessible filesystems).
  *
  * @returns SDK metadata containing tools and slash commands
  */
 export async function extractSDKMetadata(): Promise<SDKMetadata> {
     const abortController = new AbortController()
+    const timeoutMs = resolveMetadataExtractionTimeoutMs()
     const timeoutId = setTimeout(() => {
-        logger.debug(`[metadataExtractor] Extraction timed out after ${METADATA_EXTRACTION_TIMEOUT_MS}ms`)
+        logger.debug(`[metadataExtractor] Extraction timed out after ${timeoutMs}ms`)
         abortController.abort()
-    }, METADATA_EXTRACTION_TIMEOUT_MS)
+    }, timeoutMs)
+    if (typeof timeoutId.unref === 'function') {
+        timeoutId.unref()
+    }
 
     try {
         logger.debug('[metadataExtractor] Starting SDK metadata extraction')
@@ -56,19 +70,16 @@ export async function extractSDKMetadata(): Promise<SDKMetadata> {
                 logger.debug('[metadataExtractor] Captured SDK metadata:', metadata)
 
                 // Abort the query since we got what we need
-                clearTimeout(timeoutId)
                 abortController.abort()
 
                 return metadata
             }
         }
 
-        clearTimeout(timeoutId)
         logger.debug('[metadataExtractor] No init message received from SDK')
         return {}
 
     } catch (error) {
-        clearTimeout(timeoutId)
         // Check if it's an abort error (expected — either from timeout or after capture)
         if (error instanceof Error && error.name === 'AbortError') {
             logger.debug('[metadataExtractor] SDK query aborted (timeout or after capturing metadata)')
@@ -76,6 +87,8 @@ export async function extractSDKMetadata(): Promise<SDKMetadata> {
         }
         logger.debug('[metadataExtractor] Error extracting SDK metadata:', error)
         return {}
+    } finally {
+        clearTimeout(timeoutId)
     }
 }
 

--- a/apps/cli/src/backends/claude/sdk/metadataExtractor.ts
+++ b/apps/cli/src/backends/claude/sdk/metadataExtractor.ts
@@ -12,16 +12,27 @@ export interface SDKMetadata {
     slashCommands?: string[]
 }
 
+/** Maximum time to wait for SDK metadata extraction before giving up. */
+const METADATA_EXTRACTION_TIMEOUT_MS = 10_000
+
 /**
- * Extract SDK metadata by running a minimal query and capturing the init message
+ * Extract SDK metadata by running a minimal query and capturing the init message.
+ *
+ * Times out after METADATA_EXTRACTION_TIMEOUT_MS to prevent indefinite hangs
+ * when the spawned SDK process blocks (e.g. on slow or inaccessible filesystems).
+ *
  * @returns SDK metadata containing tools and slash commands
  */
 export async function extractSDKMetadata(): Promise<SDKMetadata> {
     const abortController = new AbortController()
-    
+    const timeoutId = setTimeout(() => {
+        logger.debug(`[metadataExtractor] Extraction timed out after ${METADATA_EXTRACTION_TIMEOUT_MS}ms`)
+        abortController.abort()
+    }, METADATA_EXTRACTION_TIMEOUT_MS)
+
     try {
         logger.debug('[metadataExtractor] Starting SDK metadata extraction')
-        
+
         // Run SDK with minimal tools allowed
         const sdkQuery = query({
             prompt: 'hello',
@@ -36,28 +47,31 @@ export async function extractSDKMetadata(): Promise<SDKMetadata> {
         for await (const message of sdkQuery) {
             if (message.type === 'system' && message.subtype === 'init') {
                 const systemMessage = message as SDKSystemMessage
-                
+
                 const metadata: SDKMetadata = {
                     tools: systemMessage.tools,
                     slashCommands: systemMessage.slash_commands
                 }
-                
+
                 logger.debug('[metadataExtractor] Captured SDK metadata:', metadata)
-                
+
                 // Abort the query since we got what we need
+                clearTimeout(timeoutId)
                 abortController.abort()
-                
+
                 return metadata
             }
         }
-        
+
+        clearTimeout(timeoutId)
         logger.debug('[metadataExtractor] No init message received from SDK')
         return {}
-        
+
     } catch (error) {
-        // Check if it's an abort error (expected)
+        clearTimeout(timeoutId)
+        // Check if it's an abort error (expected — either from timeout or after capture)
         if (error instanceof Error && error.name === 'AbortError') {
-            logger.debug('[metadataExtractor] SDK query aborted after capturing metadata')
+            logger.debug('[metadataExtractor] SDK query aborted (timeout or after capturing metadata)')
             return {}
         }
         logger.debug('[metadataExtractor] Error extracting SDK metadata:', error)


### PR DESCRIPTION
## Summary

- `extractSDKMetadata()` has no timeout — if the spawned SDK process hangs (e.g. due to inaccessible filesystems or missing credentials), the extraction waits indefinitely, leaking a process for the session lifetime
- Adds a 10-second timeout via `setTimeout` + `AbortController`
- If the SDK query doesn't produce an init message within the timeout, the query is aborted and empty metadata is returned gracefully
- Normal extraction completes in ~1-2 seconds, so 10 seconds provides ample headroom

## Context

Discovered while debugging daemon-spawned sessions on macOS where the metadata extraction subprocess would hang indefinitely due to filesystem access issues (symlinks to cloud storage). While `extractSDKMetadataAsync` is fire-and-forget and doesn't block session startup, the leaked process persists for the session lifetime.

## Test plan

- [ ] Verify normal metadata extraction still completes successfully (should be well under 10s)
- [ ] Verify that when the SDK query hangs, extraction times out after 10s and returns empty metadata gracefully
- [ ] Verify existing test mocks (`extractSDKMetadataAsync: vi.fn()`) still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a metadata extraction timeout to prevent hangs and ensure stuck processes are aborted.
  * Improved logging for timeouts, aborts, and successful metadata capture to aid diagnosis and observability.

* **Tests**
  * Added sequential integration tests validating metadata capture, child-process termination, and configurable timeout behavior under normal and hanging scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->