### PR TITLE
feat(mcp): pass through local Claude Code mcpServers in Happier sessions

### DIFF
--- a/apps/cli/src/backends/claude/cli/command.ts
+++ b/apps/cli/src/backends/claude/cli/command.ts
@@ -153,6 +153,8 @@ export async function handleClaudeCliCommand(context: CommandContext): Promise<v
       chromeOverride = true;
     } else if (arg === '--no-chrome') {
       chromeOverride = false;
+    } else if (arg === '--no-local-mcp') {
+      options.disableLocalMcpPassthrough = true;
     } else {
       unknownArgs.push(arg);
       // Check if this arg expects a value (simplified check for common patterns)
@@ -200,6 +202,7 @@ ${chalk.bold('Examples:')}
                               happier sugar for --dangerously-skip-permissions
   happier --chrome           Enable Chrome browser access for this session
   happier --no-chrome        Disable Chrome even if default is on
+  happier --no-local-mcp     Don't pass local Claude Code MCP servers to session
   happier --js-runtime bun   Use bun instead of node to spawn Claude Code
   happier --claude-env ANTHROPIC_BASE_URL=http://127.0.0.1:3456
                              Use a custom API endpoint (e.g., claude-code-router)

--- a/apps/cli/src/backends/claude/runClaude.ts
+++ b/apps/cli/src/backends/claude/runClaude.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
 
 import { logger } from '@/ui/logger';
 import { restoreStdinBestEffort } from '@/ui/ink/restoreStdinBestEffort';
@@ -20,7 +21,7 @@ import { startHookServer } from '@/backends/claude/utils/startHookServer';
 import { generateHookSettingsFile, cleanupHookSettingsFile } from '@/backends/claude/utils/generateHookSettings';
 import { registerKillSessionHandler } from '@/rpc/handlers/killSession';
 import { projectPath } from '../../projectPath';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { startOfflineReconnection, connectionState } from '@/api/offline/serverConnectionErrors';
 import { claudeLocal } from '@/backends/claude/claudeLocal';
 import { createSessionScanner } from '@/backends/claude/utils/sessionScanner';
@@ -84,6 +85,36 @@ export interface StartOptions {
      * Used for resuming inactive sessions.
      */
     existingSessionId?: string
+    /**
+     * When true, disables automatic pass-through of MCP servers from the local
+     * Claude Code settings.json. By default (false/undefined), Happier reads
+     * `mcpServers` from `~/.claude/settings.json` (or `$CLAUDE_CONFIG_DIR/settings.json`)
+     * and passes them to Claude Code via `--mcp-config` so they are available in
+     * Happier-managed sessions.
+     */
+    disableLocalMcpPassthrough?: boolean
+}
+
+/**
+ * Read `mcpServers` from the local Claude Code settings.json so that any MCP
+ * servers the user has configured for Claude Code's TUI mode are also available
+ * in Happier-managed sessions.
+ *
+ * Reads from `$CLAUDE_CONFIG_DIR/settings.json` when the env var is set, or
+ * the default `~/.claude/settings.json` otherwise. Returns an empty object if
+ * the file is absent or unreadable — never throws.
+ */
+export function readLocalClaudeMcpServers(claudeEnvVars?: Record<string, string>): Record<string, any> {
+    try {
+        const configDir = claudeEnvVars?.CLAUDE_CONFIG_DIR ?? join(os.homedir(), '.claude');
+        const settingsPath = join(configDir, 'settings.json');
+        if (!existsSync(settingsPath)) return {};
+        const raw = readFileSync(settingsPath, 'utf-8');
+        const settings = JSON.parse(raw) as { mcpServers?: Record<string, any> };
+        return settings.mcpServers ?? {};
+    } catch {
+        return {};
+    }
 }
 
 export function extractMcpServersFromClaudeArgs(args?: string[]): { claudeArgs?: string[]; mcpServers: Record<string, any> } {
@@ -838,6 +869,8 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
             }
         },
 	        mcpServers: {
+	            // Local Claude Code settings.json MCPs (unless disabled via --no-local-mcp).
+	            ...(options.disableLocalMcpPassthrough ? {} : readLocalClaudeMcpServers(options.claudeEnvVars)),
 	            ...extractedMcp.mcpServers,
 	            // Keep Happy MCP server last so a user-provided "happy" entry cannot override it.
 	            happy: {
@@ -1368,6 +1401,8 @@ async function runClaudeLocalFastStart(credentials: Credentials, options: StartO
                         }
                     },
                     mcpServers: {
+                        // Local Claude Code settings.json MCPs (unless disabled via --no-local-mcp).
+                        ...(options.disableLocalMcpPassthrough ? {} : readLocalClaudeMcpServers(options.claudeEnvVars)),
                         ...extractedMcp.mcpServers,
                         happy: {
                             type: 'http' as const,


### PR DESCRIPTION
## Problem

When Happier spawns Claude Code in remote/streaming mode, the Claude Code process runs headlessly with `--output-format stream-json`. In this mode, Claude Code's internal MCP subprocess manager does **not** initialize stdio/HTTP servers from `settings.json → mcpServers`. Any MCP servers the user has configured (e.g. a local RAG search server, a notes server, custom tools) are silently unavailable — even though they work fine in interactive TUI sessions.

**Evidence:** `~/.claude.json → mcpServers: {}` stays empty forever; no MCP server processes are ever spawned during Happier sessions.

## Fix

Add `readLocalClaudeMcpServers()` to `runClaude.ts` — reads `mcpServers` from `$CLAUDE_CONFIG_DIR/settings.json` (or `~/.claude/settings.json`) and merges them into the `mcpServers` object passed via `--mcp-config` to Claude Code.

This is wired into both code paths where `mcpServers` is constructed:
- The main `loop()` call (~line 869)
- The fast-start coordinator path (~line 1401)

### Toggle

The feature is **on by default** (new behavior). To restore previous behavior:

```
happier --no-local-mcp
```

### Priority order (later spreads win)

1. **Local settings.json** — user's existing Claude Code MCP config (new, base layer)
2. **Session args** — any `--mcp-config` passed at session level (`extractedMcp`)
3. **Happier bridge** — always last, cannot be overridden

### Why this approach

- **Zero new config surface** — users already have their MCPs configured in `~/.claude/settings.json`. No duplication required.
- **Respects `CLAUDE_CONFIG_DIR`** — non-default Claude installations work automatically.
- **Non-breaking** — `--no-local-mcp` restores exact previous behavior.
- **Minimal diff** — 2 files, ~40 lines total.

## Testing

1. Add a stdio MCP server to `~/.claude/settings.json → mcpServers`
2. Start a Happier session
3. Confirm `mcp__<servername>__*` tools appear
4. Start again with `happier --no-local-mcp` — confirm tools do NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)