### PR TITLE
Add `happier-dev` bin to package.json

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,6 +4,7 @@
   "description": "Mobile and Web client for Claude Code and Codex",
   "bin": {
     "happier": "./bin/happier.mjs",
+    "happier-dev": "./bin/happier-dev.mjs",
     "happier-mcp": "./bin/happier-mcp.mjs"
   },
   "author": "Leeroy Brun <leeroy.brun@gmail.com>",


### PR DESCRIPTION
Fixes #161 

I didn't use AI to write this.

## Checklist

- [x] PR targets `dev` (not `main`)
- [x] I linked an issue/discussion (recommended for non-trivial changes)
- [x] I added/updated tests where feasible (or explained why not)
- [x] I updated docs if behavior changed
- [x] If AI-assisted, I disclosed it and listed what I personally verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `happier-dev` CLI command, providing an additional entry point alongside existing development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->