### PR TITLE
fix(cli-claude): resolve npm global claude install via process.execPath

### DIFF
--- a/apps/cli/src/backends/claude/sdk/utils.test.ts
+++ b/apps/cli/src/backends/claude/sdk/utils.test.ts
@@ -21,6 +21,7 @@ const envKeys = [
 ] as const;
 const TEMP_DIRS = new Set<string>();
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+const originalExecPathDescriptor = Object.getOwnPropertyDescriptor(process, 'execPath');
 let envScope = createEnvKeyScope(envKeys);
 
 function createTempRoot(prefix: string): string {
@@ -45,9 +46,22 @@ function createWindowsCommand(params: { dir: string; name: string; stdout: strin
   });
 }
 
+// Stub process.execPath to an empty sandbox directory so findClaudeInNpmGlobalModules()
+// cannot accidentally resolve to the host's real npm global install while tests run.
+function stubExecPathToEmptySandbox(workDir: string): void {
+  const sandboxNodeDir = join(workDir, 'sandbox-node');
+  mkdirSync(sandboxNodeDir, { recursive: true });
+  const sandboxNode = join(sandboxNodeDir, process.platform === 'win32' ? 'node.exe' : 'node');
+  writeTextFileSync(sandboxNode, '');
+  Object.defineProperty(process, 'execPath', { value: sandboxNode, configurable: true });
+}
+
 afterEach(() => {
   if (originalPlatformDescriptor) {
     Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+  }
+  if (originalExecPathDescriptor) {
+    Object.defineProperty(process, 'execPath', originalExecPathDescriptor);
   }
   envScope.restore();
   envScope = createEnvKeyScope(envKeys);
@@ -66,6 +80,8 @@ describe('Claude SDK utils - getDefaultClaudeCodePath', () => {
     binDir = join(workDir, 'bin');
     mkdirSync(homeDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
+
+    stubExecPathToEmptySandbox(workDir);
 
     process.env.HOME = homeDir;
     process.env.USERPROFILE = homeDir;
@@ -214,6 +230,8 @@ describe('Claude SDK utils - getDefaultClaudeCodePathForAgentSdk', () => {
     mkdirSync(homeDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
 
+    stubExecPathToEmptySandbox(workDir);
+
     process.env.HOME = homeDir;
     process.env.USERPROFILE = homeDir;
     process.env.PATH = binDir;
@@ -350,5 +368,55 @@ describe('Claude SDK utils - getDefaultClaudeCodePathForAgentSdk', () => {
     } finally {
       process.chdir(originalCwd);
     }
+  });
+
+  it('resolves the npm global cli.js entrypoint from process.execPath on Unix when PATH is empty', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    process.env.PATH = join(workDir, 'empty-path-npm-global-unix');
+    mkdirSync(process.env.PATH, { recursive: true });
+
+    // Simulate an npm global layout: <prefix>/bin/node and <prefix>/lib/node_modules/...
+    const prefixDir = join(workDir, 'npm-prefix');
+    const nodeBinDir = join(prefixDir, 'bin');
+    mkdirSync(nodeBinDir, { recursive: true });
+    const fakeNode = createUnixExecutable({
+      dir: nodeBinDir,
+      name: 'node',
+      body: 'exit 0',
+    });
+
+    const globalCliDir = join(prefixDir, 'lib', 'node_modules', '@anthropic-ai', 'claude-code');
+    mkdirSync(globalCliDir, { recursive: true });
+    const globalCliJs = join(globalCliDir, 'cli.js');
+    writeTextFileSync(globalCliJs, 'console.log("claude");\n');
+
+    Object.defineProperty(process, 'execPath', { value: fakeNode, configurable: true });
+
+    expect(getDefaultClaudeCodePathForAgentSdk()).toBe(globalCliJs);
+  });
+
+  it('resolves the npm global cli.js entrypoint from process.execPath on Windows when PATH is empty', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    process.env.PATH = join(workDir, 'empty-path-npm-global-win');
+    mkdirSync(process.env.PATH, { recursive: true });
+
+    // Simulate the Windows npm layout: <execDir>/node.exe + <execDir>/node_modules/...
+    const nodeDir = join(workDir, 'nodejs');
+    mkdirSync(nodeDir, { recursive: true });
+    const fakeNode = join(nodeDir, 'node.exe');
+    writeTextFileSync(fakeNode, 'MZ');
+
+    const globalCliDir = join(nodeDir, 'node_modules', '@anthropic-ai', 'claude-code');
+    mkdirSync(globalCliDir, { recursive: true });
+    const globalCliJs = join(globalCliDir, 'cli.js');
+    writeTextFileSync(globalCliJs, 'console.log("claude");\n');
+
+    Object.defineProperty(process, 'execPath', { value: fakeNode, configurable: true });
+
+    expect(getDefaultClaudeCodePathForAgentSdk()).toBe(globalCliJs);
   });
 });

--- a/apps/cli/src/backends/claude/sdk/utils.ts
+++ b/apps/cli/src/backends/claude/sdk/utils.ts
@@ -184,7 +184,10 @@ function findClaudeInNpmGlobalModules(): string | null {
     const execDir = dirname(process.execPath)
     const claudePkgRelative = join('node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
 
-    // Windows npm installs packages next to node.exe; Unix npm installs under ../lib/.
+    // Windows npm installs packages next to node.exe (`<execDir>/node_modules/...`).
+    // Unix npm installs one level up under `<prefix>/lib/node_modules/...`.
+    // The Windows candidate is checked first on all platforms; on Unix it is simply
+    // a no-op because that path layout does not exist there.
     const candidates = [
         join(execDir, claudePkgRelative),
         join(dirname(execDir), 'lib', claudePkgRelative),
@@ -328,11 +331,6 @@ export function getDefaultClaudeCodePathForAgentSdk(): string {
         }
     }
 
-    const npmGlobalPath = findClaudeInNpmGlobalModules();
-    if (npmGlobalPath && isAgentSdkCompatibleClaudeEntrypoint(npmGlobalPath)) {
-        return canonicalizeClaudeEntrypointPath(npmGlobalPath);
-    }
-
     const homeDir = resolveHomeDir();
     if (process.platform !== 'win32') {
         const versionsDir = join(homeDir, '.local', 'share', 'claude', 'versions');
@@ -340,6 +338,17 @@ export function getDefaultClaudeCodePathForAgentSdk(): string {
         if (versioned && isAgentSdkCompatibleClaudeEntrypoint(versioned)) {
             return canonicalizeClaudeEntrypointPath(versioned);
         }
+    }
+
+    // Placed after the Unix versioned-install probe so that a user with both a
+    // newer `~/.local/share/claude/versions/` install and an older npm-global
+    // install still gets the versioned one. Intentionally NOT canonicalized —
+    // we want to preserve the symlink/junction target (e.g. nvm-windows
+    // `C:\Program Files\nodejs`) so that Claude auto-updates and nvm version
+    // switches can retarget the same path without pinning to an old version.
+    const npmGlobalPath = findClaudeInNpmGlobalModules();
+    if (npmGlobalPath && isAgentSdkCompatibleClaudeEntrypoint(npmGlobalPath)) {
+        return npmGlobalPath;
     }
 
     const nativeInstallPath = findClaudeInNativeInstallerLocations(homeDir);

--- a/apps/cli/src/backends/claude/sdk/utils.ts
+++ b/apps/cli/src/backends/claude/sdk/utils.ts
@@ -3,7 +3,7 @@
  * Provides helper functions for path resolution and logging
  */
 
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { closeSync, existsSync, openSync, readdirSync, readSync, realpathSync, statSync } from 'node:fs'
 import { getProviderCliInstallGuideUrl, getProviderCliManualInstallSummaryLines } from '@happier-dev/agents'
 import { resolveProviderCliCommand } from '@happier-dev/cli-common/providers'
@@ -172,6 +172,30 @@ function findLatestVersionedClaudeEntrypointForAgentSdk(versionsDir: string): st
     }
 }
 
+/**
+ * Derive the npm global `cli.js` entrypoint from `process.execPath`.
+ *
+ * Intentionally independent of PATH: daemons / spawned CLI processes often inherit
+ * a minimal PATH that no longer contains the directory where `node` itself lives
+ * (Windows + nvm-windows where `C:\Program Files\nodejs` is a junction, or detached
+ * Linux daemons whose PATH is reset by systemd/launchd).
+ */
+function findClaudeInNpmGlobalModules(): string | null {
+    const execDir = dirname(process.execPath)
+    const claudePkgRelative = join('node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
+
+    // Windows npm installs packages next to node.exe; Unix npm installs under ../lib/.
+    const candidates = [
+        join(execDir, claudePkgRelative),
+        join(dirname(execDir), 'lib', claudePkgRelative),
+    ]
+
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) return candidate
+    }
+    return null
+}
+
 function findClaudeInNativeInstallerLocations(homeDir: string): string | null {
     if (process.platform === 'win32') {
         const localAppData = process.env.LOCALAPPDATA || join(homeDir, 'AppData', 'Local')
@@ -302,6 +326,11 @@ export function getDefaultClaudeCodePathForAgentSdk(): string {
         if (isAgentSdkCompatibleClaudeEntrypoint(resolved.command)) {
             return resolved.command;
         }
+    }
+
+    const npmGlobalPath = findClaudeInNpmGlobalModules();
+    if (npmGlobalPath && isAgentSdkCompatibleClaudeEntrypoint(npmGlobalPath)) {
+        return canonicalizeClaudeEntrypointPath(npmGlobalPath);
     }
 
     const homeDir = resolveHomeDir();


### PR DESCRIPTION
## Summary

- The Agent SDK's Claude Code path resolver currently depends on `PATH` to find `claude` when it is installed via npm global. Daemons / spawned CLI processes frequently inherit a minimal PATH that does not contain the directory where `node` itself lives, and the fallback paths (`~/.local/bin`, native installer locations) don't cover npm global installs either.
- This shows up as a confusing `Claude Code is not installed (or not detectable)` error in the app when `claude` works fine from an interactive shell.
- Two common setups that trip this:
  - **Windows + nvm-windows**: `C:\Program Files\nodejs` is a junction managed by nvm and can be missing from a detached daemon child's PATH.
  - **Linux daemons with reset PATH**: Same problem class previously addressed for systemd in #42, but that fix only captures PATH at `happier daemon install` time and doesn't help CLIs spawned outside that flow.
- Adds a new resolution step that derives the npm global `@anthropic-ai/claude-code/cli.js` entrypoint from `process.execPath`, which always points to the active Node.js binary regardless of PATH state.

## Details

- New `findClaudeInNpmGlobalModules()` helper in `apps/cli/src/backends/claude/sdk/utils.ts`. It checks both the Windows layout (`<execDir>/node_modules/...`) and the Unix layout (`<execDir>/../lib/node_modules/...`).
- Wired into `getDefaultClaudeCodePathForAgentSdk()` as a new fallback step between the existing `resolveProviderCliCommand` attempt and the versioned install dir / native installer location checks. Ordering ensures the existing happy paths (PATH-resolved `claude`, explicit `HAPPIER_CLAUDE_PATH` override) are preserved and unchanged.
- No caching is introduced — matches the existing behavior of `getDefaultClaudeCodePathForAgentSdk()`, which is called once per remote Claude session spawn.

## Test plan

- [x] Unit tests for both platform layouts added in `apps/cli/src/backends/claude/sdk/utils.test.ts`, stubbing `process.execPath` to a sandbox directory.
- [x] Existing test suite isolated from the host's real npm global install via a new `stubExecPathToEmptySandbox()` helper in both `describe` blocks, so the "no Claude Code installed" assertions no longer accidentally find a real `cli.js` on the test runner.
- [x] `vitest run src/backends/claude/sdk/utils.test.ts` — 15/15 passing.
- [x] Manual reproduction on Windows + nvm-windows: `process.execPath` points at `C:\Program Files\nodejs\node.exe`, which resolves to the real `C:\Program Files\nodejs\node_modules\@anthropic-ai\claude-code\cli.js`.

## Related

- #42 — similar problem class (daemon PATH stripping) addressed for Linux systemd. This change complements it by handling the resolver side directly so no install-time PATH capture is needed, and covers Windows + nvm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI can now detect Claude installations installed via npm global modules, improving installation detection across environments.

* **Tests**
  * Added tests covering Claude path resolution for npm-global installations on both Windows and non-Windows platforms, including sandboxed execPath scenarios to ensure reliable discovery and restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->