### PR TITLE
fix(cli): allow runtime permission mode escalation to bypassPermissions

### DIFF
--- a/apps/cli/src/backends/claude/remote/claudeRemoteAgentSdk.optionsAndHooks.test.ts
+++ b/apps/cli/src/backends/claude/remote/claudeRemoteAgentSdk.optionsAndHooks.test.ts
@@ -577,7 +577,7 @@ describe('claudeRemoteAgentSdk options and hooks', () => {
         }
     });
 
-    it('sets allowDangerouslySkipPermissions only when permissionMode is bypassPermissions', async () => {
+    it('always sets allowDangerouslySkipPermissions so permission mode can escalate to bypassPermissions at runtime', async () => {
         let capturedOptions: any = null;
 
         const createQuery = vi.fn((_params: any) => {
@@ -595,13 +595,13 @@ describe('claudeRemoteAgentSdk options and hooks', () => {
             } as any;
         });
 
-        const runOnce = async (permissionMode: any) => {
+        const runOnce = async (modeOverrides: any) => {
             capturedOptions = null;
             let didSendFirst = false;
             const nextMessage = vi.fn(async () => {
                 if (didSendFirst) return null;
                 didSendFirst = true;
-                return { message: 'hello', mode: makeMode({ permissionMode }) };
+                return { message: 'hello', mode: makeMode(modeOverrides) };
             });
 
                 await claudeRemoteAgentSdk({
@@ -622,8 +622,9 @@ describe('claudeRemoteAgentSdk options and hooks', () => {
             return capturedOptions;
         };
 
-        expect((await runOnce('default'))?.allowDangerouslySkipPermissions).toBe(false);
-        expect((await runOnce('bypassPermissions'))?.allowDangerouslySkipPermissions).toBe(true);
+        expect((await runOnce({ permissionMode: 'default' }))?.allowDangerouslySkipPermissions).toBe(true);
+        expect((await runOnce({ permissionMode: 'bypassPermissions' }))?.allowDangerouslySkipPermissions).toBe(true);
+        expect((await runOnce({ permissionMode: 'default', agentModeId: 'plan' }))?.allowDangerouslySkipPermissions).toBe(true);
     });
 
     it('prefers CLI model overrides over mode.model', async () => {

--- a/apps/cli/src/backends/claude/remote/claudeRemoteAgentSdk.ts
+++ b/apps/cli/src/backends/claude/remote/claudeRemoteAgentSdk.ts
@@ -436,7 +436,7 @@ export async function claudeRemoteAgentSdk(opts: {
             ...(startFrom && resumeSessionAt ? { resumeSessionAt } : {}),
             settingSources,
             permissionMode: mappedPermissionMode,
-            allowDangerouslySkipPermissions: mappedPermissionMode === 'bypassPermissions',
+            allowDangerouslySkipPermissions: true,
             model: argOverrides.model ?? mode.model,
             fallbackModel: argOverrides.fallbackModel ?? mode.fallbackModel,
             maxTurns: argOverrides.maxTurns,


### PR DESCRIPTION
## Summary

- Always set `allowDangerouslySkipPermissions: true` at Agent SDK session creation, so that `setPermissionMode('bypassPermissions')` works on follow-up messages

## Problem

When a session is started with a non-yolo permission mode (e.g. `default` or `acceptEdits`) and the user later switches to yolo mode from the phone, the runtime `setPermissionMode('bypassPermissions')` call throws:

```
Cannot set permission mode to bypassPermissions because the session was not launched with --dangerously-skip-permissions
```

This surfaces as:
```
Failed to update runtime settings (non-fatal); continuing.
```

The user sees the error on their phone, and the session continues running with the **wrong permission mode** — it stays on whatever mode it was launched with instead of switching to yolo.

### Root cause

At session creation (`claudeRemoteAgentSdk.ts`), `allowDangerouslySkipPermissions` is only set to `true` when the **initial** mode is `bypassPermissions`:

```ts
allowDangerouslySkipPermissions: mappedPermissionMode === 'bypassPermissions',
```

But on follow-up messages, `setPermissionMode()` is called to update the mode — and it cannot escalate to `bypassPermissions` because the Claude Agent SDK requires `allowDangerouslySkipPermissions` to have been set at launch time.

### Fix

Always set `allowDangerouslySkipPermissions: true` at session creation. This does **not** change the initial permission mode (still controlled by `permissionMode: mappedPermissionMode`). It only removes the gate that prevents upgrading permissions at runtime via `setPermissionMode()`.

## Test plan

- [ ] Start a session from terminal with default permissions
- [ ] From phone, switch to yolo mode mid-session
- [ ] Verify no "Failed to update runtime settings" error
- [ ] Verify the session actually runs in bypassPermissions mode after switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Permission-skip behavior for the Claude agent has been simplified: the agent now always runs with permission skipping enabled, altering how tool access checks occur at runtime.
* **Tests**
  * Test coverage updated to assert the always-enabled permission-skip behavior across modes and agent configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->