### PR TITLE
Fix stalled resumes: wake after send + fail-closed MCP bridge

### DIFF
--- a/apps/cli/src/agent/runtime/createHappierMcpBridge.test.ts
+++ b/apps/cli/src/agent/runtime/createHappierMcpBridge.test.ts
@@ -40,6 +40,11 @@ describe('createHappierMcpBridge', () => {
   })
 
   it('uses direct script mode by default', async () => {
+    vi.mocked(existsSync).mockImplementation((pathLike) => {
+      const path = String(pathLike)
+      return path.endsWith('/package-dist/backends/codex/happyMcpStdioBridge.mjs')
+    })
+
     const session = {} as any
     const { mcpServers } = await createHappierMcpBridge(session)
 
@@ -56,6 +61,11 @@ describe('createHappierMcpBridge', () => {
   })
 
   it('supports current-process mode', async () => {
+    vi.mocked(existsSync).mockImplementation((pathLike) => {
+      const path = String(pathLike)
+      return path.endsWith('/package-dist/backends/codex/happyMcpStdioBridge.mjs')
+    })
+
     const session = {} as any
     const { mcpServers } = await createHappierMcpBridge(session, { commandMode: 'current-process' })
 
@@ -135,6 +145,10 @@ describe('createHappierMcpBridge', () => {
 
   it('uses the ensured JavaScript runtime for the bundled dist bridge when direct script mode runs under bun', async () => {
     requireJavaScriptRuntimeExecutableMock.mockResolvedValue('/managed/js-runtime')
+    vi.mocked(existsSync).mockImplementation((pathLike) => {
+      const path = String(pathLike)
+      return path.endsWith('/package-dist/backends/codex/happyMcpStdioBridge.mjs')
+    })
 
     const session = {} as any
     const { mcpServers } = await createHappierMcpBridge(session)

--- a/apps/cli/src/mcp/runtime/resolveNodeBackedMcpServerCommand.test.ts
+++ b/apps/cli/src/mcp/runtime/resolveNodeBackedMcpServerCommand.test.ts
@@ -180,4 +180,15 @@ describe('resolveNodeBackedMcpServerCommand', () => {
       }),
     ).rejects.toThrow(/HAPPIER_JS_RUNTIME_PATH/);
   });
+
+  it('throws a clear error when no usable entrypoint exists', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await expect(
+      resolveNodeBackedMcpServerCommand({
+        distEntrypointSegments: ['mcp', 'bridges', 'remoteMcpStdioBridge.mjs'],
+        sourceEntrypointSegments: ['mcp', 'bridges', 'remoteMcpStdioBridge.ts'],
+      }),
+    ).rejects.toThrow(/usable entrypoint/i);
+  });
 });

--- a/apps/cli/src/mcp/runtime/resolveNodeBackedMcpServerCommand.ts
+++ b/apps/cli/src/mcp/runtime/resolveNodeBackedMcpServerCommand.ts
@@ -55,8 +55,9 @@ export async function resolveNodeBackedMcpServerCommand(params: Readonly<{
     };
   }
 
-  return {
-    command,
-    args: ['--no-warnings', '--no-deprecation', packagedEntrypoint, ...(params.args ?? [])],
-  };
+  throw new Error(
+    `[resolveNodeBackedMcpServerCommand] No usable entrypoint found. Checked packaged entrypoint: ${packagedEntrypoint}; checked source entrypoint: ${sourceEntrypoint} (tsx hook ${
+      typeof tsxHookPath === 'string' && tsxHookPath.length > 0 ? 'available' : 'missing'
+    }).`,
+  );
 }

--- a/apps/cli/src/workspaces/replication/orchestration/executeWorkspaceReplicationJobWithLocalRuntime.test.ts
+++ b/apps/cli/src/workspaces/replication/orchestration/executeWorkspaceReplicationJobWithLocalRuntime.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { access, copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/apps/ui/sources/components/sessions/shell/SessionView.sendMessage.resumeInactive.pendingQueue.test.tsx
+++ b/apps/ui/sources/components/sessions/shell/SessionView.sendMessage.resumeInactive.pendingQueue.test.tsx
@@ -16,6 +16,7 @@ import { installSessionShellCommonModuleMocks } from './sessionShellTestHelpers'
 
 const previousDev = (globalThis as { __DEV__?: boolean }).__DEV__;
 const enqueuePendingMessageSpy = vi.hoisted(() => vi.fn(async (..._args: any[]) => {}));
+const submitMessageSpy = vi.hoisted(() => vi.fn(async (..._args: any[]) => {}));
 const resumeSessionSpy = vi.hoisted(() =>
     vi.fn<(..._args: any[]) => Promise<ResumeSessionResult>>(async (..._args: any[]) => ({
         type: 'error' as const,
@@ -80,6 +81,9 @@ const themeColors = vi.hoisted(() => ({
 }));
 
 let authCredentials: any = { token: 't', secret: 's' };
+const sessionState = vi.hoisted(() => ({
+    current: null as any,
+}));
 const pendingFireAndForget: Promise<unknown>[] = [];
 
 vi.mock('react-native-reanimated', () => ({}));
@@ -175,7 +179,7 @@ installSessionShellCommonModuleMocks({
     },
     storage: async (importOriginal) => {
         const { createStorageModuleMock } = await import('@/dev/testkit/mocks/storage');
-        const session: any = {
+        sessionState.current = {
             id: 's1',
             seq: 0,
             presence: Date.now() - 60_000,
@@ -198,7 +202,7 @@ installSessionShellCommonModuleMocks({
             overrides: {
                 storage: {
                     getState: () => ({
-                        sessions: { s1: session },
+                        sessions: { s1: sessionState.current },
                         machines: {
                             'm-target': {
                                 id: 'm-target',
@@ -224,7 +228,7 @@ installSessionShellCommonModuleMocks({
                         sessionListViewDataByServerId: {},
                     }),
                 } as any,
-                useSession: () => session,
+                useSession: () => sessionState.current,
                 useIsDataReady: () => true,
                 useRealtimeStatus: () => 'connected',
                 useSessionMessages: () => ({ messages: [], isLoaded: true }),
@@ -335,7 +339,7 @@ vi.mock('@/sync/sync', () => ({
         onSessionVisible: () => {},
         sendMessage: async () => {},
         enqueuePendingMessage: (...args: any[]) => enqueuePendingMessageSpy(...args),
-        submitMessage: async () => {},
+        submitMessage: (...args: any[]) => submitMessageSpy(...args),
         encryption: {
             getMachineEncryption: () => null,
         },
@@ -431,7 +435,25 @@ describe('SessionView (sendMessage resumeInactive pendingQueue)', () => {
     beforeEach(() => {
         (globalThis as { __DEV__?: boolean }).__DEV__ = false;
         authCredentials = { token: 't', secret: 's' };
+        sessionState.current = {
+            id: 's1',
+            seq: 0,
+            presence: Date.now() - 60_000,
+            active: false,
+            accessLevel: 'edit',
+            pendingVersion: 2,
+            metadata: {
+                machineId: 'm-stale',
+                flavor: 'codex',
+                version: '0.0.0',
+                path: '/tmp/target',
+                homeDir: '/tmp',
+                codexSessionId: 'codex-session-1',
+            },
+            agentState: {},
+        };
         enqueuePendingMessageSpy.mockClear();
+        submitMessageSpy.mockClear();
         resumeCapabilityMachineIds.length = 0;
         settingsState.current = { experiments: true, featureToggles: {}, codexBackendMode: 'acp' };
         canResumeSessionWithOptionsSpy.mockReset();
@@ -496,6 +518,54 @@ describe('SessionView (sendMessage resumeInactive pendingQueue)', () => {
         expect(modalMockState.current?.spies.alert).not.toHaveBeenCalled();
         expect(findAgentInput(screen).props.value).toBe('');
         expect(screen.findByTestId('session-pendingQueue-resumeFailed')).toBeTruthy();
+
+        await screen.unmount();
+    });
+
+    it('wakes the daemon after submitting a message in an active session', async () => {
+        sessionState.current = {
+            ...sessionState.current,
+            presence: 'online',
+            active: true,
+        };
+
+        const screen = await renderSessionView();
+
+        pendingFireAndForget.length = 0;
+
+        const agentInput = findAgentInput(screen);
+
+        await act(async () => {
+            agentInput.props.onChangeText('please continue');
+        });
+        await act(async () => {
+            agentInput.props.onSend();
+        });
+
+        expect(pendingFireAndForget.length).toBeGreaterThan(0);
+        await act(async () => {
+            await pendingFireAndForget[0];
+        });
+
+        // Submit happens immediately; wake runs best-effort after submit.
+        expect(submitMessageSpy).toHaveBeenCalledTimes(1);
+        expect(submitMessageSpy.mock.calls[0]?.[0]).toBe('s1');
+        expect(submitMessageSpy.mock.calls[0]?.[1]).toBe('please continue');
+
+        // Wake is fire-and-forget, so it can arrive as a second promise.
+        expect(pendingFireAndForget.length).toBeGreaterThanOrEqual(2);
+        await act(async () => {
+            await pendingFireAndForget[1];
+        });
+
+        expect(resumeSessionSpy).toHaveBeenCalledTimes(1);
+        expect(resumeSessionSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                machineId: 'm-target',
+                directory: '/tmp/target',
+            }),
+        );
+        expect(modalMockState.current?.spies.alert).not.toHaveBeenCalled();
 
         await screen.unmount();
     });

--- a/apps/ui/sources/components/sessions/shell/SessionView.tsx
+++ b/apps/ui/sources/components/sessions/shell/SessionView.tsx
@@ -1743,16 +1743,44 @@ function SessionViewLoaded({
                                 return;
                             }
 
-                            try {
-                                await sync.submitMessage(sessionId, outbound.text, outbound.displayText, outbound.metaOverrides);
-                                if (shouldSendReviewComments) {
-                                    storage.getState().clearSessionReviewCommentDrafts(sessionId);
-                                }
-                            } catch (e) {
-                                setMessage(previousMessage);
-                                Modal.alert(t('common.error'), e instanceof Error ? e.message : t('errors.failedToSendMessage'));
-                            }
-                        })(), { tag: 'SessionView.sendMessage.submitMessage' });
+	                            try {
+	                                await sync.submitMessage(sessionId, outbound.text, outbound.displayText, outbound.metaOverrides);
+	                                if (shouldSendReviewComments) {
+	                                    storage.getState().clearSessionReviewCommentDrafts(sessionId);
+	                                }
+
+	                                const wakeOpts = getPendingQueueWakeResumeOptions({
+	                                    sessionId,
+	                                    session,
+	                                    resumeCapabilityOptions,
+	                                    resumeTargetOverride: reachableMachineTarget
+	                                        ? {
+	                                            machineId: reachableMachineTarget.machineId,
+	                                            directory: reachableMachineTarget.basePath,
+	                                        }
+	                                        : null,
+	                                    permissionOverride: getPermissionModeOverrideForSpawn(session),
+	                                });
+	                                if (wakeOpts) {
+	                                    fireAndForget((async () => {
+	                                        try {
+	                                            const result = await resumeSession({
+	                                                ...wakeOpts,
+	                                                serverId: capabilityServerId,
+	                                            });
+	                                            if (result.type === 'error') {
+	                                                // Non-fatal: message is already persisted in the transcript.
+	                                            }
+	                                        } catch {
+	                                            // Non-fatal: message is already persisted in the transcript.
+	                                        }
+	                                    })(), { tag: 'SessionView.sendMessage.wakeActive' });
+	                                }
+	                            } catch (e) {
+	                                setMessage(previousMessage);
+	                                Modal.alert(t('common.error'), e instanceof Error ? e.message : t('errors.failedToSendMessage'));
+	                            }
+	                        })(), { tag: 'SessionView.sendMessage.submitMessage' });
                     };
 
                     const promptInvocationsV1 = storage.getState().settings.promptInvocationsV1;


### PR DESCRIPTION
- UI: After a direct message submit in an active session, do a best-effort wake (resume) so sessions recover if the runner died mid-session.
- CLI: resolveNodeBackedMcpServerCommand now fails closed instead of returning a non-existent packaged entrypoint; prevents Claude Code from crashing later with MODULE_NOT_FOUND when the Happier MCP bridge path is missing.
- CLI: fix missing readFile import in executeWorkspaceReplicationJobWithLocalRuntime test.

Repro evidence:
- Claude Code debug logs showed MCP server "happier" failing to start due to missing package-dist bridge, leading to Claude Code exiting code 1 and sessions appearing to stall.

Tests:
- apps/ui: SessionView.sendMessage.resumeInactive.pendingQueue.test.tsx
- apps/cli: resolveNodeBackedMcpServerCommand.test.ts, createHappierMcpBridge.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue where command resolution would proceed with invalid entrypoints instead of properly reporting the error.

* **New Features**
  * Active sessions now automatically attempt to resume the pending queue after successfully submitting a message.

* **Tests**
  * Enhanced test coverage for entrypoint validation edge cases and session message sending workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->