### PR TITLE
fix(agents): include codex mcp resume install setting in shape

### DIFF
--- a/packages/agents/src/providerSettings/definitions/codex.settingsShape.test.ts
+++ b/packages/agents/src/providerSettings/definitions/codex.settingsShape.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import {
+  CODEX_PROVIDER_SETTINGS_DEFAULTS,
+  buildCodexProviderSettingsShape,
+} from './codex';
+
+describe('codex provider settings shape/default parity', () => {
+  it('includes codexMcpResumeInstallSpec in both shape and defaults', () => {
+    const shape = buildCodexProviderSettingsShape(z);
+
+    expect(shape).toHaveProperty('codexMcpResumeInstallSpec');
+    expect(CODEX_PROVIDER_SETTINGS_DEFAULTS).toHaveProperty('codexMcpResumeInstallSpec', '');
+  });
+});
+

--- a/packages/agents/src/providerSettings/definitions/codex.ts
+++ b/packages/agents/src/providerSettings/definitions/codex.ts
@@ -6,6 +6,7 @@ export type CodexBackendMode = 'mcp' | 'acp';
 
 export const CODEX_PROVIDER_SETTINGS_DEFAULTS = Object.freeze({
   codexBackendMode: 'acp' satisfies CodexBackendMode,
+  codexMcpResumeInstallSpec: '',
   codexAcpInstallSpec: '',
 });
 
@@ -15,6 +16,7 @@ export function buildCodexProviderSettingsShape(zod: typeof z): ProviderSettings
     codexBackendMode: zod
       .enum(['mcp', 'mcp_resume', 'acp'])
       .transform((value): CodexBackendMode => (value === 'mcp' ? 'mcp' : 'acp')),
+    codexMcpResumeInstallSpec: zod.string(),
     codexAcpInstallSpec: zod.string(),
   } as const;
 }


### PR DESCRIPTION
## Summary
- add `codexMcpResumeInstallSpec` to Codex provider defaults in `packages/agents`
- add `codexMcpResumeInstallSpec` to Codex provider settings shape validation
- add a focused unit test that guards shape/default parity for this field

## Why
`apps/ui` registers this field in the Codex provider plugin, but `packages/agents` did not define it in shape/defaults. This caused runtime plugin-registry validation failures in UI tests.

## Validation
- `yarn workspace @happier-dev/agents test src/providerSettings/definitions/codex.settingsShape.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for MCP resume installation specification in Codex provider configuration.

* **Tests**
  * Implemented validation tests to ensure provider settings configuration consistency with defined defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->