### PR TITLE
fix(mcp): preserve bridged input schemas

### DIFF
--- a/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts
+++ b/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts
@@ -6,15 +6,110 @@ import { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { describe, expect, it } from 'vitest';
-import { z } from 'zod';
 
 import { resolveNodeBackedMcpServerCommand } from '@/mcp/runtime/resolveNodeBackedMcpServerCommand';
+
+const rememberInputSchema: ListToolsResult['tools'][number]['inputSchema'] = {
+  type: 'object',
+  description: 'Remember input',
+  properties: {
+    content: { type: 'string', description: 'Content to remember', minLength: 3 },
+    context: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    tags: { anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }] },
+    metadata: {
+      type: 'object',
+      allOf: [
+        {
+          type: 'object',
+          properties: { source: { type: 'string' } },
+          required: ['source'],
+        },
+      ],
+      additionalProperties: false,
+    },
+  },
+  required: ['content'],
+  additionalProperties: true,
+};
+
+const remoteTools: ListToolsResult['tools'] = [
+  {
+    name: 'echo',
+    description: 'Echo',
+    inputSchema: {
+      type: 'object',
+      properties: { text: { type: 'string' } },
+      required: ['text'],
+      additionalProperties: true,
+    },
+  },
+  {
+    name: 'remember',
+    description: 'Remember',
+    inputSchema: rememberInputSchema,
+  },
+];
+
+function createRemoteTestMcpServer(name: string): Server {
+  const server = new Server({ name, version: '1.0.0' }, { capabilities: { tools: {} } });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: remoteTools }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const args = request.params.arguments ?? {};
+    if (request.params.name === 'echo') {
+      return { content: [{ type: 'text' as const, text: String(args.text ?? '') }], isError: false as const };
+    }
+    if (request.params.name === 'remember') {
+      return { content: [{ type: 'text' as const, text: String(args.content ?? '') }], isError: false as const };
+    }
+    return { content: [{ type: 'text' as const, text: `Unknown tool: ${request.params.name}` }], isError: true as const };
+  });
+
+  return server;
+}
+
+function expectRememberSchemaPreserved(inputSchema: unknown): void {
+  expect(inputSchema).toMatchObject({
+    type: 'object',
+    description: 'Remember input',
+    required: ['content'],
+    additionalProperties: true,
+    properties: {
+      content: { type: 'string', description: 'Content to remember', minLength: 3 },
+      context: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+      tags: { anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }] },
+      metadata: {
+        type: 'object',
+        allOf: [
+          {
+            type: 'object',
+            properties: { source: { type: 'string' } },
+            required: ['source'],
+          },
+        ],
+        additionalProperties: false,
+      },
+    },
+  });
+}
+
+function readFirstTextContent(result: unknown): string {
+  if (!result || typeof result !== 'object' || !('content' in result)) return '';
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) return '';
+  const first = content[0];
+  if (!first || typeof first !== 'object') return '';
+  const text = (first as { text?: unknown }).text;
+  return typeof text === 'string' ? text : '';
+}
 
 function resolveEnvRecord(): Record<string, string> {
   const out: Record<string, string> = {};
@@ -32,40 +127,13 @@ async function resolveRemoteBridgeInvocation(): Promise<{
   return resolveNodeBackedMcpServerCommand({
     distEntrypointSegments: ['mcp', 'bridges', 'remoteMcpStdioBridge.mjs'],
     sourceEntrypointSegments: ['mcp', 'bridges', 'remoteMcpStdioBridge.ts'],
+    preferSourceEntrypoint: true,
   });
 }
 
 async function startTestMcpHttpServer(): Promise<{ url: string; stop: () => void }> {
   const server = createServer(async (req, res) => {
-    const mcp = new McpServer({ name: 'test-mcp', version: '1.0.0' });
-    mcp.registerTool(
-      'echo',
-      {
-        description: 'Echo',
-        inputSchema: z.object({ text: z.string() }).passthrough(),
-      } as any,
-      async (args: any) => ({
-        content: [{ type: 'text' as const, text: String(args?.text ?? '') }],
-        isError: false as const,
-      }),
-    );
-    mcp.registerTool(
-      'remember',
-      {
-        description: 'Remember',
-        inputSchema: z
-          .object({
-            content: z.string(),
-            context: z.union([z.string(), z.null()]).optional(),
-            tags: z.union([z.array(z.string()), z.null()]).optional(),
-          })
-          .passthrough(),
-      } as any,
-      async (args: any) => ({
-        content: [{ type: 'text' as const, text: String(args?.content ?? '') }],
-        isError: false as const,
-      }),
-    );
+    const mcp = createRemoteTestMcpServer('test-mcp');
 
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
@@ -91,39 +159,14 @@ async function startTestMcpHttpServer(): Promise<{ url: string; stop: () => void
 }
 
 async function startTestMcpSseServer(): Promise<{ url: string; stop: () => void }> {
-  const transportsBySessionId = new Map<string, { transport: SSEServerTransport; mcp: McpServer }>();
+  const transportsBySessionId = new Map<string, { transport: SSEServerTransport; mcp: Server }>();
 
   const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://localhost');
     const pathname = url.pathname;
 
     if (req.method === 'GET' && pathname === '/sse') {
-      const mcp = new McpServer({ name: 'test-mcp-sse', version: '1.0.0' });
-      mcp.registerTool(
-        'echo',
-        { description: 'Echo', inputSchema: z.object({ text: z.string() }).passthrough() } as any,
-        async (args: any) => ({
-          content: [{ type: 'text' as const, text: String(args?.text ?? '') }],
-          isError: false as const,
-        }),
-      );
-      mcp.registerTool(
-        'remember',
-        {
-          description: 'Remember',
-          inputSchema: z
-            .object({
-              content: z.string(),
-              context: z.union([z.string(), z.null()]).optional(),
-              tags: z.union([z.array(z.string()), z.null()]).optional(),
-            })
-            .passthrough(),
-        } as any,
-        async (args: any) => ({
-          content: [{ type: 'text' as const, text: String(args?.content ?? '') }],
-          isError: false as const,
-        }),
-      );
+      const mcp = createRemoteTestMcpServer('test-mcp-sse');
 
       const transport = new SSEServerTransport('/message', res);
       transportsBySessionId.set(transport.sessionId, { transport, mcp });
@@ -145,7 +188,7 @@ async function startTestMcpSseServer(): Promise<{ url: string; stop: () => void 
         res.writeHead(404).end('unknown session');
         return;
       }
-      await entry.transport.handlePostMessage(req as any, res);
+      await entry.transport.handlePostMessage(req, res);
       return;
     }
 
@@ -194,25 +237,19 @@ describe('remoteMcpStdioBridge', () => {
       await client.connect(transport);
 
       const tools = await client.listTools();
-      const names = (tools.tools ?? []).map((t: any) => String(t.name));
+      const names = (tools.tools ?? []).map((t) => String(t.name));
       expect(names).toContain('echo');
       expect(names).toContain('remember');
 
-      const rememberTool = (tools.tools ?? []).find((t: any) => t?.name === 'remember');
-      expect(rememberTool?.inputSchema).toMatchObject({
-        type: 'object',
-        required: ['content'],
-        properties: {
-          content: { type: 'string' },
-        },
-      });
+      const rememberTool = (tools.tools ?? []).find((t) => t.name === 'remember');
+      expectRememberSchemaPreserved(rememberTool?.inputSchema);
 
       const res = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
-      const text = String((res as any)?.content?.[0]?.text ?? '');
+      const text = readFirstTextContent(res);
       expect(text).toBe('hi');
 
-      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'] } });
-      const rememberText = String((rememberRes as any)?.content?.[0]?.text ?? '');
+      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'], metadata: { source: 'test' } } });
+      const rememberText = readFirstTextContent(rememberRes);
       expect(rememberText).toBe('store this');
 
       await client.close();
@@ -253,21 +290,15 @@ describe('remoteMcpStdioBridge', () => {
       await client.connect(transport);
 
       const tools = await client.listTools();
-      const rememberTool = (tools.tools ?? []).find((t: any) => t?.name === 'remember');
-      expect(rememberTool?.inputSchema).toMatchObject({
-        type: 'object',
-        required: ['content'],
-        properties: {
-          content: { type: 'string' },
-        },
-      });
+      const rememberTool = (tools.tools ?? []).find((t) => t.name === 'remember');
+      expectRememberSchemaPreserved(rememberTool?.inputSchema);
 
       const res = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
-      const text = String((res as any)?.content?.[0]?.text ?? '');
+      const text = readFirstTextContent(res);
       expect(text).toBe('hi');
 
-      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'] } });
-      const rememberText = String((rememberRes as any)?.content?.[0]?.text ?? '');
+      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'], metadata: { source: 'test' } } });
+      const rememberText = readFirstTextContent(rememberRes);
       expect(rememberText).toBe('store this');
 
       await client.close();

--- a/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts
+++ b/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts
@@ -49,6 +49,23 @@ async function startTestMcpHttpServer(): Promise<{ url: string; stop: () => void
         isError: false as const,
       }),
     );
+    mcp.registerTool(
+      'remember',
+      {
+        description: 'Remember',
+        inputSchema: z
+          .object({
+            content: z.string(),
+            context: z.union([z.string(), z.null()]).optional(),
+            tags: z.union([z.array(z.string()), z.null()]).optional(),
+          })
+          .passthrough(),
+      } as any,
+      async (args: any) => ({
+        content: [{ type: 'text' as const, text: String(args?.content ?? '') }],
+        isError: false as const,
+      }),
+    );
 
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
@@ -87,6 +104,23 @@ async function startTestMcpSseServer(): Promise<{ url: string; stop: () => void 
         { description: 'Echo', inputSchema: z.object({ text: z.string() }).passthrough() } as any,
         async (args: any) => ({
           content: [{ type: 'text' as const, text: String(args?.text ?? '') }],
+          isError: false as const,
+        }),
+      );
+      mcp.registerTool(
+        'remember',
+        {
+          description: 'Remember',
+          inputSchema: z
+            .object({
+              content: z.string(),
+              context: z.union([z.string(), z.null()]).optional(),
+              tags: z.union([z.array(z.string()), z.null()]).optional(),
+            })
+            .passthrough(),
+        } as any,
+        async (args: any) => ({
+          content: [{ type: 'text' as const, text: String(args?.content ?? '') }],
           isError: false as const,
         }),
       );
@@ -162,10 +196,24 @@ describe('remoteMcpStdioBridge', () => {
       const tools = await client.listTools();
       const names = (tools.tools ?? []).map((t: any) => String(t.name));
       expect(names).toContain('echo');
+      expect(names).toContain('remember');
+
+      const rememberTool = (tools.tools ?? []).find((t: any) => t?.name === 'remember');
+      expect(rememberTool?.inputSchema).toMatchObject({
+        type: 'object',
+        required: ['content'],
+        properties: {
+          content: { type: 'string' },
+        },
+      });
 
       const res = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
       const text = String((res as any)?.content?.[0]?.text ?? '');
       expect(text).toBe('hi');
+
+      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'] } });
+      const rememberText = String((rememberRes as any)?.content?.[0]?.text ?? '');
+      expect(rememberText).toBe('store this');
 
       await client.close();
     } finally {
@@ -204,9 +252,23 @@ describe('remoteMcpStdioBridge', () => {
       const client = new Client({ name: 'bridge-test-sse', version: '1.0.0' }, { capabilities: {} });
       await client.connect(transport);
 
+      const tools = await client.listTools();
+      const rememberTool = (tools.tools ?? []).find((t: any) => t?.name === 'remember');
+      expect(rememberTool?.inputSchema).toMatchObject({
+        type: 'object',
+        required: ['content'],
+        properties: {
+          content: { type: 'string' },
+        },
+      });
+
       const res = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
       const text = String((res as any)?.content?.[0]?.text ?? '');
       expect(text).toBe('hi');
+
+      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'] } });
+      const rememberText = String((rememberRes as any)?.content?.[0]?.text ?? '');
+      expect(rememberText).toBe('store this');
 
       await client.close();
     } finally {

--- a/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts
+++ b/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts
@@ -26,13 +26,8 @@ const rememberInputSchema: ListToolsResult['tools'][number]['inputSchema'] = {
     tags: { anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }] },
     metadata: {
       type: 'object',
-      allOf: [
-        {
-          type: 'object',
-          properties: { source: { type: 'string' } },
-          required: ['source'],
-        },
-      ],
+      properties: { source: { type: 'string' } },
+      required: ['source'],
       additionalProperties: false,
     },
   },
@@ -88,13 +83,8 @@ function expectRememberSchemaPreserved(inputSchema: unknown): void {
       tags: { anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }] },
       metadata: {
         type: 'object',
-        allOf: [
-          {
-            type: 'object',
-            properties: { source: { type: 'string' } },
-            required: ['source'],
-          },
-        ],
+        properties: { source: { type: 'string' } },
+        required: ['source'],
         additionalProperties: false,
       },
     },
@@ -209,6 +199,7 @@ describe('remoteMcpStdioBridge', () => {
   it('proxies listTools/callTool over streamable http via stdio', async () => {
     const httpServer = await startTestMcpHttpServer();
     const tmp = await mkdtemp(join(tmpdir(), 'happier-mcp-bridge-it-'));
+    let client: Client | null = null;
     try {
       const configPath = join(tmp, 'happier-mcp-remote-bridge.it.json');
       await writeFile(
@@ -233,7 +224,7 @@ describe('remoteMcpStdioBridge', () => {
         },
       });
 
-      const client = new Client({ name: 'bridge-test', version: '1.0.0' }, { capabilities: {} });
+      client = new Client({ name: 'bridge-test', version: '1.0.0' }, { capabilities: {} });
       await client.connect(transport);
 
       const tools = await client.listTools();
@@ -252,8 +243,8 @@ describe('remoteMcpStdioBridge', () => {
       const rememberText = readFirstTextContent(rememberRes);
       expect(rememberText).toBe('store this');
 
-      await client.close();
     } finally {
+      await client?.close().catch(() => {});
       httpServer.stop();
       await rm(tmp, { recursive: true, force: true });
     }
@@ -262,6 +253,7 @@ describe('remoteMcpStdioBridge', () => {
   it('supports SSE transport via stdio bridge', async () => {
     const sseServer = await startTestMcpSseServer();
     const tmp = await mkdtemp(join(tmpdir(), 'happier-mcp-bridge-it-'));
+    let client: Client | null = null;
     try {
       const configPath = join(tmp, 'bridge.json');
       await writeFile(
@@ -286,7 +278,7 @@ describe('remoteMcpStdioBridge', () => {
         },
       });
 
-      const client = new Client({ name: 'bridge-test-sse', version: '1.0.0' }, { capabilities: {} });
+      client = new Client({ name: 'bridge-test-sse', version: '1.0.0' }, { capabilities: {} });
       await client.connect(transport);
 
       const tools = await client.listTools();
@@ -301,8 +293,8 @@ describe('remoteMcpStdioBridge', () => {
       const rememberText = readFirstTextContent(rememberRes);
       expect(rememberText).toBe('store this');
 
-      await client.close();
     } finally {
+      await client?.close().catch(() => {});
       sseServer.stop();
       await rm(tmp, { recursive: true, force: true });
     }

--- a/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts
+++ b/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts
@@ -57,13 +57,25 @@ function createRemoteTestMcpServer(name: string): Server {
   const server = new Server({ name, version: '1.0.0' }, { capabilities: { tools: {} } });
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: remoteTools }));
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const args = request.params.arguments ?? {};
     if (request.params.name === 'echo') {
       return { content: [{ type: 'text' as const, text: String(args.text ?? '') }], isError: false as const };
     }
     if (request.params.name === 'remember') {
-      return { content: [{ type: 'text' as const, text: String(args.content ?? '') }], isError: false as const };
+      const progressToken = request.params._meta?.progressToken;
+      if (typeof progressToken === 'string' || typeof progressToken === 'number') {
+        await extra.sendNotification({
+          method: 'notifications/progress',
+          params: {
+            progressToken,
+            progress: 1,
+            total: 2,
+            message: String(request.params._meta?.requestTrace ?? 'missing-trace'),
+          },
+        });
+      }
+      return { content: [{ type: 'text' as const, text: `${String(args.content ?? '')}:${String(request.params._meta?.requestTrace ?? '')}` }], isError: false as const };
     }
     return { content: [{ type: 'text' as const, text: `Unknown tool: ${request.params.name}` }], isError: true as const };
   });
@@ -239,9 +251,20 @@ describe('remoteMcpStdioBridge', () => {
       const text = readFirstTextContent(res);
       expect(text).toBe('hi');
 
-      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'], metadata: { source: 'test' } } });
+      const progressEvents: Array<{ progress: number; total?: number; message?: string }> = [];
+      const rememberRes = await client.callTool(
+        { name: 'remember', arguments: { content: 'store this', tags: ['workflow'], metadata: { source: 'test' } }, _meta: { requestTrace: 'trace-http' } },
+        undefined,
+        { onprogress: (progress) => progressEvents.push(progress) },
+      );
       const rememberText = readFirstTextContent(rememberRes);
-      expect(rememberText).toBe('store this');
+      expect(rememberText).toBe('store this:trace-http');
+      expect(progressEvents).toEqual([{ progress: 1, total: 2, message: 'trace-http' }]);
+
+      const closeStartedAt = Date.now();
+      await client.close();
+      client = null;
+      expect(Date.now() - closeStartedAt).toBeLessThan(1_500);
 
     } finally {
       await client?.close().catch(() => {});
@@ -289,9 +312,9 @@ describe('remoteMcpStdioBridge', () => {
       const text = readFirstTextContent(res);
       expect(text).toBe('hi');
 
-      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'], metadata: { source: 'test' } } });
+      const rememberRes = await client.callTool({ name: 'remember', arguments: { content: 'store this', tags: ['workflow'], metadata: { source: 'test' } }, _meta: { requestTrace: 'trace-sse' } });
       const rememberText = readFirstTextContent(rememberRes);
-      expect(rememberText).toBe('store this');
+      expect(rememberText).toBe('store this:trace-sse');
 
     } finally {
       await client?.close().catch(() => {});

--- a/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.ts
+++ b/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.ts
@@ -12,11 +12,12 @@
 
 import { readFile, unlink } from 'node:fs/promises';
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 import { callMcpToolWithResolvedTimeout } from '@/mcp/mcpToolCallRequestOptions';
@@ -38,87 +39,6 @@ function writeStderr(line: string): void {
   } catch {
     // ignore
   }
-}
-
-function parseArgsValue(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-  return value as Record<string, unknown>;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-function jsonSchemaToZod(schema: unknown): z.ZodTypeAny {
-  const record = asRecord(schema);
-  if (!record) return z.any();
-
-  const anyOf = Array.isArray(record.anyOf) ? record.anyOf.map((entry) => jsonSchemaToZod(entry)) : null;
-  if (anyOf && anyOf.length > 0) {
-    const [first, ...rest] = anyOf;
-    return rest.reduce<z.ZodTypeAny>((current, entry) => z.union([current, entry]), first);
-  }
-
-  const oneOf = Array.isArray(record.oneOf) ? record.oneOf.map((entry) => jsonSchemaToZod(entry)) : null;
-  if (oneOf && oneOf.length > 0) {
-    const [first, ...rest] = oneOf;
-    return rest.reduce<z.ZodTypeAny>((current, entry) => z.union([current, entry]), first);
-  }
-
-  if (Array.isArray(record.enum) && record.enum.length > 0) {
-    const literals = record.enum.map((entry) => z.literal(entry));
-    const [first, ...rest] = literals;
-    return rest.reduce<z.ZodTypeAny>((current, entry) => z.union([current, entry]), first);
-  }
-
-  const typeValue = record.type;
-  if (Array.isArray(typeValue) && typeValue.length > 0) {
-    const entries = typeValue.map((entry) => jsonSchemaToZod({ ...record, type: entry }));
-    const [first, ...rest] = entries;
-    return rest.reduce<z.ZodTypeAny>((current, entry) => z.union([current, entry]), first);
-  }
-
-  switch (typeValue) {
-    case 'string':
-      return z.string();
-    case 'number':
-      return z.number();
-    case 'integer':
-      return z.number().int();
-    case 'boolean':
-      return z.boolean();
-    case 'null':
-      return z.null();
-    case 'array': {
-      return z.array(jsonSchemaToZod(record.items));
-    }
-    case 'object': {
-      const properties = asRecord(record.properties) ?? {};
-      const required = new Set(Array.isArray(record.required) ? record.required.filter((entry): entry is string => typeof entry === 'string') : []);
-      const shape: Record<string, z.ZodTypeAny> = {};
-      for (const [key, value] of Object.entries(properties)) {
-        const propertySchema = jsonSchemaToZod(value);
-        shape[key] = required.has(key) ? propertySchema : propertySchema.optional();
-      }
-
-      let objectSchema = z.object(shape);
-      if (record.additionalProperties === false) return objectSchema.strict();
-
-      const additionalProperties = asRecord(record.additionalProperties);
-      if (additionalProperties) return objectSchema.catchall(jsonSchemaToZod(additionalProperties));
-
-      return objectSchema.passthrough();
-    }
-    default:
-      return z.any();
-  }
-}
-
-function getRegisteredInputSchema(tool: unknown): z.ZodTypeAny {
-  const record = asRecord(tool);
-  if (!record) return z.any();
-  return jsonSchemaToZod(record.inputSchema);
 }
 
 async function connectRemoteClient(config: RemoteBridgeConfig): Promise<Client> {
@@ -163,32 +83,18 @@ async function main(): Promise<void> {
 
   const remoteClient = await connectRemoteClient(config);
 
-  const toolList = await remoteClient.listTools();
-  const tools = Array.isArray((toolList as any)?.tools) ? ((toolList as any).tools as any[]) : [];
+  const server = new Server(
+    { name: 'Happier MCP Remote Bridge', version: '1.0.0' },
+    { capabilities: { tools: { listChanged: true } } },
+  );
 
-  const server = new McpServer({ name: 'Happier MCP Remote Bridge', version: '1.0.0' });
+  server.setRequestHandler(ListToolsRequestSchema, async (request) => await remoteClient.listTools(request.params));
 
-  for (const tool of tools) {
-    const name = typeof tool?.name === 'string' ? tool.name : '';
-    if (!name) continue;
-
-    server.registerTool(
-      name,
-      {
-        description: typeof tool?.description === 'string' ? tool.description : undefined,
-        title: typeof tool?.title === 'string' ? tool.title : undefined,
-        // Preserve the remote JSON schema so downstream clients can see required
-        // arguments. If the remote tool omits a usable schema, fall back to
-        // permissive validation and let the remote server enforce its own rules.
-        inputSchema: getRegisteredInputSchema(tool),
-        _meta: tool?.inputSchema ? { remoteInputSchema: tool.inputSchema } : undefined,
-      } as any,
-      (async (argsOrExtra: unknown, extra?: unknown) => {
-        const toolArgs = parseArgsValue(argsOrExtra) ?? parseArgsValue(extra);
-        return await callMcpToolWithResolvedTimeout({ client: remoteClient, toolName: name, args: toolArgs });
-      }) as any,
-    );
-  }
+  server.setRequestHandler(CallToolRequestSchema, async (request) => await callMcpToolWithResolvedTimeout({
+    client: remoteClient,
+    toolName: request.params.name,
+    args: request.params.arguments,
+  }));
 
   const stdio = new StdioServerTransport();
   await server.connect(stdio);

--- a/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.ts
+++ b/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.ts
@@ -85,7 +85,7 @@ async function main(): Promise<void> {
 
   const server = new Server(
     { name: 'Happier MCP Remote Bridge', version: '1.0.0' },
-    { capabilities: { tools: { listChanged: true } } },
+    { capabilities: { tools: {} } },
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async (request) => await remoteClient.listTools(request.params));

--- a/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.ts
+++ b/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.ts
@@ -45,6 +45,82 @@ function parseArgsValue(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function jsonSchemaToZod(schema: unknown): z.ZodTypeAny {
+  const record = asRecord(schema);
+  if (!record) return z.any();
+
+  const anyOf = Array.isArray(record.anyOf) ? record.anyOf.map((entry) => jsonSchemaToZod(entry)) : null;
+  if (anyOf && anyOf.length > 0) {
+    const [first, ...rest] = anyOf;
+    return rest.reduce<z.ZodTypeAny>((current, entry) => z.union([current, entry]), first);
+  }
+
+  const oneOf = Array.isArray(record.oneOf) ? record.oneOf.map((entry) => jsonSchemaToZod(entry)) : null;
+  if (oneOf && oneOf.length > 0) {
+    const [first, ...rest] = oneOf;
+    return rest.reduce<z.ZodTypeAny>((current, entry) => z.union([current, entry]), first);
+  }
+
+  if (Array.isArray(record.enum) && record.enum.length > 0) {
+    const literals = record.enum.map((entry) => z.literal(entry));
+    const [first, ...rest] = literals;
+    return rest.reduce<z.ZodTypeAny>((current, entry) => z.union([current, entry]), first);
+  }
+
+  const typeValue = record.type;
+  if (Array.isArray(typeValue) && typeValue.length > 0) {
+    const entries = typeValue.map((entry) => jsonSchemaToZod({ ...record, type: entry }));
+    const [first, ...rest] = entries;
+    return rest.reduce<z.ZodTypeAny>((current, entry) => z.union([current, entry]), first);
+  }
+
+  switch (typeValue) {
+    case 'string':
+      return z.string();
+    case 'number':
+      return z.number();
+    case 'integer':
+      return z.number().int();
+    case 'boolean':
+      return z.boolean();
+    case 'null':
+      return z.null();
+    case 'array': {
+      return z.array(jsonSchemaToZod(record.items));
+    }
+    case 'object': {
+      const properties = asRecord(record.properties) ?? {};
+      const required = new Set(Array.isArray(record.required) ? record.required.filter((entry): entry is string => typeof entry === 'string') : []);
+      const shape: Record<string, z.ZodTypeAny> = {};
+      for (const [key, value] of Object.entries(properties)) {
+        const propertySchema = jsonSchemaToZod(value);
+        shape[key] = required.has(key) ? propertySchema : propertySchema.optional();
+      }
+
+      let objectSchema = z.object(shape);
+      if (record.additionalProperties === false) return objectSchema.strict();
+
+      const additionalProperties = asRecord(record.additionalProperties);
+      if (additionalProperties) return objectSchema.catchall(jsonSchemaToZod(additionalProperties));
+
+      return objectSchema.passthrough();
+    }
+    default:
+      return z.any();
+  }
+}
+
+function getRegisteredInputSchema(tool: unknown): z.ZodTypeAny {
+  const record = asRecord(tool);
+  if (!record) return z.any();
+  return jsonSchemaToZod(record.inputSchema);
+}
+
 async function connectRemoteClient(config: RemoteBridgeConfig): Promise<Client> {
   const client = new Client({ name: 'happier-remote-bridge', version: '1.0.0' }, { capabilities: {} });
 
@@ -101,9 +177,10 @@ async function main(): Promise<void> {
       {
         description: typeof tool?.description === 'string' ? tool.description : undefined,
         title: typeof tool?.title === 'string' ? tool.title : undefined,
-        // The SDK expects a Zod schema for input validation. Remote `listTools` returns JSON schema.
-        // Prefer permissive validation here and let the remote server enforce its own schema.
-        inputSchema: z.any(),
+        // Preserve the remote JSON schema so downstream clients can see required
+        // arguments. If the remote tool omits a usable schema, fall back to
+        // permissive validation and let the remote server enforce its own rules.
+        inputSchema: getRegisteredInputSchema(tool),
         _meta: tool?.inputSchema ? { remoteInputSchema: tool.inputSchema } : undefined,
       } as any,
       (async (argsOrExtra: unknown, extra?: unknown) => {

--- a/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.ts
+++ b/apps/cli/src/mcp/bridges/remoteMcpStdioBridge.ts
@@ -90,14 +90,50 @@ async function main(): Promise<void> {
 
   server.setRequestHandler(ListToolsRequestSchema, async (request) => await remoteClient.listTools(request.params));
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => await callMcpToolWithResolvedTimeout({
-    client: remoteClient,
-    toolName: request.params.name,
-    args: request.params.arguments,
-  }));
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    const progressToken = request.params._meta?.progressToken;
+    const onprogress = typeof progressToken === 'string' || typeof progressToken === 'number'
+      ? (progress: Readonly<{ progress: number; total?: number; message?: string }>) => {
+        void extra.sendNotification({
+          method: 'notifications/progress',
+          params: {
+            ...progress,
+            progressToken,
+          },
+        }).catch((err) => {
+          writeStderr(`[happier-mcp-remote-bridge] Failed to forward progress: ${err instanceof Error ? err.message : String(err)}`);
+        });
+      }
+      : undefined;
+
+    return await callMcpToolWithResolvedTimeout({
+      client: remoteClient,
+      toolName: request.params.name,
+      args: request.params.arguments,
+      requestMetadata: request.params._meta,
+      onprogress,
+    });
+  });
+
+  let didCloseRemoteClient = false;
+  const closeRemoteClientOnce = async (): Promise<void> => {
+    if (didCloseRemoteClient) return;
+    didCloseRemoteClient = true;
+    await remoteClient.close().catch(() => {});
+  };
 
   const stdio = new StdioServerTransport();
   await server.connect(stdio);
+  const previousOnClose = stdio.onclose;
+  stdio.onclose = () => {
+    previousOnClose?.();
+    void closeRemoteClientOnce();
+  };
+  process.stdin.once('end', () => {
+    void server.close().catch((err) => {
+      writeStderr(`[happier-mcp-remote-bridge] Failed to close stdio server: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  });
 }
 
 main().catch((err) => {

--- a/apps/cli/src/mcp/mcpToolCallRequestOptions.test.ts
+++ b/apps/cli/src/mcp/mcpToolCallRequestOptions.test.ts
@@ -92,4 +92,31 @@ describe('callMcpToolWithResolvedTimeout', () => {
       { timeout: 165_000 },
     );
   });
+
+  it('preserves request metadata and progress callbacks when calling the MCP client', async () => {
+    const callTool = vi.fn().mockResolvedValue({ content: [] });
+    const client = { callTool } as unknown as Pick<Client, 'callTool'>;
+    const onprogress = vi.fn();
+
+    await callMcpToolWithResolvedTimeout({
+      client,
+      toolName: 'remember',
+      args: { content: 'store this' },
+      requestMetadata: { requestTrace: 'trace-1', progressToken: 'downstream-token' },
+      onprogress,
+    });
+
+    expect(callTool).toHaveBeenCalledWith(
+      {
+        name: 'remember',
+        arguments: { content: 'store this' },
+        _meta: { requestTrace: 'trace-1', progressToken: 'downstream-token' },
+      },
+      undefined,
+      {
+        timeout: DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS,
+        onprogress,
+      },
+    );
+  });
 });

--- a/apps/cli/src/mcp/mcpToolCallRequestOptions.ts
+++ b/apps/cli/src/mcp/mcpToolCallRequestOptions.ts
@@ -1,4 +1,6 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type { RequestMeta } from '@modelcontextprotocol/sdk/types.js';
 
 import { configuration } from '@/configuration';
 
@@ -65,13 +67,22 @@ export async function callMcpToolWithResolvedTimeout(params: Readonly<{
   client: McpCallToolClient;
   toolName: string;
   args: unknown;
+  requestMetadata?: RequestMeta;
+  onprogress?: RequestOptions['onprogress'];
 }>): ReturnType<Client['callTool']> {
   return await params.client.callTool(
-    { name: params.toolName, arguments: normalizeMcpToolArguments(params.args) },
+    {
+      name: params.toolName,
+      arguments: normalizeMcpToolArguments(params.args),
+      ...(params.requestMetadata === undefined ? {} : { _meta: params.requestMetadata }),
+    },
     undefined,
-    resolveMcpToolCallRequestOptions({
-      toolName: params.toolName,
-      args: params.args,
-    }),
+    {
+      ...resolveMcpToolCallRequestOptions({
+        toolName: params.toolName,
+        args: params.args,
+      }),
+      ...(params.onprogress === undefined ? {} : { onprogress: params.onprogress }),
+    },
   );
 }


### PR DESCRIPTION
## Summary
- preserve remote MCP input schema details in the stdio bridge instead of flattening every bridged tool to `z.any()`
- convert remote JSON tool schemas into equivalent Zod schemas so downstream clients still see required arguments like `content`
- add an integration regression that verifies a bridged tool with required and optional nullable fields keeps `required: [\"content\"]` over both HTTP and SSE transports

## Problem
When Happier bridged remote MCP tools through `remoteMcpStdioBridge`, it registered every tool with `inputSchema: z.any()`. Tool calls still worked, but `listTools()` lost required-field information. In practice this broke Hindsight-backed tools in Happier-managed OpenCode sessions because required arguments such as `content` disappeared from the surfaced schema.

## Verification
- ran `yarn --cwd "/Users/primary/code/jr200/happier/apps/cli" build`
- ran `yarn --cwd "/Users/primary/code/jr200/happier/apps/cli" vitest run --config vitest.integration.config.ts src/mcp/bridges/remoteMcpStdioBridge.integration.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "remember" tool to available capabilities (supports progress updates).

* **Improvements**
  * Tool listings now preserve explicit input schemas and forward request metadata and progress callbacks.
  * Bridge/server lifecycle and forwarding are more robust, with cleaner client/server shutdown behavior.

* **Tests**
  * Integration tests extended to verify "remember" appears in listings, its schema is preserved, progress is emitted, and invocation returns expected content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/happier-dev/happier/pull/167)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->