### PR TITLE
fix: match session webhook PID to parent when wrapper scripts are used

### DIFF
--- a/apps/cli/src/daemon/sessions/onHappySessionWebhook.ts
+++ b/apps/cli/src/daemon/sessions/onHappySessionWebhook.ts
@@ -4,6 +4,7 @@ import { logger } from '@/ui/logger';
 
 import os from 'node:os';
 import path from 'node:path';
+import { execSync } from 'node:child_process';
 
 import { findHappyProcessByPid } from '../doctor';
 import type { TrackedSession } from '../types';
@@ -15,6 +16,24 @@ function resolveTildePath(inputPath: string): string {
   if (trimmed === '~') return os.homedir();
   if (trimmed.startsWith('~/')) return path.join(os.homedir(), trimmed.slice(2));
   return inputPath;
+}
+
+/**
+ * Get the parent PID of a process.
+ *
+ * Used to detect wrapper-script scenarios where the daemon spawns a wrapper
+ * (e.g. Node.js entrypoint) that in turn spawns the actual session binary.
+ * Returns null on Windows or if the lookup fails.
+ */
+function getParentPid(pid: number): number | null {
+  if (process.platform === 'win32') return null;
+  try {
+    const stdout = execSync(`ps -o ppid= -p ${pid}`, { encoding: 'utf-8', timeout: 1000 });
+    const ppid = parseInt(stdout.trim(), 10);
+    return Number.isFinite(ppid) ? ppid : null;
+  } catch {
+    return null;
+  }
 }
 
 export function createOnHappySessionWebhook(params: Readonly<{
@@ -86,15 +105,40 @@ export function createOnHappySessionWebhook(params: Readonly<{
         logger.debug(`[DAEMON RUN] Refreshed externally-started session ${sessionId}`);
       }
     } else if (!existingSession) {
-      // New session started externally
-      const trackedSession: TrackedSession = {
-        startedBy: 'happy directly - likely by user from terminal',
-        happySessionId: sessionId,
-        happySessionMetadataFromLocalWebhook: normalizedMetadata,
-        pid
-      };
-      pidToTrackedSession.set(pid, trackedSession);
-      logger.debug(`[DAEMON RUN] Registered externally-started session ${sessionId}`);
+      // PID not in tracked map. Check if this is a child of a tracked PID —
+      // this happens when a wrapper script (e.g. Node.js entrypoint) spawns
+      // the actual session binary as a child process, causing a PID mismatch
+      // between what the daemon spawned and what the session reports.
+      const ppid = getParentPid(pid);
+      const parentSession = ppid ? pidToTrackedSession.get(ppid) : null;
+
+      if (parentSession && parentSession.startedBy === 'daemon') {
+        // Re-key the tracked session from wrapper PID to actual session PID
+        pidToTrackedSession.delete(ppid);
+        parentSession.pid = pid;
+        parentSession.happySessionId = sessionId;
+        parentSession.happySessionMetadataFromLocalWebhook = normalizedMetadata;
+        pidToTrackedSession.set(pid, parentSession);
+        logger.debug(`[DAEMON RUN] Re-keyed daemon session from wrapper PID ${ppid} to actual PID ${pid}`);
+
+        // Resolve any awaiter that was waiting on the wrapper PID
+        const awaiter = pidToAwaiter.get(ppid);
+        if (awaiter) {
+          pidToAwaiter.delete(ppid);
+          awaiter(parentSession);
+          logger.debug(`[DAEMON RUN] Resolved session awaiter via parent PID ${ppid}`);
+        }
+      } else {
+        // New session started externally (not by this daemon)
+        const trackedSession: TrackedSession = {
+          startedBy: 'happy directly - likely by user from terminal',
+          happySessionId: sessionId,
+          happySessionMetadataFromLocalWebhook: normalizedMetadata,
+          pid
+        };
+        pidToTrackedSession.set(pid, trackedSession);
+        logger.debug(`[DAEMON RUN] Registered externally-started session ${sessionId}`);
+      }
     }
 
     // Best-effort: write/update marker so future daemon restarts can reattach.


### PR DESCRIPTION
## Summary

- When the daemon spawns a session through a wrapper script (e.g. a Node.js entrypoint that spawns the actual binary as a child process), the daemon tracks the wrapper's PID while the session reports the binary's PID via webhook
- This PID mismatch causes the session to be registered as "externally-started," a ~90-second webhook timeout, and delayed spawn response to the client
- When an unknown PID reports via webhook, now checks if its parent PID (PPID) matches any daemon-tracked PID
- If a match is found, re-keys the tracked session to the actual PID and resolves pending awaiters immediately

### Implementation

- Adds `getParentPid()` helper using `ps -o ppid= -p <pid>` (Unix only, <10ms, 1s timeout guard)
- On Windows the PPID check is skipped and existing behavior is preserved
- Only runs when a PID is NOT in the tracked map (infrequent path)
- Failures are caught gracefully — worst case falls back to existing "register as externally-started" behavior

## Context

Discovered with compiled binary deployments where a Node.js entrypoint wrapper spawns the actual Happier binary. The daemon tracks the wrapper's PID, but the session webhook reports the binary's PID. This causes a PID mismatch that results in a 90-second timeout before the spawn response reaches the client, even though the session itself works fine.

## Test plan

- [ ] Verify daemon-spawned sessions are correctly tracked when spawned directly (no wrapper)
- [ ] Verify daemon-spawned sessions via wrapper scripts are re-keyed to the correct PID
- [ ] Verify the ~90-second webhook timeout no longer occurs in the wrapper scenario
- [ ] Verify externally-started sessions (not spawned by daemon) are still registered correctly
- [ ] Verify Windows behavior is unaffected (PPID check skipped)