### PR TITLE
android: Tweak keyboard size

### DIFF
--- a/apps/ui/sources/dev/testkit/index.ts
+++ b/apps/ui/sources/dev/testkit/index.ts
@@ -20,6 +20,7 @@ export * from './hooks/renderHook';
 export * from './mocks/icons';
 export * from './mocks/flashList';
 export * from './mocks/modal';
+export * from './mocks/nativeEnvironment';
 export * from './mocks/reactNative';
 export * from './mocks/router';
 export * from './mocks/storage';

--- a/apps/ui/sources/dev/testkit/mocks/nativeEnvironment.ts
+++ b/apps/ui/sources/dev/testkit/mocks/nativeEnvironment.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+export type TestKeyboardState = Readonly<{
+    isVisible: boolean;
+    height: number;
+}>;
+
+export type TestSafeAreaInsets = Readonly<{
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+}>;
+
+export type TestNativeEnvironmentState = Readonly<{
+    keyboard: TestKeyboardState;
+    safeArea: TestSafeAreaInsets;
+}>;
+
+export function createKeyboardControllerMock(state: TestNativeEnvironmentState) {
+    return {
+        KeyboardAvoidingView: ({ children }: React.PropsWithChildren) => React.createElement(React.Fragment, null, children),
+        KeyboardProvider: ({ children }: React.PropsWithChildren) => React.createElement(React.Fragment, null, children),
+        useKeyboardState: () => state.keyboard,
+    };
+}
+
+export function createSafeAreaContextMock(state: TestNativeEnvironmentState) {
+    return {
+        SafeAreaProvider: ({ children }: React.PropsWithChildren) => React.createElement(React.Fragment, null, children),
+        initialWindowMetrics: null,
+        useSafeAreaInsets: () => state.safeArea,
+    };
+}

--- a/apps/ui/sources/hooks/ui/useKeyboardHeight.native.test.ts
+++ b/apps/ui/sources/hooks/ui/useKeyboardHeight.native.test.ts
@@ -29,13 +29,15 @@ vi.mock('react-native', async () => {
     });
 });
 
-vi.mock('react-native-keyboard-controller', () => ({
-    useKeyboardState: () => nativeState.keyboard,
-}));
+vi.mock('react-native-keyboard-controller', async () => {
+    const { createKeyboardControllerMock } = await import('@/dev/testkit/mocks/nativeEnvironment');
+    return createKeyboardControllerMock(nativeState);
+});
 
-vi.mock('react-native-safe-area-context', () => ({
-    useSafeAreaInsets: () => nativeState.safeArea,
-}));
+vi.mock('react-native-safe-area-context', async () => {
+    const { createSafeAreaContextMock } = await import('@/dev/testkit/mocks/nativeEnvironment');
+    return createSafeAreaContextMock(nativeState);
+});
 
 describe('useKeyboardHeight native', () => {
     beforeEach(() => {

--- a/apps/ui/sources/hooks/ui/useKeyboardHeight.native.test.ts
+++ b/apps/ui/sources/hooks/ui/useKeyboardHeight.native.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { renderHook, standardCleanup } from '@/dev/testkit';
+
+const nativeState = vi.hoisted(() => ({
+    platformOS: 'ios' as 'ios' | 'android',
+    keyboard: {
+        isVisible: true,
+        height: 300,
+    },
+    safeArea: {
+        top: 0,
+        right: 0,
+        bottom: 34,
+        left: 0,
+    },
+}));
+
+vi.mock('react-native', async () => {
+    const { createReactNativeWebMock } = await import('@/dev/testkit/mocks/reactNative');
+    return createReactNativeWebMock({
+        Platform: {
+            get OS() {
+                return nativeState.platformOS;
+            },
+            select: <T,>(options: { ios?: T; android?: T; native?: T; default?: T }) =>
+                options[nativeState.platformOS] ?? options.native ?? options.default,
+        },
+    });
+});
+
+vi.mock('react-native-keyboard-controller', () => ({
+    useKeyboardState: () => nativeState.keyboard,
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => nativeState.safeArea,
+}));
+
+describe('useKeyboardHeight native', () => {
+    beforeEach(() => {
+        standardCleanup();
+        nativeState.platformOS = 'ios';
+        nativeState.keyboard.isVisible = true;
+        nativeState.keyboard.height = 300;
+        nativeState.safeArea.bottom = 34;
+    });
+
+    it('returns 0 while the keyboard is hidden', async () => {
+        nativeState.keyboard.isVisible = false;
+
+        const { useKeyboardHeight } = await import('./useKeyboardHeight.native');
+        const hook = await renderHook(() => useKeyboardHeight());
+
+        expect(hook.getCurrent()).toBe(0);
+    });
+
+    it('subtracts the bottom safe area from iOS keyboard height', async () => {
+        nativeState.platformOS = 'ios';
+
+        const { useKeyboardHeight } = await import('./useKeyboardHeight.native');
+        const hook = await renderHook(() => useKeyboardHeight());
+
+        expect(hook.getCurrent()).toBe(266);
+    });
+
+    it('does not subtract the bottom safe area from Android keyboard height', async () => {
+        nativeState.platformOS = 'android';
+
+        const { useKeyboardHeight } = await import('./useKeyboardHeight.native');
+        const hook = await renderHook(() => useKeyboardHeight());
+
+        expect(hook.getCurrent()).toBe(300);
+    });
+});

--- a/apps/ui/sources/hooks/ui/useKeyboardHeight.native.ts
+++ b/apps/ui/sources/hooks/ui/useKeyboardHeight.native.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { useKeyboardState } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -7,8 +8,9 @@ export function useKeyboardHeight(): number {
 
     if (!keyboard.isVisible) return 0;
 
-    // `react-native-keyboard-controller`'s `height` includes the bottom inset on iOS.
-    // Subtract it so callers can treat this as "additional occupied height".
-    return Math.max(0, keyboard.height - safeArea.bottom);
+    // On iOS, `react-native-keyboard-controller`'s `height` includes the bottom safe area inset.
+    // On Android (edge-to-edge mode), it does not — subtracting it would under-report the height.
+    const deduction = Platform.OS === 'ios' ? safeArea.bottom : 0;
+    return Math.max(0, keyboard.height - deduction);
 }
 


### PR DESCRIPTION
## Summary
This is a follow up to  #89 , as the text input wasn't visible when opening up the keyboard.

<!-- What does this PR change? 1–3 sentences. -->

## Why

It does a specific check on iOS to determine the deduction amount for the keyboard height.
<!-- What problem does this solve? Link an issue/discussion if relevant. -->

## How to test

Build locally, and run on Android. Make sure opening up the keyboard on the session screen, you can see the text input.


## Checklist

- [x] PR targets `dev` (not `main`)
- [x] I linked an issue/discussion (recommended for non-trivial changes)
- [x] I added/updated tests where feasible (or explained why not)
- [x] I updated docs if behavior changed
- [x] If AI-assisted, I disclosed it and listed what I personally verified -- I used Claude Sonnet for consulting on this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected keyboard height calculation to apply iOS safe-area subtraction only on iOS, improving keyboard layout across platforms.
* **Tests**
  * Added native-platform tests for hidden keyboard, iOS inset subtraction, and Android raw-height behaviors.
* **Chores**
  * Added reusable native-environment test mocks and exported them via the testkit for easier native testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/happier-dev/happier/pull/164)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->