### PR TITLE
[codex] Support Codex title sync and native passthrough

### DIFF
--- a/apps/cli/src/backends/claude/cli/command.help.test.ts
+++ b/apps/cli/src/backends/claude/cli/command.help.test.ts
@@ -90,6 +90,14 @@ function createHelpContext(): CommandContext {
   } satisfies CommandContext;
 }
 
+function createClaudeSubcommandHelpContext(): CommandContext {
+  return {
+    args: ['claude', 'agents', '--help'],
+    rawArgv: [],
+    terminalRuntime: null,
+  } satisfies CommandContext;
+}
+
 describe('happier (default claude) help output', () => {
   it('includes global server selection flags', async () => {
     const root = createTempRoot('happier-claude-help-default-');
@@ -118,6 +126,37 @@ describe('happier (default claude) help output', () => {
       expect(execFileSyncSpy).toHaveBeenCalledWith(
         claudePath,
         ['--help'],
+        expect.objectContaining({
+          encoding: 'utf8',
+          windowsHide: true,
+        }),
+      );
+    } finally {
+      output.restore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('forwards Claude subcommand context when displaying combined help', async () => {
+    const root = createTempRoot('happier-claude-subcommand-help-');
+    const claudePath = createExecutable(
+      root,
+      process.platform === 'win32' ? 'claude.cmd' : 'claude',
+      process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n',
+    );
+    process.env.HAPPIER_CLAUDE_PATH = claudePath;
+
+    const exitSpy = createExitSpy();
+    const output = captureConsoleLogAndMuteStdout();
+
+    try {
+      await expect(handleClaudeCliCommand(createClaudeSubcommandHelpContext())).rejects.toThrow('exit:0');
+
+      expect(output.logs.join('\n')).toContain('Claude Code Options');
+      expect(output.logs.join('\n')).toContain('claude agents --help');
+      expect(execFileSyncSpy).toHaveBeenCalledWith(
+        claudePath,
+        ['agents', '--help'],
         expect.objectContaining({
           encoding: 'utf8',
           windowsHide: true,

--- a/apps/cli/src/backends/claude/cli/command.help.test.ts
+++ b/apps/cli/src/backends/claude/cli/command.help.test.ts
@@ -8,7 +8,7 @@ import { createEnvKeyScope } from '@/testkit/env/envScope';
 import { writeExecutableShimSync } from '@/testkit/fs/executableShim';
 import { writeTextFileSync } from '@/testkit/fs/fileHelpers';
 import { createTempDirSync, removeTempDirSync } from '@/testkit/fs/tempDir';
-import { captureConsoleLogAndMuteStdout } from '@/testkit/logger/captureOutput';
+import { captureConsoleLogAndMuteStdout, captureConsoleText } from '@/testkit/logger/captureOutput';
 
 const { execFileSyncSpy, runtimeState } = vi.hoisted(() => ({
   execFileSyncSpy: vi.fn(() => 'claude help output'),
@@ -338,6 +338,25 @@ describe('happier (default claude) help output', () => {
 
       expect(execFileSyncSpy).not.toHaveBeenCalled();
       expect(output.logs.join('\n')).toContain('HAPPIER_CLAUDE_PATH');
+    } finally {
+      output.restore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('treats an option after --js-runtime as a missing runtime value', async () => {
+    const exitSpy = createExitSpy();
+    const output = captureConsoleText();
+
+    try {
+      await expect(handleClaudeCliCommand({
+        args: ['claude', '--js-runtime', '--permission-mode', 'default'],
+        rawArgv: [],
+        terminalRuntime: null,
+      })).rejects.toThrow('exit:1');
+
+      expect(output.text()).toContain('Missing value for --js-runtime');
+      expect(execFileSyncSpy).not.toHaveBeenCalled();
     } finally {
       output.restore();
       exitSpy.mockRestore();

--- a/apps/cli/src/backends/claude/cli/command.ts
+++ b/apps/cli/src/backends/claude/cli/command.ts
@@ -26,7 +26,6 @@ import { isBun } from '@/utils/runtime';
 import { fetchSessionById } from '@/session/transport/http/sessionsHttp';
 import { handleResumeCommand } from '@/cli/commands/resume';
 import { partitionProviderSessionArgs } from '@/cli/providerSessionArgPartition';
-import packageJson from '../../../../package.json';
 
 import type { CommandContext } from '@/cli/commandRegistry';
 
@@ -163,6 +162,8 @@ export async function handleClaudeCliCommand(context: CommandContext): Promise<v
   }
 
   if (showHelp) {
+    const providerHelpArgs = [...parsed.providerArgs, '--help'];
+    const providerHelpCommand = `claude ${providerHelpArgs.join(' ')}`;
     console.log(`${buildRootHelpText()}
 ${chalk.bold('Happier supports ALL Claude options!')}
   Use any claude flag with happier as you would with claude. Our favorite:
@@ -170,13 +171,13 @@ ${chalk.bold('Happier supports ALL Claude options!')}
   happier --resume
 
 ${chalk.gray('─'.repeat(60))}
-${chalk.bold.cyan('Claude Code Options (from `claude --help`):')}
+${chalk.bold.cyan(`Claude Code Options (from \`${providerHelpCommand}\`):`)}
 `);
 
     // Run claude --help and display its output
     try {
       const { execFileSync } = await import('node:child_process');
-      const helpInvocation = await resolveClaudeHelpInvocation();
+      const helpInvocation = await resolveClaudeCliInfoInvocation(providerHelpArgs);
       const claudeHelp = execFileSync(
         helpInvocation.command,
         helpInvocation.args,
@@ -204,14 +205,32 @@ ${chalk.bold.cyan('Claude Code Options (from `claude --help`):')}
   }
 
   if (showVersion) {
-    console.log(`happier version: ${packageJson.version}`);
-    const versionOnlyInvocation =
-      strippedArgs.length > 0 &&
-      strippedArgs.every((arg) => arg === '-v' || arg === '--version');
-    if (versionOnlyInvocation) {
-      return;
+    try {
+      const { execFileSync } = await import('node:child_process');
+      const versionInvocation = await resolveClaudeCliInfoInvocation([parsed.versionFlag ?? '--version']);
+      const claudeVersion = execFileSync(
+        versionInvocation.command,
+        versionInvocation.args,
+        {
+          encoding: 'utf8',
+          windowsHide: true,
+          ...(versionInvocation.env ? { env: versionInvocation.env } : {}),
+          ...(versionInvocation.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+          ...(configuration.vendorCliHelpTimeoutMs > 0 ? { timeout: configuration.vendorCliHelpTimeoutMs } : {}),
+        },
+      );
+      console.log(claudeVersion.trimEnd());
+    } catch (error) {
+      if (error instanceof ReferenceError) {
+        console.log(chalk.yellow(error.message));
+        if (readProviderCliOverride('claude')) {
+          process.exit(1);
+        }
+      } else {
+        console.log(chalk.yellow('Could not retrieve claude version. Make sure claude is installed.'));
+      }
     }
-    // For mixed invocations, continue and pass --version through to Claude Code.
+    return;
   }
 
   const startedBy = options.startedBy ?? 'terminal';
@@ -299,7 +318,7 @@ ${chalk.bold.cyan('Claude Code Options (from `claude --help`):')}
   }
 }
 
-async function resolveClaudeHelpInvocation(): Promise<{
+async function resolveClaudeCliInfoInvocation(providerArgs: readonly string[]): Promise<{
   command: string;
   args: string[];
   env?: NodeJS.ProcessEnv;
@@ -313,7 +332,7 @@ async function resolveClaudeHelpInvocation(): Promise<{
     });
     const invocation = resolveWindowsCommandInvocation({
       command: runtimeExecutable,
-      args: [launch.resolvedPath, '--help'],
+      args: [launch.resolvedPath, ...providerArgs],
       env: process.env,
     });
     return {
@@ -326,7 +345,7 @@ async function resolveClaudeHelpInvocation(): Promise<{
 
   const invocation = resolveWindowsCommandInvocation({
     command: launch.command,
-    args: [...launch.args, '--help'],
+    args: [...launch.args, ...providerArgs],
     env: process.env,
   });
   return {

--- a/apps/cli/src/backends/claude/cli/command.ts
+++ b/apps/cli/src/backends/claude/cli/command.ts
@@ -1,8 +1,6 @@
 import chalk from 'chalk';
-import { z } from 'zod';
 import { resolveWindowsCommandInvocation } from '@happier-dev/cli-common/process';
 
-import { PERMISSION_MODES, isPermissionMode } from '@/api/types';
 import { runClaude, type StartOptions } from '@/backends/claude/runClaude';
 import { isClaudeCliJavaScriptFile } from '@/backends/claude/utils/resolveClaudeCliPath';
 import { readCredentials, readSettings } from '@/persistence';
@@ -27,6 +25,7 @@ import { readProviderCliOverride } from '@/runtime/managedTools/providerCliResol
 import { isBun } from '@/utils/runtime';
 import { fetchSessionById } from '@/session/transport/http/sessionsHttp';
 import { handleResumeCommand } from '@/cli/commands/resume';
+import { partitionProviderSessionArgs } from '@/cli/providerSessionArgPartition';
 import packageJson from '../../../../package.json';
 
 import type { CommandContext } from '@/cli/commandRegistry';
@@ -71,6 +70,41 @@ export function stripHappyInternalSettingsFlag(
   return stripped;
 }
 
+function extractClaudeWrapperFlags(args: readonly string[]): {
+  argsWithoutWrapperFlags: string[];
+  chromeOverride: boolean | undefined;
+  jsRuntime: StartOptions['jsRuntime'];
+} {
+  const argsWithoutWrapperFlags: string[] = [];
+  let chromeOverride: boolean | undefined;
+  let jsRuntime: StartOptions['jsRuntime'];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--chrome') {
+      chromeOverride = true;
+      continue;
+    }
+    if (arg === '--no-chrome') {
+      chromeOverride = false;
+      continue;
+    }
+    if (arg === '--js-runtime') {
+      const runtime = args[i + 1];
+      if (runtime !== 'node' && runtime !== 'bun') {
+        console.error(chalk.red(`Invalid --js-runtime value: ${runtime}. Must be 'node' or 'bun'`));
+        process.exit(1);
+      }
+      jsRuntime = runtime;
+      i += 1;
+      continue;
+    }
+    argsWithoutWrapperFlags.push(arg);
+  }
+
+  return { argsWithoutWrapperFlags, chromeOverride, jsRuntime };
+}
+
 export async function handleClaudeCliCommand(context: CommandContext): Promise<void> {
   const args = [...context.args];
 
@@ -82,141 +116,40 @@ export async function handleClaudeCliCommand(context: CommandContext): Promise<v
 
   const strippedArgs = stripHappyInternalSettingsFlag(args);
 
-  // Parse command line arguments for main command
-  const options: StartOptions = {};
-  let showHelp = false;
-  let showVersion = false;
-  let refreshSettings = false;
-  let profileQuery: string | null = null;
-  let chromeOverride: boolean | undefined = undefined;
-  const unknownArgs: string[] = []; // Collect unknown args to pass through to claude
+  const claudeWrapperFlags = extractClaudeWrapperFlags(strippedArgs);
+  const parsed = partitionProviderSessionArgs({
+    args: claudeWrapperFlags.argsWithoutWrapperFlags,
+    providerSubcommand: 'claude',
+    forwardModelFlag: true,
+    forwardResumeFlag: true,
+    yoloProviderArgs: ['--dangerously-skip-permissions'],
+  });
 
-  for (let i = 0; i < strippedArgs.length; i++) {
-    const arg = strippedArgs[i];
-
-    if (arg === '-h' || arg === '--help') {
-      showHelp = true;
-      unknownArgs.push(arg);
-    } else if (arg === '-v' || arg === '--version') {
-      showVersion = true;
-      unknownArgs.push(arg);
-    } else if (arg === '--refresh-settings') {
-      refreshSettings = true;
-    } else if (arg === '--profile') {
-      if (i + 1 >= strippedArgs.length) {
-        console.error(chalk.red('Missing value for --profile (expected: profile id or name)'));
-        process.exit(1);
-      }
-      const raw = strippedArgs[++i];
-      const normalized = typeof raw === 'string' ? raw.trim() : '';
-      if (!normalized) {
-        console.error(chalk.red('Invalid --profile value: empty'));
-        process.exit(1);
-      }
-      profileQuery = normalized;
-    } else if (arg.startsWith('--profile=')) {
-      const normalized = arg.slice('--profile='.length).trim();
-      if (!normalized) {
-        console.error(chalk.red('Invalid --profile value: empty'));
-        process.exit(1);
-      }
-      profileQuery = normalized;
-    } else if (arg === '--happy-starting-mode') {
-      options.startingMode = z.enum(['local', 'remote']).parse(strippedArgs[++i]);
-    } else if (arg === '--yolo') {
-      // Shortcut for --dangerously-skip-permissions
-      unknownArgs.push('--dangerously-skip-permissions');
-    } else if (arg === '--started-by') {
-      options.startedBy = strippedArgs[++i] as 'daemon' | 'terminal';
-    } else if (arg === '--permission-mode') {
-      if (i + 1 >= strippedArgs.length) {
-        console.error(chalk.red(`Missing value for --permission-mode. Valid values: ${PERMISSION_MODES.join(', ')}`));
-        process.exit(1);
-      }
-      const value = strippedArgs[++i];
-      if (!isPermissionMode(value)) {
-        console.error(chalk.red(`Invalid --permission-mode value: ${value}. Valid values: ${PERMISSION_MODES.join(', ')}`));
-        process.exit(1);
-      }
-      options.permissionMode = value;
-    } else if (arg.startsWith('--permission-mode=')) {
-      const value = arg.slice('--permission-mode='.length).trim();
-      if (!value) {
-        console.error(chalk.red(`Missing value for --permission-mode. Valid values: ${PERMISSION_MODES.join(', ')}`));
-        process.exit(1);
-      }
-      if (!isPermissionMode(value)) {
-        console.error(chalk.red(`Invalid --permission-mode value: ${value}. Valid values: ${PERMISSION_MODES.join(', ')}`));
-        process.exit(1);
-      }
-      options.permissionMode = value;
-    } else if (arg === '--permission-mode-updated-at') {
-      if (i + 1 >= strippedArgs.length) {
-        console.error(chalk.red('Missing value for --permission-mode-updated-at (expected: unix ms timestamp)'));
-        process.exit(1);
-      }
-      const raw = strippedArgs[++i];
-      const parsedAt = Number(raw);
-      if (!Number.isFinite(parsedAt) || parsedAt <= 0) {
-        console.error(chalk.red(`Invalid --permission-mode-updated-at value: ${raw}. Expected a positive number (unix ms)`));
-        process.exit(1);
-      }
-      options.permissionModeUpdatedAt = Math.floor(parsedAt);
-    } else if (arg === '--model') {
-      if (i + 1 >= strippedArgs.length) {
-        console.error(chalk.red('Missing value for --model (expected: model id)'));
-        process.exit(1);
-      }
-      const raw = strippedArgs[++i];
-      const normalized = typeof raw === 'string' ? raw.trim() : '';
-      if (!normalized) {
-        console.error(chalk.red('Invalid --model value: empty'));
-        process.exit(1);
-      }
-      options.modelId = normalized;
-      unknownArgs.push('--model', normalized);
-    } else if (arg === '--model-updated-at') {
-      if (i + 1 >= strippedArgs.length) {
-        console.error(chalk.red('Missing value for --model-updated-at (expected: unix ms timestamp)'));
-        process.exit(1);
-      }
-      const raw = strippedArgs[++i];
-      const parsedAt = Number(raw);
-      if (!Number.isFinite(parsedAt) || parsedAt <= 0) {
-        console.error(chalk.red(`Invalid --model-updated-at value: ${raw}. Expected a positive number (unix ms)`));
-        process.exit(1);
-      }
-      options.modelUpdatedAt = Math.floor(parsedAt);
-    } else if (arg === '--account-settings-version-hint') {
-      if (i + 1 < strippedArgs.length && !strippedArgs[i + 1]?.startsWith('-')) {
-        i += 1;
-      }
-    } else if (arg === '--js-runtime') {
-      const runtime = strippedArgs[++i];
-      if (runtime !== 'node' && runtime !== 'bun') {
-        console.error(chalk.red(`Invalid --js-runtime value: ${runtime}. Must be 'node' or 'bun'`));
-        process.exit(1);
-      }
-      options.jsRuntime = runtime;
-    } else if (arg === '--existing-session') {
-      // Used by daemon to reconnect to an existing session (for inactive session resume)
-      options.existingSessionId = strippedArgs[++i];
-    } else if (arg === '--chrome') {
-      chromeOverride = true;
-    } else if (arg === '--no-chrome') {
-      chromeOverride = false;
-    } else {
-      unknownArgs.push(arg);
-      // Check if this arg expects a value (simplified check for common patterns)
-      if (i + 1 < strippedArgs.length && !strippedArgs[i + 1].startsWith('-')) {
-        unknownArgs.push(strippedArgs[++i]);
-      }
+  const options: StartOptions = {
+    ...(parsed.permissionMode ? { permissionMode: parsed.permissionMode } : {}),
+    ...(typeof parsed.permissionModeUpdatedAt === 'number' ? { permissionModeUpdatedAt: parsed.permissionModeUpdatedAt } : {}),
+    ...(parsed.modelId ? { modelId: parsed.modelId } : {}),
+    ...(typeof parsed.modelUpdatedAt === 'number' ? { modelUpdatedAt: parsed.modelUpdatedAt } : {}),
+    ...(parsed.startedBy ? { startedBy: parsed.startedBy } : {}),
+    ...(parsed.existingSessionId ? { existingSessionId: parsed.existingSessionId } : {}),
+    ...(claudeWrapperFlags.jsRuntime ? { jsRuntime: claudeWrapperFlags.jsRuntime } : {}),
+  };
+  if (parsed.startingMode) {
+    if (parsed.startingMode !== 'local' && parsed.startingMode !== 'remote') {
+      console.error(chalk.red(`Invalid --happy-starting-mode: ${parsed.startingMode}. Use "local" or "remote".`));
+      process.exit(1);
     }
+    options.startingMode = parsed.startingMode;
+  }
+  if (parsed.providerArgs.length > 0) {
+    options.claudeArgs = [...parsed.providerArgs];
   }
 
-  if (unknownArgs.length > 0) {
-    options.claudeArgs = [...(options.claudeArgs || []), ...unknownArgs];
-  }
+  const showHelp = parsed.helpRequested;
+  const showVersion = parsed.versionRequested;
+  const refreshSettings = parsed.refreshSettings;
+  const profileQuery = parsed.profileQuery ?? null;
+  const chromeOverride = claudeWrapperFlags.chromeOverride;
 
   if (typeof options.modelId === 'string' && options.modelId.trim()) {
     options.model = options.modelId.trim();

--- a/apps/cli/src/backends/claude/cli/command.ts
+++ b/apps/cli/src/backends/claude/cli/command.ts
@@ -90,6 +90,10 @@ function extractClaudeWrapperFlags(args: readonly string[]): {
     }
     if (arg === '--js-runtime') {
       const runtime = args[i + 1];
+      if (typeof runtime !== 'string' || runtime.startsWith('-')) {
+        console.error(chalk.red('Missing value for --js-runtime. Expected: node|bun'));
+        process.exit(1);
+      }
       if (runtime !== 'node' && runtime !== 'bun') {
         console.error(chalk.red(`Invalid --js-runtime value: ${runtime}. Must be 'node' or 'bun'`));
         process.exit(1);

--- a/apps/cli/src/backends/claude/cli/command.version.test.ts
+++ b/apps/cli/src/backends/claude/cli/command.version.test.ts
@@ -1,32 +1,61 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { handleClaudeCliCommand } from './command';
 import * as authModule from '@/ui/auth';
 import * as runClaudeModule from '@/backends/claude/runClaude';
 import * as persistenceModule from '@/persistence';
 import * as accountSettingsModule from '@/settings/accountSettings/bootstrapAccountSettingsContext';
 import * as providerSettingsModule from '@/settings/providerSettings';
 
+const { execFileSyncSpy } = vi.hoisted(() => ({
+  execFileSyncSpy: vi.fn(() => '2.1.138 (Claude Code)\n'),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, execFileSync: execFileSyncSpy };
+});
+
+import { handleClaudeCliCommand } from './command';
+
 afterEach(() => {
   vi.restoreAllMocks();
+  execFileSyncSpy.mockClear();
 });
 
 describe('handleClaudeCliCommand --version', () => {
-  it('does not initialize auth/session for version-only invocation', async () => {
+  it('passes explicit Claude version requests through without auth or session startup', async () => {
+    const previousClaudePath = process.env.HAPPIER_CLAUDE_PATH;
+    process.env.HAPPIER_CLAUDE_PATH = process.execPath;
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const authSpy = vi.spyOn(authModule, 'authAndSetupMachineIfNeeded').mockResolvedValue({ credentials: { token: 'x' } as any } as any);
     const runSpy = vi.spyOn(runClaudeModule, 'runClaude').mockResolvedValue(undefined);
     vi.spyOn(persistenceModule, 'readSettings').mockResolvedValue({} as any);
 
-    await handleClaudeCliCommand({
-      args: ['--version'],
-      terminalRuntime: null,
-      rawArgv: ['happier', '--version'],
-    } as any);
+    try {
+      await handleClaudeCliCommand({
+        args: ['claude', '--version'],
+        terminalRuntime: null,
+        rawArgv: ['happier', 'claude', '--version'],
+      } as any);
 
-    expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/^happier version:/));
-    expect(authSpy).not.toHaveBeenCalled();
-    expect(runSpy).not.toHaveBeenCalled();
+      expect(execFileSyncSpy).toHaveBeenCalledWith(
+        process.execPath,
+        ['--version'],
+        expect.objectContaining({
+          encoding: 'utf8',
+          windowsHide: true,
+        }),
+      );
+      expect(logSpy).toHaveBeenCalledWith('2.1.138 (Claude Code)');
+      expect(authSpy).not.toHaveBeenCalled();
+      expect(runSpy).not.toHaveBeenCalled();
+    } finally {
+      if (previousClaudePath === undefined) {
+        delete process.env.HAPPIER_CLAUDE_PATH;
+      } else {
+        process.env.HAPPIER_CLAUDE_PATH = previousClaudePath;
+      }
+    }
   });
 
   it('fast-starts local terminal invocations without blocking on auth/setup', async () => {

--- a/apps/cli/src/backends/codex/appServer/runtime.test.ts
+++ b/apps/cli/src/backends/codex/appServer/runtime.test.ts
@@ -65,6 +65,14 @@ async function writeFakeCodexAppServerScript(params: Readonly<{
         '        process.stdout.write(JSON.stringify({ id: msg.id, result: { threadId: adoptsOverrideThread ? "thread-overrides" : (msg.params?.threadId ?? null), model: msg.params?.model ?? (adoptsOverrideThread ? "gpt-5.4-mini" : "gpt-5.4"), serviceTier: Object.prototype.hasOwnProperty.call(msg.params ?? {}, "serviceTier") ? msg.params.serviceTier : null } }) + "\\n");',
         '        continue;',
         '    }',
+        '    if (msg.method === "thread/name/set") {',
+        '        if (msg.params?.name === "fail-native-title-sync") {',
+        '            process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32000, message: "native title sync failed" } }) + "\\n");',
+        '            continue;',
+        '        }',
+        '        process.stdout.write(JSON.stringify({ id: msg.id, result: { ok: true } }) + "\\n");',
+        '        continue;',
+        '    }',
         '    if (msg.method === "collaborationMode/list") {',
         '        process.stdout.write(JSON.stringify({ id: msg.id, result: [{ name: "Default", mode: "default", reasoning_effort: null }, { name: "Plan", mode: "plan", reasoning_effort: "medium" }] }) + "\\n");',
         '        continue;',
@@ -183,6 +191,54 @@ async function writeFakeCodexAppServerScript(params: Readonly<{
         '            setTimeout(() => {',
         '                process.stdout.write(JSON.stringify({ id: 0, method: "mcpServer/elicitation/request", params: { threadId: msg.params?.threadId ?? null, turnId: turnId, serverName: "happier", mode: "form", requestedSchema: { type: "object", properties: {} } } }) + "\\n");',
         '            }, 6);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: msg.params?.threadId ?? null, turn: { id: turnId } } }) + "\\n");',
+        '            }, 20);',
+        '            continue;',
+        '        }',
+        '        if (text === "bridge-mcp-title-tool-completed") {',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/started", params: { item: { id: "mcp_title_1", type: "mcpToolCall", server: "happier", tool: "change_title", arguments: { title: "New Title" } } } }) + "\\n");',
+        '            }, 6);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/completed", params: { item: { id: "mcp_title_1", type: "mcpToolCall", result: { Ok: { success: true, title: "New Title" } } } } }) + "\\n");',
+        '            }, 10);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: msg.params?.threadId ?? null, turn: { id: turnId } } }) + "\\n");',
+        '            }, 20);',
+        '            continue;',
+        '        }',
+        '        if (text === "bridge-mcp-title-tool-blank-title") {',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/started", params: { item: { id: "mcp_title_blank", type: "mcpToolCall", server: "happier", tool: "change_title", arguments: { title: "   " } } } }) + "\\n");',
+        '            }, 6);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/completed", params: { item: { id: "mcp_title_blank", type: "mcpToolCall", result: { Ok: { success: true, title: "   " } } } } }) + "\\n");',
+        '            }, 10);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: msg.params?.threadId ?? null, turn: { id: turnId } } }) + "\\n");',
+        '            }, 20);',
+        '            continue;',
+        '        }',
+        '        if (text === "bridge-mcp-title-tool-failed") {',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/started", params: { item: { id: "mcp_title_failed", type: "mcpToolCall", server: "happier", tool: "change_title", arguments: { title: "Failed Title" } } } }) + "\\n");',
+        '            }, 6);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/completed", params: { item: { id: "mcp_title_failed", type: "mcpToolCall", result: { Ok: { success: false, title: "Failed Title" } } } } }) + "\\n");',
+        '            }, 10);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: msg.params?.threadId ?? null, turn: { id: turnId } } }) + "\\n");',
+        '            }, 20);',
+        '            continue;',
+        '        }',
+        '        if (text === "bridge-mcp-title-tool-native-sync-fails") {',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/started", params: { item: { id: "mcp_title_native_fail", type: "mcpToolCall", server: "happier", tool: "change_title", arguments: { title: "fail-native-title-sync" } } } }) + "\\n");',
+        '            }, 6);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/completed", params: { item: { id: "mcp_title_native_fail", type: "mcpToolCall", result: { Ok: { success: true, title: "fail-native-title-sync" } } } } }) + "\\n");',
+        '            }, 10);',
         '            setTimeout(() => {',
         '                process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: msg.params?.threadId ?? null, turn: { id: turnId } } }) + "\\n");',
         '            }, 20);',
@@ -530,6 +586,10 @@ describe('createCodexAppServerRuntime', () => {
             CODEX_API_KEY: undefined,
         });
         return { root, requestLogPath, fakeAppServer };
+    }
+
+    async function readRequestLog(requestLogPath: string): Promise<Array<{ id: unknown; method: string; params: any; result: any; error: any }>> {
+        return (await readFile(requestLogPath, 'utf8')).trim().split('\n').map((line) => JSON.parse(line));
     }
 
     it('allows app-server startup when Codex credentials are missing so the backend can surface auth errors itself', async () => {
@@ -1519,6 +1579,137 @@ describe('createCodexAppServerRuntime', () => {
             'mcp__happier__change_title',
             { title: 'New Title' },
         );
+    });
+
+    it('syncs completed Happier title tool calls to the Codex native thread name', async () => {
+        const { root, requestLogPath } = await createRuntimeFixture('happier-codex-app-server-runtime-native-title-sync-');
+
+        const runtime = createCodexAppServerRuntime({
+            directory: root,
+            onThinkingChange: vi.fn(),
+            session: {
+                updateMetadata: vi.fn(),
+                sendAgentMessageCommitted: vi.fn(async () => {}),
+                sendCodexMessage: vi.fn(),
+            } as any,
+            permissionHandler: { handleToolCall: vi.fn() } as any,
+        } as any);
+
+        try {
+            await runtime.startOrLoad({});
+            await runtime.sendPrompt('bridge-mcp-title-tool-completed');
+
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            const requestLog = await readRequestLog(requestLogPath);
+
+            expect(requestLog).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        method: 'thread/name/set',
+                        params: { threadId: 'thread-started', name: 'New Title' },
+                        error: null,
+                    }),
+                ]),
+            );
+        } finally {
+            await runtime.reset();
+        }
+    });
+
+    it('does not sync blank completed Happier title tool calls to the Codex native thread name', async () => {
+        const { root, requestLogPath } = await createRuntimeFixture('happier-codex-app-server-runtime-native-title-sync-blank-');
+
+        const runtime = createCodexAppServerRuntime({
+            directory: root,
+            onThinkingChange: vi.fn(),
+            session: {
+                updateMetadata: vi.fn(),
+                sendAgentMessageCommitted: vi.fn(async () => {}),
+                sendCodexMessage: vi.fn(),
+            } as any,
+            permissionHandler: { handleToolCall: vi.fn() } as any,
+        } as any);
+
+        try {
+            await runtime.startOrLoad({});
+            await runtime.sendPrompt('bridge-mcp-title-tool-blank-title');
+
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            const requestLog = await readRequestLog(requestLogPath);
+
+            expect(requestLog.filter((entry) => entry.method === 'thread/name/set')).toEqual([]);
+        } finally {
+            await runtime.reset();
+        }
+    });
+
+    it('does not sync failed completed Happier title tool calls to the Codex native thread name', async () => {
+        const { root, requestLogPath } = await createRuntimeFixture('happier-codex-app-server-runtime-native-title-sync-failed-');
+
+        const runtime = createCodexAppServerRuntime({
+            directory: root,
+            onThinkingChange: vi.fn(),
+            session: {
+                updateMetadata: vi.fn(),
+                sendAgentMessageCommitted: vi.fn(async () => {}),
+                sendCodexMessage: vi.fn(),
+            } as any,
+            permissionHandler: { handleToolCall: vi.fn() } as any,
+        } as any);
+
+        try {
+            await runtime.startOrLoad({});
+            await runtime.sendPrompt('bridge-mcp-title-tool-failed');
+
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            const requestLog = await readRequestLog(requestLogPath);
+
+            expect(requestLog.filter((entry) => entry.method === 'thread/name/set')).toEqual([]);
+        } finally {
+            await runtime.reset();
+        }
+    });
+
+    it('keeps completed Happier title tool calls accepted when Codex native title sync fails', async () => {
+        const { root, requestLogPath } = await createRuntimeFixture('happier-codex-app-server-runtime-native-title-sync-fails-');
+        const sendCodexMessage = vi.fn();
+
+        const runtime = createCodexAppServerRuntime({
+            directory: root,
+            onThinkingChange: vi.fn(),
+            session: {
+                updateMetadata: vi.fn(),
+                sendAgentMessageCommitted: vi.fn(async () => {}),
+                sendCodexMessage,
+            } as any,
+            permissionHandler: { handleToolCall: vi.fn() } as any,
+        } as any);
+
+        try {
+            await runtime.startOrLoad({});
+            await runtime.sendPrompt('bridge-mcp-title-tool-native-sync-fails');
+
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            const requestLog = await readRequestLog(requestLogPath);
+
+            expect(requestLog).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        method: 'thread/name/set',
+                        params: { threadId: 'thread-started', name: 'fail-native-title-sync' },
+                    }),
+                ]),
+            );
+            expect(sendCodexMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'tool-call-result',
+                    callId: 'mcp_title_native_fail',
+                    output: { success: true, title: 'fail-native-title-sync' },
+                }),
+            );
+        } finally {
+            await runtime.reset();
+        }
     });
 
     it('bridges MCP elicitation requests that use callId fields through the permission handler', async () => {

--- a/apps/cli/src/backends/codex/appServer/runtime.test.ts
+++ b/apps/cli/src/backends/codex/appServer/runtime.test.ts
@@ -600,7 +600,7 @@ describe('createCodexAppServerRuntime', () => {
         return { root, requestLogPath, fakeAppServer };
     }
 
-    async function readRequestLog(requestLogPath: string): Promise<Array<{ id: unknown; method: string; params: any; result: any; error: any }>> {
+    async function readRequestLog(requestLogPath: string): Promise<Array<{ id: unknown; method: string; params: unknown; result: unknown; error: unknown }>> {
         return (await readFile(requestLogPath, 'utf8')).trim().split('\n').map((line) => JSON.parse(line));
     }
 

--- a/apps/cli/src/backends/codex/appServer/runtime.test.ts
+++ b/apps/cli/src/backends/codex/appServer/runtime.test.ts
@@ -208,6 +208,18 @@ async function writeFakeCodexAppServerScript(params: Readonly<{
         '            }, 20);',
         '            continue;',
         '        }',
+        '        if (text === "bridge-mcp-title-tool-completed-content-envelope") {',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/started", params: { item: { id: "mcp_title_content_1", type: "mcpToolCall", server: "happier", tool: "change_title", arguments: { title: "Content Envelope Title" } } } }) + "\\n");',
+        '            }, 6);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "item/completed", params: { item: { id: "mcp_title_content_1", type: "mcpToolCall", result: { Ok: { content: [{ type: "text", text: "{\\"success\\":true,\\"title\\":\\"Content Envelope Title\\"}" }], isError: false } } } } }) + "\\n");',
+        '            }, 10);',
+        '            setTimeout(() => {',
+        '                process.stdout.write(JSON.stringify({ method: "turn/completed", params: { threadId: msg.params?.threadId ?? null, turn: { id: turnId } } }) + "\\n");',
+        '            }, 20);',
+        '            continue;',
+        '        }',
         '        if (text === "bridge-mcp-title-tool-blank-title") {',
         '            setTimeout(() => {',
         '                process.stdout.write(JSON.stringify({ method: "item/started", params: { item: { id: "mcp_title_blank", type: "mcpToolCall", server: "happier", tool: "change_title", arguments: { title: "   " } } } }) + "\\n");',
@@ -1607,6 +1619,41 @@ describe('createCodexAppServerRuntime', () => {
                     expect.objectContaining({
                         method: 'thread/name/set',
                         params: { threadId: 'thread-started', name: 'New Title' },
+                        error: null,
+                    }),
+                ]),
+            );
+        } finally {
+            await runtime.reset();
+        }
+    });
+
+    it('syncs completed Happier title tool calls returned in MCP content envelopes to the Codex native thread name', async () => {
+        const { root, requestLogPath } = await createRuntimeFixture('happier-codex-app-server-runtime-native-title-sync-content-');
+
+        const runtime = createCodexAppServerRuntime({
+            directory: root,
+            onThinkingChange: vi.fn(),
+            session: {
+                updateMetadata: vi.fn(),
+                sendAgentMessageCommitted: vi.fn(async () => {}),
+                sendCodexMessage: vi.fn(),
+            } as any,
+            permissionHandler: { handleToolCall: vi.fn() } as any,
+        } as any);
+
+        try {
+            await runtime.startOrLoad({});
+            await runtime.sendPrompt('bridge-mcp-title-tool-completed-content-envelope');
+
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            const requestLog = await readRequestLog(requestLogPath);
+
+            expect(requestLog).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        method: 'thread/name/set',
+                        params: { threadId: 'thread-started', name: 'Content Envelope Title' },
                         error: null,
                     }),
                 ]),

--- a/apps/cli/src/backends/codex/appServer/runtime.ts
+++ b/apps/cli/src/backends/codex/appServer/runtime.ts
@@ -159,9 +159,29 @@ function readHappierTitleToolTitle(input: unknown): string | null {
     return record ? trimStringValue(record.title) : null;
 }
 
-function didHappierTitleToolSucceed(output: unknown): boolean {
+function readMcpContentTextPayloads(record: Record<string, unknown>): unknown[] {
+    const content = Array.isArray(record.content) ? record.content : [];
+    const parsed: unknown[] = [];
+    for (const entry of content) {
+        const entryRecord = readRecord(entry);
+        const text = entryRecord ? trimStringValue(entryRecord.text) : null;
+        if (!text) continue;
+        try {
+            parsed.push(JSON.parse(text));
+        } catch {
+            // Ignore non-JSON MCP text payloads.
+        }
+    }
+    return parsed;
+}
+
+function didHappierTitleToolSucceed(output: unknown, depth = 0): boolean {
+    if (depth > 2) return false;
     const record = readRecord(output);
-    return record ? record.success === true : false;
+    if (!record) return false;
+    if (record.success === true || record.ok === true) return true;
+    if (record.isError === true) return false;
+    return readMcpContentTextPayloads(record).some((payload) => didHappierTitleToolSucceed(payload, depth + 1));
 }
 
 function readRollbackUnsupportedErrorMessage(error: unknown): string | null {

--- a/apps/cli/src/backends/codex/appServer/runtime.ts
+++ b/apps/cli/src/backends/codex/appServer/runtime.ts
@@ -14,6 +14,7 @@ import {
     SESSION_MEDIA_MESSAGE_META_KIND_V1,
     type SessionMediaItemV1,
 } from '@happier-dev/protocol';
+import { isChangeTitleToolNameAlias } from '@happier-dev/protocol/tools/v2';
 import { TurnChangeSetCollector } from '@/agent/tools/diff/turnChangeSetCollector';
 import { emitCanonicalTurnDiffTool } from '@/agent/runtime/emitCanonicalTurnDiffTool';
 import { logger } from '@/ui/logger';
@@ -151,6 +152,16 @@ function trimStringValue(value: unknown): string | null {
     if (typeof value !== 'string') return null;
     const trimmed = value.trim();
     return trimmed.length > 0 ? trimmed : null;
+}
+
+function readHappierTitleToolTitle(input: unknown): string | null {
+    const record = readRecord(input);
+    return record ? trimStringValue(record.title) : null;
+}
+
+function didHappierTitleToolSucceed(output: unknown): boolean {
+    const record = readRecord(output);
+    return record ? record.success === true : false;
 }
 
 function readRollbackUnsupportedErrorMessage(error: unknown): string | null {
@@ -392,6 +403,7 @@ export function createCodexAppServerRuntime(params: Readonly<{
     const normalizedAssistantFinalSeenByStreamScope = new Set<string>();
     const rawAssistantFinalByStreamScope = new Map<string, PendingRawAssistantFinal>();
     const persistedMediaDedupeKeys = new Set<string>();
+    const pendingHappierTitleToolNamesByCallId = new Map<string, string>();
     const syntheticSubagentThreadIds = new Set<string>();
     const syntheticSubagentTracker = createCodexSyntheticSubagentTracker({
         session: params.session,
@@ -707,6 +719,12 @@ export function createCodexAppServerRuntime(params: Readonly<{
 
         if (update.type === 'tool-call') {
             await itemTranscriptBridge.flushAll({ reason: 'tool-call-boundary' });
+            if (update.toolKind === 'mcp' && isChangeTitleToolNameAlias(update.name)) {
+                const title = readHappierTitleToolTitle(update.input);
+                if (title) {
+                    pendingHappierTitleToolNamesByCallId.set(update.callId, title);
+                }
+            }
             if (update.toolKind === 'file-change') {
                 const input = update.input && typeof update.input === 'object' && !Array.isArray(update.input)
                     ? update.input as Record<string, unknown>
@@ -742,6 +760,8 @@ export function createCodexAppServerRuntime(params: Readonly<{
         }
 
         if (update.type === 'tool-result') {
+            const completedTitleName = pendingHappierTitleToolNamesByCallId.get(update.callId) ?? null;
+            pendingHappierTitleToolNamesByCallId.delete(update.callId);
             if (context.sidechainId) {
                 params.session.sendAgentMessage('codex', {
                     type: 'tool-result',
@@ -758,6 +778,17 @@ export function createCodexAppServerRuntime(params: Readonly<{
                     id: randomUUID(),
                 });
             }
+            if (completedTitleName && didHappierTitleToolSucceed(update.output) && threadId && !context.sidechainId) {
+                try {
+                    const client = await ensureClient();
+                    await client.request('thread/name/set', { threadId, name: completedTitleName });
+                } catch (error) {
+                    logger.debug('[codex-app-server] Failed to sync Happier title to Codex native thread name', {
+                        threadId,
+                        error,
+                    });
+                }
+            }
         }
     };
 
@@ -767,6 +798,7 @@ export function createCodexAppServerRuntime(params: Readonly<{
         latestAssistantItemIdByStreamScope.clear();
         normalizedAssistantFinalSeenByStreamScope.clear();
         rawAssistantFinalByStreamScope.clear();
+        pendingHappierTitleToolNamesByCallId.clear();
         await itemTranscriptBridge.flushAll({
             reason,
             ...(reason === 'abort' ? { interruptedReason: 'app-server-turn-interrupted' } : {}),

--- a/apps/cli/src/backends/codex/cli/command.test.ts
+++ b/apps/cli/src/backends/codex/cli/command.test.ts
@@ -118,4 +118,22 @@ describe('handleCodexCliCommand', () => {
       codexArgs: ['resume', '--all'],
     }));
   });
+
+  it('passes lowercase -v through as a Codex-native argument', async () => {
+    process.env.HAPPIER_ACCOUNT_SETTINGS_MODE = 'never';
+    const credentials: Credentials = { token: 't', encryption: { type: 'legacy', secret: new Uint8Array(32).fill(1) } };
+    vi.spyOn(persistenceModule, 'readCredentials').mockResolvedValue(null);
+    vi.spyOn(authModule, 'authAndSetupMachineIfNeeded').mockResolvedValue({ credentials } as any);
+    const runSpy = vi.spyOn(runCodexModule, 'runCodex').mockResolvedValue();
+
+    await handleCodexCliCommand({
+      args: ['-v'],
+      terminalRuntime: null,
+    } as any);
+
+    expect(runSpy).toHaveBeenCalledWith(expect.objectContaining({
+      credentials,
+      codexArgs: ['-v'],
+    }));
+  });
 });

--- a/apps/cli/src/backends/codex/cli/command.test.ts
+++ b/apps/cli/src/backends/codex/cli/command.test.ts
@@ -99,4 +99,23 @@ describe('handleCodexCliCommand', () => {
       directory: '/tmp/from-long-flag',
     }));
   });
+
+  it('preserves Codex-native args while consuming Happier session flags', async () => {
+    process.env.HAPPIER_ACCOUNT_SETTINGS_MODE = 'never';
+    const credentials: Credentials = { token: 't', encryption: { type: 'legacy', secret: new Uint8Array(32).fill(1) } };
+    vi.spyOn(persistenceModule, 'readCredentials').mockResolvedValue(null);
+    vi.spyOn(authModule, 'authAndSetupMachineIfNeeded').mockResolvedValue({ credentials } as any);
+    const runSpy = vi.spyOn(runCodexModule, 'runCodex').mockResolvedValue();
+
+    await handleCodexCliCommand({
+      args: ['--permission-mode', 'yolo', 'resume', '--all'],
+      terminalRuntime: null,
+    } as any);
+
+    expect(runSpy).toHaveBeenCalledWith(expect.objectContaining({
+      credentials,
+      permissionMode: 'yolo',
+      codexArgs: ['resume', '--all'],
+    }));
+  });
 });

--- a/apps/cli/src/backends/codex/cli/command.ts
+++ b/apps/cli/src/backends/codex/cli/command.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { readOptionalFlagValue, readOptionalFlagValueFromAliases } from '@/cli/sessionStartArgs';
+import { readOptionalFlagValue } from '@/cli/sessionStartArgs';
 import { runBackendSessionCliCommand } from '@/cli/runBackendSessionCliCommand';
 
 import type { CommandContext } from '@/cli/commandRegistry';
@@ -10,19 +10,18 @@ export async function handleCodexCliCommand(context: CommandContext): Promise<vo
     context,
     loadRun: async () => (await import('@/backends/codex/runCodex')).runCodex,
     agentIdForAccountSettings: 'codex',
-    resolveExtraOptions: (args) => {
+    directoryFlags: ['-C', '--cd'],
+    forwardModelFlag: true,
+    resolveExtraOptions: (args, parsed) => {
       const startingModeRaw = readOptionalFlagValue(args, '--happy-starting-mode');
       const startingMode: 'local' | 'remote' | undefined =
         startingModeRaw === 'local' || startingModeRaw === 'remote' ? startingModeRaw : undefined;
-      const directoryRaw = readOptionalFlagValueFromAliases(args, ['-C', '--cd']);
-      const directory = typeof directoryRaw === 'string' && directoryRaw.trim().length > 0
-        ? directoryRaw.trim()
-        : undefined;
+      const directory = parsed.directory;
       if (startingModeRaw && !startingMode) {
         console.error(chalk.red(`Invalid --happy-starting-mode: ${startingModeRaw}. Use "local" or "remote".`));
         process.exit(1);
       }
-      return { startingMode, directory };
+      return { startingMode, directory, codexArgs: parsed.providerArgs };
     },
   });
 }

--- a/apps/cli/src/backends/codex/cli/command.ts
+++ b/apps/cli/src/backends/codex/cli/command.ts
@@ -12,7 +12,7 @@ export async function handleCodexCliCommand(context: CommandContext): Promise<vo
     agentIdForAccountSettings: 'codex',
     directoryFlags: ['-C', '--cd'],
     forwardModelFlag: true,
-    versionFlags: ['-v', '-V', '--version'],
+    versionFlags: ['-V', '--version'],
     resolveExtraOptions: (args, parsed) => {
       const startingModeRaw = readOptionalFlagValue(args, '--happy-starting-mode');
       const startingMode: 'local' | 'remote' | undefined =

--- a/apps/cli/src/backends/codex/cli/command.ts
+++ b/apps/cli/src/backends/codex/cli/command.ts
@@ -12,6 +12,7 @@ export async function handleCodexCliCommand(context: CommandContext): Promise<vo
     agentIdForAccountSettings: 'codex',
     directoryFlags: ['-C', '--cd'],
     forwardModelFlag: true,
+    versionFlags: ['-v', '-V', '--version'],
     resolveExtraOptions: (args, parsed) => {
       const startingModeRaw = readOptionalFlagValue(args, '--happy-starting-mode');
       const startingMode: 'local' | 'remote' | undefined =

--- a/apps/cli/src/backends/codex/codexLocalLauncher.integration.test.ts
+++ b/apps/cli/src/backends/codex/codexLocalLauncher.integration.test.ts
@@ -407,6 +407,58 @@ describe('codexLocalLauncher', () => {
     }
   });
 
+  it('passes provider-native Codex args after Happier wrapper args', async () => {
+    const fixture = await createCodexBinaryFixture();
+    const argsPath = join(fixture.binDir, 'argv.json');
+    const sessionId = randomUUID();
+    const nowIso = new Date().toISOString();
+
+    await writeFakeCodexScript(fixture.fakeCodex, {
+      terminatedFlag: fixture.terminatedFlag,
+      recordArgv: true,
+    });
+
+    const { session } = createLocalSessionHarness();
+    const messageQueue = createLocalMessageQueue();
+    const restoreEnv = applyCodexLauncherEnv({
+      HAPPIER_CODEX_SESSIONS_DIR: fixture.sessionsRoot,
+      HAPPIER_CODEX_TUI_BIN: fixture.fakeCodex,
+      TEST_CODEX_SESSION_ID: sessionId,
+      TEST_CODEX_TIMESTAMP: nowIso,
+      TEST_CODEX_ARGV_PATH: argsPath,
+    });
+
+    try {
+      const launcherPromise = codexLocalLauncher({
+        path: fixture.sessionsRoot,
+        api: {},
+        session,
+        messageQueue,
+        permissionMode: 'default',
+        resumeId: sessionId,
+        codexArgs: ['resume', '--all'],
+      });
+
+      await waitFor(() => {
+        expect(existsSync(argsPath)).toBe(true);
+      });
+      const argv = JSON.parse(await readFile(argsPath, 'utf8')) as string[];
+      const cdIndex = argv.indexOf('--cd');
+      expect(cdIndex).toBeGreaterThanOrEqual(0);
+      expect(argv.slice(cdIndex, cdIndex + 4)).toEqual(['--cd', fixture.sessionsRoot, 'resume', '--all']);
+      expect(argv).not.toContain(sessionId);
+
+      messageQueue.push('hi', { permissionMode: 'default' });
+      await expect(launcherPromise).resolves.toEqual({ type: 'switch', resumeId: sessionId });
+      await waitFor(() => {
+        expect(existsSync(fixture.terminatedFlag)).toBe(true);
+      });
+    } finally {
+      restoreEnv();
+      await cleanupCodexBinaryFixture(fixture);
+    }
+  });
+
   it('maps read-only permission mode to never approvalPolicy', async () => {
     const fixture = await createCodexBinaryFixture();
     const argsPath = join(fixture.binDir, 'argv.json');

--- a/apps/cli/src/backends/codex/codexLocalLauncher.integration.test.ts
+++ b/apps/cli/src/backends/codex/codexLocalLauncher.integration.test.ts
@@ -776,6 +776,50 @@ describe('codexLocalLauncher', () => {
     }
   });
 
+  it('switches a fresh local session to remote when no rollout exists', async () => {
+    const fixture = await createCodexBinaryFixture();
+
+    await writeFakeCodexScript(fixture.fakeCodex, {
+      terminatedFlag: fixture.terminatedFlag,
+      writeSessionMeta: false,
+      exitAfterMs: 500,
+      recordArgv: false,
+      handleSigint: false,
+    });
+
+    const { session } = createLocalSessionHarness();
+    const messageQueue = createLocalMessageQueue();
+    const restoreEnv = applyCodexLauncherEnv({
+      HAPPIER_CODEX_SESSIONS_DIR: fixture.sessionsRoot,
+      HAPPIER_CODEX_TUI_BIN: fixture.fakeCodex,
+      TEST_CODEX_SESSION_ID: undefined,
+      TEST_CODEX_TIMESTAMP: undefined,
+      TEST_CODEX_ARGV_PATH: undefined,
+    });
+
+    try {
+      const launcherPromise = codexLocalLauncher({
+        path: fixture.sessionsRoot,
+        api: {},
+        session,
+        messageQueue,
+        permissionMode: 'default',
+        rolloutDiscovery: {
+          initialTimeoutMs: 100,
+          initialPollIntervalMs: 25,
+          extendedPollIntervalMs: 25,
+        },
+      });
+
+      messageQueue.push('hi', { permissionMode: 'default' });
+
+      await expect(launcherPromise).resolves.toEqual({ type: 'switch', resumeId: null });
+    } finally {
+      restoreEnv();
+      await cleanupCodexBinaryFixture(fixture);
+    }
+  });
+
   it('returns exit when the Codex TUI process cannot be spawned', async () => {
     const fixture = await createCodexBinaryFixture();
     const { session } = createLocalSessionHarness();

--- a/apps/cli/src/backends/codex/codexLocalLauncher.integration.test.ts
+++ b/apps/cli/src/backends/codex/codexLocalLauncher.integration.test.ts
@@ -872,6 +872,51 @@ describe('codexLocalLauncher', () => {
     }
   });
 
+  it('keeps native Codex arg invocations local when no rollout exists', async () => {
+    const fixture = await createCodexBinaryFixture();
+
+    await writeFakeCodexScript(fixture.fakeCodex, {
+      terminatedFlag: fixture.terminatedFlag,
+      writeSessionMeta: false,
+      exitAfterMs: 120,
+      recordArgv: false,
+      handleSigint: false,
+    });
+
+    const { session } = createLocalSessionHarness();
+    const messageQueue = createLocalMessageQueue();
+    const restoreEnv = applyCodexLauncherEnv({
+      HAPPIER_CODEX_SESSIONS_DIR: fixture.sessionsRoot,
+      HAPPIER_CODEX_TUI_BIN: fixture.fakeCodex,
+      TEST_CODEX_SESSION_ID: undefined,
+      TEST_CODEX_TIMESTAMP: undefined,
+      TEST_CODEX_ARGV_PATH: undefined,
+    });
+
+    try {
+      const launcherPromise = codexLocalLauncher({
+        path: fixture.sessionsRoot,
+        api: {},
+        session,
+        messageQueue,
+        permissionMode: 'default',
+        codexArgs: ['--help'],
+        rolloutDiscovery: {
+          initialTimeoutMs: 50,
+          initialPollIntervalMs: 20,
+          extendedPollIntervalMs: 20,
+        },
+      });
+
+      messageQueue.push('hi', { permissionMode: 'default' });
+
+      await expect(launcherPromise).resolves.toMatchObject({ type: 'exit' });
+    } finally {
+      restoreEnv();
+      await cleanupCodexBinaryFixture(fixture);
+    }
+  });
+
   it('returns exit when the Codex TUI process cannot be spawned', async () => {
     const fixture = await createCodexBinaryFixture();
     const { session } = createLocalSessionHarness();

--- a/apps/cli/src/backends/codex/codexLocalLauncher.testkit.ts
+++ b/apps/cli/src/backends/codex/codexLocalLauncher.testkit.ts
@@ -123,6 +123,7 @@ export async function writeFakeCodexScript(path: string, opts: {
   taskCompleteAfterMs?: number;
   turnAbortedAfterMs?: number;
   turnAbortedReason?: string;
+  writeSessionMeta?: boolean;
 }): Promise<void> {
   const sessionMetaDelayMs = typeof opts.sessionMetaDelayMs === 'number' ? opts.sessionMetaDelayMs : 0;
   const assistantText = typeof opts.assistantText === 'string' ? opts.assistantText : null;
@@ -137,6 +138,7 @@ export async function writeFakeCodexScript(path: string, opts: {
   const taskCompleteAfterMs = typeof opts.taskCompleteAfterMs === 'number' ? opts.taskCompleteAfterMs : null;
   const turnAbortedAfterMs = typeof opts.turnAbortedAfterMs === 'number' ? opts.turnAbortedAfterMs : null;
   const turnAbortedReason = typeof opts.turnAbortedReason === 'string' ? opts.turnAbortedReason : 'interrupted';
+  const writeSessionMetaEnabled = opts.writeSessionMeta !== false;
 
 const script = `#!/usr/bin/env node
 const fs = require('node:fs');
@@ -192,9 +194,9 @@ function writeSessionMeta() {
   ${turnAbortedAfterMs != null ? `setTimeout(() => write(JSON.stringify({ type: 'event_msg', payload: { type: 'turn_aborted', turn_id: id, reason: ${JSON.stringify(turnAbortedReason)} } })), ${turnAbortedAfterMs});` : ''}
 }
 
-if (${sessionMetaDelayMs} > 0) {
+if (${writeSessionMetaEnabled ? 'true' : 'false'} && ${sessionMetaDelayMs} > 0) {
   setTimeout(writeSessionMeta, ${sessionMetaDelayMs});
-} else {
+} else if (${writeSessionMetaEnabled ? 'true' : 'false'}) {
   writeSessionMeta();
 }
 

--- a/apps/cli/src/backends/codex/codexLocalLauncher.ts
+++ b/apps/cli/src/backends/codex/codexLocalLauncher.ts
@@ -27,7 +27,7 @@ import {
 } from '@/agent/localControl/turnLifecycle';
 import { startLocalPendingQueueRemoteSwitchWatcher } from '@/agent/localControl/pendingQueue/startLocalPendingQueueRemoteSwitchWatcher';
 
-export type CodexLauncherResult = { type: 'switch'; resumeId: string } | { type: 'exit'; code: number };
+export type CodexLauncherResult = { type: 'switch'; resumeId: string | null } | { type: 'exit'; code: number };
 
 export type CodexRolloutDiscoveryConfig = Readonly<{
   /**
@@ -182,6 +182,7 @@ export async function codexLocalLauncher<TMode>(opts: {
 
   let exitReason: CodexLauncherResult | null = null;
   let switchRequested = false;
+  let remoteSwitchIntentObserved = false;
   let switchNotified = false;
   let mirror: CodexRolloutMirror | null = null;
   let pendingQueueWatcher: { stop: () => void } | null = null;
@@ -326,19 +327,24 @@ export async function codexLocalLauncher<TMode>(opts: {
     // in an active local turn, the deferred switch controller waits for the
     // rollout terminal event before asking the launcher to stop the child.
     opts.messageQueue.setOnMessage((message, mode) => {
+      remoteSwitchIntentObserved = true;
       deferredRemoteSwitch.onQueuedMessage(message, mode);
     });
 
     pendingQueueWatcher = startLocalPendingQueueRemoteSwitchWatcher({
       peekPendingCount: () => opts.session.peekPendingMessageQueueV2Count(),
       pollIntervalMs: configuration.pendingQueueIdleWakePollIntervalMs,
-      requestRemoteSwitch: () => deferredRemoteSwitch.requestRemoteSwitch('server_pending_queue'),
+      requestRemoteSwitch: () => {
+        remoteSwitchIntentObserved = true;
+        return deferredRemoteSwitch.requestRemoteSwitch('server_pending_queue');
+      },
     });
 
     // Allow the UI to request a switch explicitly.
     opts.session.rpcHandlerManager.registerHandler('switch', async (params: any) => {
       const to = params && typeof params === 'object' ? (params as any).to : undefined;
       if (to === 'local') return true;
+      remoteSwitchIntentObserved = true;
       return await deferredRemoteSwitch.requestRemoteSwitch('rpc_switch');
     });
 
@@ -449,6 +455,27 @@ export async function codexLocalLauncher<TMode>(opts: {
         });
       }
 
+      if (remoteSwitchIntentObserved && !opts.resumeId && now >= deadline) {
+        logger.debug('[codex] switch: starting fresh remote because no local rollout was discovered', {
+          elapsedSinceStartMs: now - startedAtMs,
+        });
+        exitReason = { type: 'switch', resumeId: null };
+        if (child && child.exitCode === null) {
+          childStopRequested = true;
+          if (isWindows) {
+            void killProcessTree(child, { graceMs: 250 }).catch(() => undefined);
+          } else {
+            try {
+              child.kill('SIGTERM');
+            } catch {
+              // ignore
+            }
+          }
+        }
+        childExited = true;
+        break;
+      }
+
       candidateFile = await discoverCodexRolloutFileOnce({
         sessionsRootDir,
         startedAtMs,
@@ -474,6 +501,11 @@ export async function codexLocalLauncher<TMode>(opts: {
     }
 
     if (!candidateFile) {
+      if (exitReason) {
+        await childExitPromise;
+        publishRemoteControlState('switch');
+        return exitReason;
+      }
       logger.debug('[codex] rollout discovery: aborted without candidate', {
         elapsedMs: Date.now() - startedAtMs,
         childExited,

--- a/apps/cli/src/backends/codex/codexLocalLauncher.ts
+++ b/apps/cli/src/backends/codex/codexLocalLauncher.ts
@@ -70,6 +70,7 @@ async function resolveCodexTuiInvocation(opts: {
   cwd: string;
   resumeId?: string | null;
   permissionMode: PermissionMode;
+  codexArgs?: readonly string[];
 }): Promise<{ command: string; args: string[] }> {
   return await resolveCodexCliInvocation({
     args: buildCodexTuiArgs(opts),
@@ -116,13 +117,13 @@ function buildCodexTuiChildEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-function buildCodexTuiArgs(opts: { cwd: string; resumeId?: string | null; permissionMode: PermissionMode }): string[] {
+function buildCodexTuiArgs(opts: {
+  cwd: string;
+  resumeId?: string | null;
+  permissionMode: PermissionMode;
+  codexArgs?: readonly string[];
+}): string[] {
   const args: string[] = [];
-
-  const resumeId = typeof opts.resumeId === 'string' && opts.resumeId.trim().length > 0 ? opts.resumeId.trim() : null;
-  if (resumeId) {
-    args.push('resume', resumeId);
-  }
 
   // Always enforce working directory to match the Happy session path.
   args.push('--cd', opts.cwd);
@@ -135,6 +136,16 @@ function buildCodexTuiArgs(opts: { cwd: string; resumeId?: string | null; permis
     const { approvalPolicy, sandbox } = resolveCodexMcpPolicyForPermissionMode(opts.permissionMode);
     args.push('--ask-for-approval', approvalPolicy);
     args.push('--sandbox', sandbox);
+  }
+
+  if (opts.codexArgs && opts.codexArgs.length > 0) {
+    args.push(...opts.codexArgs);
+    return args;
+  }
+
+  const resumeId = typeof opts.resumeId === 'string' && opts.resumeId.trim().length > 0 ? opts.resumeId.trim() : null;
+  if (resumeId) {
+    args.push('resume', resumeId);
   }
 
   return args;
@@ -152,6 +163,7 @@ export async function codexLocalLauncher<TMode>(opts: {
   messageQueue: MessageQueue2<TMode>;
   permissionMode?: PermissionMode;
   resumeId?: string | null;
+  codexArgs?: readonly string[];
   debugMirroring?: boolean;
   rolloutDiscovery?: Partial<CodexRolloutDiscoveryConfig>;
 }): Promise<CodexLauncherResult> {
@@ -366,6 +378,7 @@ export async function codexLocalLauncher<TMode>(opts: {
       cwd: opts.path,
       resumeId: opts.resumeId,
       permissionMode: opts.permissionMode ?? 'default',
+      codexArgs: opts.codexArgs ?? [],
     });
 
     const invocation = resolveWindowsCommandInvocation({

--- a/apps/cli/src/backends/codex/codexLocalLauncher.ts
+++ b/apps/cli/src/backends/codex/codexLocalLauncher.ts
@@ -195,6 +195,7 @@ export async function codexLocalLauncher<TMode>(opts: {
   let exitReason: CodexLauncherResult | null = null;
   let switchRequested = false;
   let remoteSwitchIntentObserved = false;
+  const hasNativeCodexArgs = (opts.codexArgs?.length ?? 0) > 0;
   let switchNotified = false;
   let mirror: CodexRolloutMirror | null = null;
   let pendingQueueWatcher: { stop: () => void } | null = null;
@@ -482,7 +483,7 @@ export async function codexLocalLauncher<TMode>(opts: {
         });
       }
 
-      if (remoteSwitchIntentObserved && !opts.resumeId && now >= deadline) {
+      if (remoteSwitchIntentObserved && !opts.resumeId && !hasNativeCodexArgs && now >= deadline) {
         logger.debug('[codex] switch: starting fresh remote because no local rollout was discovered', {
           elapsedSinceStartMs: now - startedAtMs,
         });

--- a/apps/cli/src/backends/codex/codexLocalLauncher.ts
+++ b/apps/cli/src/backends/codex/codexLocalLauncher.ts
@@ -191,6 +191,20 @@ export async function codexLocalLauncher<TMode>(opts: {
   const turnLifecycle = createLocalTurnLifecycleController({ completionQuiescenceMs: 0 });
   turnLifecycle.observe({ type: 'turn_started', providerTurnId: null, source: 'codex_rollout_discovery_pending' });
 
+  const stopChildIfRunning = (): void => {
+    if (!child || child.exitCode !== null) return;
+    childStopRequested = true;
+    if (isWindows) {
+      void killProcessTree(child, { graceMs: 250 }).catch(() => undefined);
+      return;
+    }
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      // ignore
+    }
+  };
+
   const publishRemoteControlState = (tag: 'switch' | 'exit' | 'launch_error'): void => {
     try {
       opts.session.sendSessionEvent({ type: 'switch', mode: 'remote' });
@@ -460,18 +474,7 @@ export async function codexLocalLauncher<TMode>(opts: {
           elapsedSinceStartMs: now - startedAtMs,
         });
         exitReason = { type: 'switch', resumeId: null };
-        if (child && child.exitCode === null) {
-          childStopRequested = true;
-          if (isWindows) {
-            void killProcessTree(child, { graceMs: 250 }).catch(() => undefined);
-          } else {
-            try {
-              child.kill('SIGTERM');
-            } catch {
-              // ignore
-            }
-          }
-        }
+        stopChildIfRunning();
         childExited = true;
         break;
       }
@@ -550,18 +553,7 @@ export async function codexLocalLauncher<TMode>(opts: {
         // We can now safely switch because the session id is known.
         exitReason = { type: 'switch', resumeId };
       }
-      if (child && child.exitCode === null) {
-        childStopRequested = true;
-        if (isWindows) {
-          void killProcessTree(child, { graceMs: 250 }).catch(() => undefined);
-        } else {
-          try {
-            child.kill('SIGTERM');
-          } catch {
-            // ignore
-          }
-        }
-      }
+      stopChildIfRunning();
     }
 
     mirror = new CodexRolloutMirror({
@@ -595,18 +587,7 @@ export async function codexLocalLauncher<TMode>(opts: {
               elapsedSinceStartMs: Date.now() - startedAtMs,
             });
             exitReason = { type: 'switch', resumeId };
-            if (child && child.exitCode === null) {
-              childStopRequested = true;
-              if (isWindows) {
-                void killProcessTree(child, { graceMs: 250 }).catch(() => undefined);
-              } else {
-                try {
-                  child.kill('SIGTERM');
-                } catch {
-                  // ignore
-                }
-              }
-            }
+            stopChildIfRunning();
           }
           await delay(50);
         }
@@ -648,17 +629,6 @@ export async function codexLocalLauncher<TMode>(opts: {
     } catch {
       // ignore
     }
-    if (child && child.exitCode === null) {
-      childStopRequested = true;
-      if (isWindows) {
-        void killProcessTree(child, { graceMs: 250 }).catch(() => undefined);
-      } else {
-        try {
-          child.kill('SIGTERM');
-        } catch {
-          // ignore
-        }
-      }
-    }
+    stopChildIfRunning();
   }
 }

--- a/apps/cli/src/backends/codex/runCodex.fastStart.integration.test.ts
+++ b/apps/cli/src/backends/codex/runCodex.fastStart.integration.test.ts
@@ -328,6 +328,39 @@ describe('runCodex fast-start', () => {
     }
   });
 
+  it('passes initial resume id to local TUI after session init finishes', async () => {
+    const { runCodex } = await import('./runCodex');
+
+    const credentials = { token: 'test' } as Credentials;
+
+    let testError: unknown = null;
+    const runPromise = runCodex({
+      credentials,
+      startedBy: 'terminal',
+      startingMode: 'local',
+      resume: 'resume-123',
+    } as any).catch((e) => {
+      testError = e;
+    });
+
+    try {
+      await expect(waitFor(localStarted.promise, 1_000)).resolves.toBeUndefined();
+      expect(initResolved).toBe(true);
+    } catch (e) {
+      testError = e;
+    } finally {
+      localExit.resolve({ type: 'exit', code: 0 });
+      await runPromise;
+    }
+
+    const firstCall = codexLocalLauncherSpy.mock.calls[0]?.[0];
+    expect(firstCall?.resumeId).toBe('resume-123');
+
+    if (testError) {
+      throw testError;
+    }
+  });
+
   it('does not attach the deferred session to an offline stub; flushes buffered writes only after reconnection swap', async () => {
     const prevTiming = process.env.HAPPIER_STARTUP_TIMING_ENABLED;
     process.env.HAPPIER_STARTUP_TIMING_ENABLED = '1';

--- a/apps/cli/src/backends/codex/runCodex.fastStart.integration.test.ts
+++ b/apps/cli/src/backends/codex/runCodex.fastStart.integration.test.ts
@@ -259,7 +259,12 @@ describe('runCodex fast-start', () => {
     const credentials = { token: 'test' } as Credentials;
 
     let testError: unknown = null;
-    const runPromise = runCodex({ credentials, startedBy: 'terminal', startingMode: 'local' }).catch((e) => {
+    const runPromise = runCodex({
+      credentials,
+      startedBy: 'terminal',
+      startingMode: 'local',
+      codexArgs: ['resume', 'native-thread-1'],
+    }).catch((e) => {
       testError = e;
     });
 
@@ -290,6 +295,9 @@ describe('runCodex fast-start', () => {
     if (testError) {
       throw testError;
     }
+
+    const firstCall = codexLocalLauncherSpy.mock.calls[0]?.[0];
+    expect(firstCall?.codexArgs).toEqual(['resume', 'native-thread-1']);
 
   });
 
@@ -339,6 +347,7 @@ describe('runCodex fast-start', () => {
       startedBy: 'terminal',
       startingMode: 'local',
       resume: 'resume-123',
+      codexArgs: ['resume', 'native-thread-2'],
     } as any).catch((e) => {
       testError = e;
     });
@@ -355,6 +364,7 @@ describe('runCodex fast-start', () => {
 
     const firstCall = codexLocalLauncherSpy.mock.calls[0]?.[0];
     expect(firstCall?.resumeId).toBe('resume-123');
+    expect(firstCall?.codexArgs).toEqual(['resume', 'native-thread-2']);
 
     if (testError) {
       throw testError;

--- a/apps/cli/src/backends/codex/runCodex.ts
+++ b/apps/cli/src/backends/codex/runCodex.ts
@@ -667,7 +667,7 @@ export async function runCodex(opts: {
                 session,
                 messageQueue,
                 permissionMode: initialPermissionMode,
-                resumeId: null,
+                resumeId: resumeIdFromArgs,
             }));
         if (localResult.type === 'exit') {
             clearInterval(keepAliveInterval);

--- a/apps/cli/src/backends/codex/runCodex.ts
+++ b/apps/cli/src/backends/codex/runCodex.ts
@@ -411,6 +411,7 @@ export async function runCodex(opts: {
                     messageQueue,
                     permissionMode: initialPermissionMode,
                     resumeId: resumeIdFromArgs,
+                    codexArgs: opts.codexArgs ?? [],
                 });
             },
         };
@@ -669,6 +670,7 @@ export async function runCodex(opts: {
                 messageQueue,
                 permissionMode: initialPermissionMode,
                 resumeId: resumeIdFromArgs,
+                codexArgs: opts.codexArgs ?? [],
             }));
         if (localResult.type === 'exit') {
             clearInterval(keepAliveInterval);

--- a/apps/cli/src/backends/codex/runCodex.ts
+++ b/apps/cli/src/backends/codex/runCodex.ts
@@ -139,6 +139,7 @@ export async function runCodex(opts: {
     modelUpdatedAt?: number;
     existingSessionId?: string;
     resume?: string;
+    codexArgs?: string[];
     startingMode?: 'local' | 'remote';
     experimentalCodexAcp?: boolean;
     codexBackendMode?: CodexBackendMode;
@@ -1338,6 +1339,7 @@ export async function runCodex(opts: {
                     api,
                     permissionMode: currentPermissionMode ?? initialPermissionMode,
                     resumeId: storedSessionIdForResume,
+                    codexArgs: opts.codexArgs ?? [],
                     formatError: formatErrorForUi,
                     launchLocal: codexLocalLauncher,
                 });

--- a/apps/cli/src/backends/codex/runtime/localModePass.test.ts
+++ b/apps/cli/src/backends/codex/runtime/localModePass.test.ts
@@ -87,4 +87,32 @@ describe('runCodexLocalModePass', () => {
 
     expect(result).toEqual({ type: 'remote', resumeId: 'resume-123' });
   });
+
+  it('passes provider-native Codex args through to the local launcher', async () => {
+    const queue = new MessageQueue2<Mode>(() => 'hash');
+    const session = {
+      listPendingMessageQueueV2LocalIds: vi.fn().mockResolvedValue([]),
+      discardPendingMessageQueueV2All: vi.fn(),
+      discardCommittedMessageLocalIds: vi.fn(),
+      sendSessionEvent: vi.fn(),
+    };
+    const launchLocal = vi.fn().mockResolvedValue({ type: 'switch', resumeId: 'resume-123' });
+
+    await runCodexLocalModePass({
+      session: session as unknown as ApiSessionClient,
+      messageQueue: queue,
+      workspaceDir: '/tmp/project',
+      api: {},
+      permissionMode: 'default',
+      resumeId: null,
+      codexArgs: ['resume', '--all'],
+      launchLocal,
+      discardController: vi.fn(),
+      formatError: (error: unknown) => String(error),
+    });
+
+    expect(launchLocal).toHaveBeenCalledWith(expect.objectContaining({
+      codexArgs: ['resume', '--all'],
+    }));
+  });
 });

--- a/apps/cli/src/backends/codex/runtime/localModePass.ts
+++ b/apps/cli/src/backends/codex/runtime/localModePass.ts
@@ -23,6 +23,7 @@ export async function runCodexLocalModePass<Mode extends QueueModeWithLocalId>(o
   api: unknown;
   permissionMode: PermissionMode;
   resumeId: string | null;
+  codexArgs?: readonly string[];
   formatError: (error: unknown) => string;
   launchLocal?: (args: {
     path: string;
@@ -31,6 +32,7 @@ export async function runCodexLocalModePass<Mode extends QueueModeWithLocalId>(o
     messageQueue: MessageQueue2<Mode>;
     permissionMode: PermissionMode;
     resumeId: string | null;
+    codexArgs?: readonly string[];
   }) => Promise<CodexLauncherResult>;
   discardController?: DiscardController;
 }): Promise<CodexLocalModePassResult> {
@@ -75,6 +77,7 @@ export async function runCodexLocalModePass<Mode extends QueueModeWithLocalId>(o
     messageQueue: opts.messageQueue,
     permissionMode: opts.permissionMode,
     resumeId: opts.resumeId,
+    codexArgs: opts.codexArgs ?? [],
   });
 
   if (localResult.type === 'exit') {

--- a/apps/cli/src/cli/dispatch.providerInfoPassthrough.test.ts
+++ b/apps/cli/src/cli/dispatch.providerInfoPassthrough.test.ts
@@ -34,7 +34,7 @@ describe('dispatchCli provider info passthrough', () => {
     passthroughSpy.mockReturnValue(false);
   });
 
-  it('short-circuits provider --help requests before invoking the provider command handler', async () => {
+  it('lets provider command handlers render combined provider help', async () => {
     passthroughSpy.mockReturnValue(true);
 
     await dispatchCli({
@@ -43,10 +43,11 @@ describe('dispatchCli provider info passthrough', () => {
       terminalRuntime: null,
     });
 
-    expect(passthroughSpy).toHaveBeenCalledWith({
-      agentId: 'gemini',
+    expect(passthroughSpy).not.toHaveBeenCalled();
+    expect(geminiHandlerSpy).toHaveBeenCalledWith({
       args: ['gemini', '--help'],
+      rawArgv: ['happier', 'gemini', '--help'],
+      terminalRuntime: null,
     });
-    expect(geminiHandlerSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/cli/dispatch.ts
+++ b/apps/cli/src/cli/dispatch.ts
@@ -4,9 +4,8 @@ import type { TerminalRuntimeFlags } from '@/terminal/runtime/terminalRuntimeFla
 import { commandRegistry } from '@/cli/commandRegistry';
 import { buildRootHelpText } from '@/cli/buildRootHelpText';
 import { isTmuxAllowedCommand } from '@/cli/commandSurfaceManifest';
-import { maybePassthroughProviderCliInfoRequest } from '@/cli/providerCliPassthrough';
 import { readStartedByArg } from '@/cli/readStartedByArg';
-import { requireCatalogEntry, resolveCatalogAgentIdForCliSubcommand } from '@/backends/catalog';
+import { requireCatalogEntry } from '@/backends/catalog';
 import { DEFAULT_CATALOG_AGENT_ID } from '@/backends/types';
 import { applyDaemonAutostartEnvForInvocation, shouldEnsureDaemonForInvocation } from '@/daemon/ensureDaemon';
 import { applyEphemeralServerSelectionFromPrefixArgs } from '@/server/serverSelection';
@@ -88,13 +87,6 @@ export async function dispatchCli(params: Readonly<{
   }
   const commandHandler = (subcommand ? commandRegistry[subcommand] : undefined);
   if (commandHandler) {
-    const catalogAgentId =
-      typeof subcommand === 'string' && subcommand.length > 0
-        ? resolveCatalogAgentIdForCliSubcommand(subcommand)
-        : null;
-    if (catalogAgentId && maybePassthroughProviderCliInfoRequest({ agentId: catalogAgentId, args })) {
-      return;
-    }
     await commandHandler({ args, rawArgv, terminalRuntime });
     return;
   }

--- a/apps/cli/src/cli/providerCliPassthrough.test.ts
+++ b/apps/cli/src/cli/providerCliPassthrough.test.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { SpawnSyncReturns } from 'node:child_process';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -86,6 +87,75 @@ afterEach(async () => {
 });
 
 describe('maybePassthroughProviderCliInfoRequest', () => {
+  function successfulSpawnResult(): SpawnSyncReturns<Buffer> {
+    return {
+      pid: 1,
+      output: [],
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      status: 0,
+      signal: null,
+    };
+  }
+
+  it('passes native Codex resume subcommands through to the provider CLI', () => {
+    spawnSyncMock.mockReturnValue(successfulSpawnResult());
+    requireProviderCliLaunchSpecMock.mockReturnValueOnce({
+      source: 'system',
+      resolvedPath: 'codex',
+      command: 'codex',
+      args: [],
+    });
+
+    const handled = maybePassthroughProviderCliInfoRequest({
+      agentId: 'codex',
+      args: ['codex', 'resume', '--all'],
+      processEnv: process.env,
+    });
+
+    expect(handled).toBe(true);
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'codex',
+      ['resume', '--all'],
+      expect.objectContaining({ stdio: 'inherit', windowsHide: true }),
+    );
+  });
+
+  it('passes native Codex fork subcommands through to the provider CLI', () => {
+    spawnSyncMock.mockReturnValue(successfulSpawnResult());
+    requireProviderCliLaunchSpecMock.mockReturnValueOnce({
+      source: 'system',
+      resolvedPath: 'codex',
+      command: 'codex',
+      args: [],
+    });
+
+    const handled = maybePassthroughProviderCliInfoRequest({
+      agentId: 'codex',
+      args: ['codex', 'fork', 'thread-1'],
+      processEnv: process.env,
+    });
+
+    expect(handled).toBe(true);
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'codex',
+      ['fork', 'thread-1'],
+      expect.objectContaining({ stdio: 'inherit', windowsHide: true }),
+    );
+  });
+
+  it('does not pass unsupported native provider subcommands through', () => {
+    const handled = maybePassthroughProviderCliInfoRequest({
+      agentId: 'gemini',
+      args: ['gemini', 'resume', '--all'],
+      processEnv: process.env,
+    });
+
+    expect(handled).toBe(false);
+    expect(requireProviderCliLaunchSpecMock).not.toHaveBeenCalled();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
   it('runs system node-shebang provider CLIs through the resolved JS runtime', async () => {
     const root = await createTempDir('happier-provider-passthrough-');
     tempDirs.add(root);
@@ -107,6 +177,9 @@ describe('maybePassthroughProviderCliInfoRequest', () => {
 
     process.env.PATH = pathDir;
     process.env.HAPPIER_JS_RUNTIME_PATH = runtimePath;
+    if (process.platform === 'win32') {
+      spawnSyncMock.mockReturnValueOnce(successfulSpawnResult());
+    }
 
     const handled = maybePassthroughProviderCliInfoRequest({
       agentId: 'gemini',
@@ -115,6 +188,17 @@ describe('maybePassthroughProviderCliInfoRequest', () => {
     });
 
     expect(handled).toBe(true);
+    if (process.platform === 'win32') {
+      const [invocation] = resolveWindowsCommandInvocationMock.mock.calls[0] ?? [];
+      expect(invocation).toEqual(expect.objectContaining({ args: ['--help'] }));
+      expect(invocation.command.toLowerCase()).toBe(providerPath.toLowerCase());
+      expect(spawnSyncMock).toHaveBeenCalledWith(
+        invocation.command,
+        ['--help'],
+        expect.objectContaining({ stdio: 'inherit', windowsHide: true }),
+      );
+      return;
+    }
     await expect(readFile(markerPath, 'utf8')).resolves.toContain(providerPath);
   });
 

--- a/apps/cli/src/cli/providerCliPassthrough.test.ts
+++ b/apps/cli/src/cli/providerCliPassthrough.test.ts
@@ -98,7 +98,7 @@ describe('maybePassthroughProviderCliInfoRequest', () => {
     };
   }
 
-  it('passes native Codex resume subcommands through to the provider CLI', () => {
+  it('does not native-spawn provider subcommands through the info passthrough path', () => {
     spawnSyncMock.mockReturnValue(successfulSpawnResult());
     requireProviderCliLaunchSpecMock.mockReturnValueOnce({
       source: 'system',
@@ -110,44 +110,6 @@ describe('maybePassthroughProviderCliInfoRequest', () => {
     const handled = maybePassthroughProviderCliInfoRequest({
       agentId: 'codex',
       args: ['codex', 'resume', '--all'],
-      processEnv: process.env,
-    });
-
-    expect(handled).toBe(true);
-    expect(spawnSyncMock).toHaveBeenCalledWith(
-      'codex',
-      ['resume', '--all'],
-      expect.objectContaining({ stdio: 'inherit', windowsHide: true }),
-    );
-  });
-
-  it('passes native Codex fork subcommands through to the provider CLI', () => {
-    spawnSyncMock.mockReturnValue(successfulSpawnResult());
-    requireProviderCliLaunchSpecMock.mockReturnValueOnce({
-      source: 'system',
-      resolvedPath: 'codex',
-      command: 'codex',
-      args: [],
-    });
-
-    const handled = maybePassthroughProviderCliInfoRequest({
-      agentId: 'codex',
-      args: ['codex', 'fork', 'thread-1'],
-      processEnv: process.env,
-    });
-
-    expect(handled).toBe(true);
-    expect(spawnSyncMock).toHaveBeenCalledWith(
-      'codex',
-      ['fork', 'thread-1'],
-      expect.objectContaining({ stdio: 'inherit', windowsHide: true }),
-    );
-  });
-
-  it('does not pass unsupported native provider subcommands through', () => {
-    const handled = maybePassthroughProviderCliInfoRequest({
-      agentId: 'gemini',
-      args: ['gemini', 'resume', '--all'],
       processEnv: process.env,
     });
 

--- a/apps/cli/src/cli/providerCliPassthrough.ts
+++ b/apps/cli/src/cli/providerCliPassthrough.ts
@@ -1,29 +1,12 @@
 import { spawnSync } from 'node:child_process';
 
-import { AGENTS_CORE, type AgentId } from '@happier-dev/agents';
+import type { AgentId } from '@happier-dev/agents';
 import { resolveWindowsCommandInvocation } from '@happier-dev/cli-common/process';
 
 import { requireProviderCliLaunchSpec } from '@/runtime/managedTools/requireProviderCliLaunchSpec';
 
 const HELP_FLAGS = new Set(['-h', '--help']);
 const VERSION_FLAGS = new Set(['-v', '--version']);
-
-type AgentCoreDefinition = (typeof AGENTS_CORE)[AgentId];
-
-function getNativeCliPassthroughSubcommands(agent: AgentCoreDefinition): readonly string[] {
-  if (!('nativeCliPassthroughSubcommands' in agent)) return [];
-  return agent.nativeCliPassthroughSubcommands ?? [];
-}
-
-function resolveNativeProviderArgs(agentId: AgentId, args: readonly string[]): string[] | null {
-  const supported = getNativeCliPassthroughSubcommands(AGENTS_CORE[agentId]);
-  if (supported.length === 0) return null;
-
-  const providerArgs = args[0] === agentId ? args.slice(1) : args;
-  const subcommand = providerArgs[0];
-  if (!subcommand || !supported.includes(subcommand)) return null;
-  return [...providerArgs];
-}
 
 export function detectProviderCliInfoRequest(args: readonly string[]): '--help' | '--version' | null {
   if (args.some((arg) => HELP_FLAGS.has(arg))) return '--help';
@@ -67,15 +50,6 @@ export function maybePassthroughProviderCliInfoRequest(params: Readonly<{
   args: readonly string[];
   processEnv?: NodeJS.ProcessEnv;
 }>): boolean {
-  const nativeProviderArgs = resolveNativeProviderArgs(params.agentId, params.args);
-  if (nativeProviderArgs) {
-    return passthroughProviderCli({
-      agentId: params.agentId,
-      providerArgs: nativeProviderArgs,
-      processEnv: params.processEnv,
-    });
-  }
-
   const flag = detectProviderCliInfoRequest(params.args);
   if (!flag) return false;
 

--- a/apps/cli/src/cli/providerCliPassthrough.ts
+++ b/apps/cli/src/cli/providerCliPassthrough.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 
-import type { AgentId } from '@happier-dev/agents';
+import { AGENTS_CORE, type AgentCore, type AgentId } from '@happier-dev/agents';
 import { resolveWindowsCommandInvocation } from '@happier-dev/cli-common/process';
 
 import { requireProviderCliLaunchSpec } from '@/runtime/managedTools/requireProviderCliLaunchSpec';
@@ -8,24 +8,35 @@ import { requireProviderCliLaunchSpec } from '@/runtime/managedTools/requireProv
 const HELP_FLAGS = new Set(['-h', '--help']);
 const VERSION_FLAGS = new Set(['-v', '--version']);
 
+type NativeCliPassthroughSupport = Pick<AgentCore, 'id' | 'nativeCliPassthroughSubcommands'>;
+
+const NATIVE_CLI_PASSTHROUGH_SUPPORT_BY_AGENT: Readonly<Record<AgentId, NativeCliPassthroughSupport>> = AGENTS_CORE;
+
+function resolveNativeProviderArgs(agentId: AgentId, args: readonly string[]): string[] | null {
+  const supported = NATIVE_CLI_PASSTHROUGH_SUPPORT_BY_AGENT[agentId].nativeCliPassthroughSubcommands ?? [];
+  if (supported.length === 0) return null;
+
+  const providerArgs = args[0] === agentId ? args.slice(1) : args;
+  const subcommand = providerArgs[0];
+  if (!subcommand || !supported.includes(subcommand)) return null;
+  return [...providerArgs];
+}
+
 export function detectProviderCliInfoRequest(args: readonly string[]): '--help' | '--version' | null {
   if (args.some((arg) => HELP_FLAGS.has(arg))) return '--help';
   if (args.some((arg) => VERSION_FLAGS.has(arg))) return '--version';
   return null;
 }
 
-export function maybePassthroughProviderCliInfoRequest(params: Readonly<{
+function passthroughProviderCli(params: Readonly<{
   agentId: AgentId;
-  args: readonly string[];
+  providerArgs: readonly string[];
   processEnv?: NodeJS.ProcessEnv;
 }>): boolean {
-  const flag = detectProviderCliInfoRequest(params.args);
-  if (!flag) return false;
-
   const launch = requireProviderCliLaunchSpec(params.agentId, { processEnv: params.processEnv });
   const invocation = resolveWindowsCommandInvocation({
     command: launch.command,
-    args: [...launch.args, flag],
+    args: [...launch.args, ...params.providerArgs],
     env: params.processEnv ?? process.env,
     resolveCommandOnPath: false,
   });
@@ -46,4 +57,28 @@ export function maybePassthroughProviderCliInfoRequest(params: Readonly<{
     process.exit(1);
   }
   return true;
+}
+
+export function maybePassthroughProviderCliInfoRequest(params: Readonly<{
+  agentId: AgentId;
+  args: readonly string[];
+  processEnv?: NodeJS.ProcessEnv;
+}>): boolean {
+  const nativeProviderArgs = resolveNativeProviderArgs(params.agentId, params.args);
+  if (nativeProviderArgs) {
+    return passthroughProviderCli({
+      agentId: params.agentId,
+      providerArgs: nativeProviderArgs,
+      processEnv: params.processEnv,
+    });
+  }
+
+  const flag = detectProviderCliInfoRequest(params.args);
+  if (!flag) return false;
+
+  return passthroughProviderCli({
+    agentId: params.agentId,
+    providerArgs: [flag],
+    processEnv: params.processEnv,
+  });
 }

--- a/apps/cli/src/cli/providerCliPassthrough.ts
+++ b/apps/cli/src/cli/providerCliPassthrough.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 
-import { AGENTS_CORE, type AgentCore, type AgentId } from '@happier-dev/agents';
+import { AGENTS_CORE, type AgentId } from '@happier-dev/agents';
 import { resolveWindowsCommandInvocation } from '@happier-dev/cli-common/process';
 
 import { requireProviderCliLaunchSpec } from '@/runtime/managedTools/requireProviderCliLaunchSpec';
@@ -8,12 +8,15 @@ import { requireProviderCliLaunchSpec } from '@/runtime/managedTools/requireProv
 const HELP_FLAGS = new Set(['-h', '--help']);
 const VERSION_FLAGS = new Set(['-v', '--version']);
 
-type NativeCliPassthroughSupport = Pick<AgentCore, 'id' | 'nativeCliPassthroughSubcommands'>;
+type AgentCoreDefinition = (typeof AGENTS_CORE)[AgentId];
 
-const NATIVE_CLI_PASSTHROUGH_SUPPORT_BY_AGENT: Readonly<Record<AgentId, NativeCliPassthroughSupport>> = AGENTS_CORE;
+function getNativeCliPassthroughSubcommands(agent: AgentCoreDefinition): readonly string[] {
+  if (!('nativeCliPassthroughSubcommands' in agent)) return [];
+  return agent.nativeCliPassthroughSubcommands ?? [];
+}
 
 function resolveNativeProviderArgs(agentId: AgentId, args: readonly string[]): string[] | null {
-  const supported = NATIVE_CLI_PASSTHROUGH_SUPPORT_BY_AGENT[agentId].nativeCliPassthroughSubcommands ?? [];
+  const supported = getNativeCliPassthroughSubcommands(AGENTS_CORE[agentId]);
   if (supported.length === 0) return null;
 
   const providerArgs = args[0] === agentId ? args.slice(1) : args;

--- a/apps/cli/src/cli/providerCliPassthrough.ts
+++ b/apps/cli/src/cli/providerCliPassthrough.ts
@@ -6,15 +6,17 @@ import { resolveWindowsCommandInvocation } from '@happier-dev/cli-common/process
 import { requireProviderCliLaunchSpec } from '@/runtime/managedTools/requireProviderCliLaunchSpec';
 
 const HELP_FLAGS = new Set(['-h', '--help']);
-const VERSION_FLAGS = new Set(['-v', '--version']);
+const VERSION_FLAGS = new Set(['-v', '-V', '--version']);
 
-export function detectProviderCliInfoRequest(args: readonly string[]): '--help' | '--version' | null {
-  if (args.some((arg) => HELP_FLAGS.has(arg))) return '--help';
-  if (args.some((arg) => VERSION_FLAGS.has(arg))) return '--version';
+export function detectProviderCliInfoRequest(args: readonly string[]): string | null {
+  const helpFlag = args.find((arg) => HELP_FLAGS.has(arg));
+  if (helpFlag) return helpFlag;
+  const versionFlag = args.find((arg) => VERSION_FLAGS.has(arg));
+  if (versionFlag) return versionFlag;
   return null;
 }
 
-function passthroughProviderCli(params: Readonly<{
+export function passthroughProviderCliArgs(params: Readonly<{
   agentId: AgentId;
   providerArgs: readonly string[];
   processEnv?: NodeJS.ProcessEnv;
@@ -53,7 +55,7 @@ export function maybePassthroughProviderCliInfoRequest(params: Readonly<{
   const flag = detectProviderCliInfoRequest(params.args);
   if (!flag) return false;
 
-  return passthroughProviderCli({
+  return passthroughProviderCliArgs({
     agentId: params.agentId,
     providerArgs: [flag],
     processEnv: params.processEnv,

--- a/apps/cli/src/cli/providerSessionArgPartition.test.ts
+++ b/apps/cli/src/cli/providerSessionArgPartition.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { partitionProviderSessionArgs } from './providerSessionArgPartition';
+
+describe('partitionProviderSessionArgs', () => {
+  it('consumes common Happier session flags and preserves provider args', () => {
+    const result = partitionProviderSessionArgs({
+      args: [
+        'codex',
+        '--profile',
+        'work',
+        '--permission-mode',
+        'yolo',
+        '--happy-starting-mode',
+        'remote',
+        'resume',
+        '--all',
+      ],
+      providerSubcommand: 'codex',
+    });
+
+    expect(result).toMatchObject({
+      profileQuery: 'work',
+      permissionMode: 'yolo',
+      startingMode: 'remote',
+      providerArgs: ['resume', '--all'],
+    });
+  });
+
+  it('can consume provider-owned directory aliases without forwarding them', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['codex', '-C', '/tmp/a', '--cd', '/tmp/b', 'fix this'],
+      providerSubcommand: 'codex',
+      directoryFlags: ['-C', '--cd'],
+    });
+
+    expect(result.directory).toBe('/tmp/b');
+    expect(result.providerArgs).toEqual(['fix this']);
+  });
+
+  it('can forward consumed model flags to providers that also own model selection', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['claude', '--model', 'opus', '--fallback-model', 'sonnet', 'fix this'],
+      providerSubcommand: 'claude',
+      forwardModelFlag: true,
+    });
+
+    expect(result.modelId).toBe('opus');
+    expect(result.providerArgs).toEqual(['--model', 'opus', '--fallback-model', 'sonnet', 'fix this']);
+  });
+
+  it('maps --yolo to provider args when a provider supplies an alias', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['claude', '--yolo', 'fix this'],
+      providerSubcommand: 'claude',
+      yoloProviderArgs: ['--dangerously-skip-permissions'],
+    });
+
+    expect(result.permissionMode).toBe('yolo');
+    expect(result.providerArgs).toEqual(['--dangerously-skip-permissions', 'fix this']);
+  });
+
+  it('preserves provider resume flags when requested while exposing the Happier resume value', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['claude', '--resume', 'abc123', '--continue'],
+      providerSubcommand: 'claude',
+      forwardResumeFlag: true,
+    });
+
+    expect(result.resume).toBe('abc123');
+    expect(result.providerArgs).toEqual(['--resume', 'abc123', '--continue']);
+  });
+
+  it('preserves provider-specific permission mode tokens', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['claude', '--permission-mode=bypassPermissions'],
+      providerSubcommand: 'claude',
+    });
+
+    expect(result.permissionMode).toBe('bypassPermissions');
+    expect(result.providerArgs).toEqual([]);
+  });
+});

--- a/apps/cli/src/cli/providerSessionArgPartition.test.ts
+++ b/apps/cli/src/cli/providerSessionArgPartition.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { partitionProviderSessionArgs } from './providerSessionArgPartition';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('partitionProviderSessionArgs', () => {
   it('consumes common Happier session flags and preserves provider args', () => {
@@ -110,5 +114,29 @@ describe('partitionProviderSessionArgs', () => {
 
     expect(result.helpRequested).toBe(true);
     expect(result.providerArgs).toEqual(['exec']);
+  });
+
+  it('rejects option-like values for required Happier-owned flags', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null): never => {
+      throw new Error(`exit:${code ?? 0}`);
+    });
+
+    expect(() => {
+      partitionProviderSessionArgs({
+        args: ['codex', '--model', '--help'],
+        providerSubcommand: 'codex',
+        forwardModelFlag: true,
+      });
+    }).toThrow('exit:1');
+  });
+
+  it('consumes numeric account settings version hints without forwarding them', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['codex', '--account-settings-version-hint', '-1', 'exec', '--json'],
+      providerSubcommand: 'codex',
+    });
+
+    expect(result.providerArgs).toEqual(['exec', '--json']);
   });
 });

--- a/apps/cli/src/cli/providerSessionArgPartition.test.ts
+++ b/apps/cli/src/cli/providerSessionArgPartition.test.ts
@@ -80,4 +80,35 @@ describe('partitionProviderSessionArgs', () => {
     expect(result.permissionMode).toBe('bypassPermissions');
     expect(result.providerArgs).toEqual([]);
   });
+
+  it('recognizes Codex native -V as a provider version request', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['codex', '-V'],
+      providerSubcommand: 'codex',
+      versionFlags: ['-v', '-V', '--version'],
+    });
+
+    expect(result.versionRequested).toBe(true);
+    expect(result.providerArgs).toEqual([]);
+  });
+
+  it('does not treat provider-specific -V as a common Happier version flag', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['claude', '-V'],
+      providerSubcommand: 'claude',
+    });
+
+    expect(result.versionRequested).toBe(false);
+    expect(result.providerArgs).toEqual(['-V']);
+  });
+
+  it('preserves provider subcommand context around help requests', () => {
+    const result = partitionProviderSessionArgs({
+      args: ['codex', 'exec', '--help'],
+      providerSubcommand: 'codex',
+    });
+
+    expect(result.helpRequested).toBe(true);
+    expect(result.providerArgs).toEqual(['exec']);
+  });
 });

--- a/apps/cli/src/cli/providerSessionArgPartition.ts
+++ b/apps/cli/src/cli/providerSessionArgPartition.ts
@@ -23,6 +23,7 @@ export type ProviderSessionArgPartitionResult = Readonly<{
   providerArgs: string[];
   helpRequested: boolean;
   versionRequested: boolean;
+  versionFlag?: string;
 }>;
 
 export type ProviderSessionArgPartitionOptions = Readonly<{
@@ -32,6 +33,7 @@ export type ProviderSessionArgPartitionOptions = Readonly<{
   forwardModelFlag?: boolean;
   forwardResumeFlag?: boolean;
   yoloProviderArgs?: readonly string[];
+  versionFlags?: readonly string[];
 }>;
 
 const PERMISSION_MODE_EXAMPLES = [
@@ -89,8 +91,10 @@ export function partitionProviderSessionArgs(options: ProviderSessionArgPartitio
   let directory: string | undefined;
   let helpRequested = false;
   let versionRequested = false;
+  let versionFlag: string | undefined;
   const providerArgs: string[] = [];
   const directoryFlags = new Set(options.directoryFlags ?? []);
+  const versionFlags = new Set(options.versionFlags ?? ['-v', '--version']);
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
@@ -99,8 +103,9 @@ export function partitionProviderSessionArgs(options: ProviderSessionArgPartitio
       helpRequested = true;
       continue;
     }
-    if (arg === '-v' || arg === '--version') {
+    if (versionFlags.has(arg)) {
       versionRequested = true;
+      versionFlag = arg;
       continue;
     }
     if (arg === '--refresh-settings') {
@@ -277,6 +282,7 @@ export function partitionProviderSessionArgs(options: ProviderSessionArgPartitio
     ...(directory ? { directory } : {}),
     helpRequested,
     versionRequested,
+    ...(versionFlag ? { versionFlag } : {}),
     providerArgs,
   };
 }

--- a/apps/cli/src/cli/providerSessionArgPartition.ts
+++ b/apps/cli/src/cli/providerSessionArgPartition.ts
@@ -1,0 +1,282 @@
+import chalk from 'chalk';
+
+import { isPermissionMode, type PermissionMode } from '@/api/types';
+import {
+  PERMISSION_INTENTS,
+  parsePermissionModeAlias as parsePermissionModeAliasShared,
+} from '@happier-dev/agents';
+
+export type ProviderSessionArgPartitionResult = Readonly<{
+  startedBy?: 'daemon' | 'terminal';
+  refreshSettings: boolean;
+  profileQuery?: string;
+  permissionMode?: PermissionMode;
+  permissionModeUpdatedAt?: number;
+  agentModeId?: string;
+  agentModeUpdatedAt?: number;
+  modelId?: string;
+  modelUpdatedAt?: number;
+  existingSessionId?: string;
+  resume?: string;
+  startingMode?: 'local' | 'remote' | string;
+  directory?: string;
+  providerArgs: string[];
+  helpRequested: boolean;
+  versionRequested: boolean;
+}>;
+
+export type ProviderSessionArgPartitionOptions = Readonly<{
+  args: readonly string[];
+  providerSubcommand?: string | null;
+  directoryFlags?: readonly string[];
+  forwardModelFlag?: boolean;
+  forwardResumeFlag?: boolean;
+  yoloProviderArgs?: readonly string[];
+}>;
+
+const PERMISSION_MODE_EXAMPLES = [
+  '--permission-mode read-only',
+  '--permission-mode yolo',
+  '--permission-mode accept-edits',
+] as const;
+
+function parsePermissionModeAlias(raw: string): PermissionMode | null {
+  const parsed = parsePermissionModeAliasShared(raw);
+  if (!parsed) return null;
+  return isPermissionMode(parsed) ? parsed : null;
+}
+
+function fail(message: string): never {
+  console.error(chalk.red(message));
+  process.exit(1);
+}
+
+function readRequiredValue(args: readonly string[], index: number, label: string): string {
+  if (index + 1 >= args.length) {
+    fail(`Missing value for ${label}`);
+  }
+  const value = args[index + 1];
+  if (typeof value !== 'string' || value.length === 0) {
+    fail(`Missing value for ${label}`);
+  }
+  return value;
+}
+
+function readOptionalValue(args: readonly string[], index: number): string | undefined {
+  const value = args[index + 1];
+  if (!value || value.startsWith('-')) return undefined;
+  return value;
+}
+
+export function partitionProviderSessionArgs(options: ProviderSessionArgPartitionOptions): ProviderSessionArgPartitionResult {
+  const args = [...options.args];
+  if (options.providerSubcommand && args[0] === options.providerSubcommand) {
+    args.shift();
+  }
+
+  let startedBy: 'daemon' | 'terminal' | undefined;
+  let refreshSettings = false;
+  let profileQuery: string | undefined;
+  let permissionMode: PermissionMode | undefined;
+  let permissionModeUpdatedAt: number | undefined;
+  let agentModeId: string | undefined;
+  let agentModeUpdatedAt: number | undefined;
+  let modelId: string | undefined;
+  let modelUpdatedAt: number | undefined;
+  let existingSessionId: string | undefined;
+  let resume: string | undefined;
+  let startingMode: 'local' | 'remote' | string | undefined;
+  let directory: string | undefined;
+  let helpRequested = false;
+  let versionRequested = false;
+  const providerArgs: string[] = [];
+  const directoryFlags = new Set(options.directoryFlags ?? []);
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (arg === '-h' || arg === '--help') {
+      helpRequested = true;
+      continue;
+    }
+    if (arg === '-v' || arg === '--version') {
+      versionRequested = true;
+      continue;
+    }
+    if (arg === '--refresh-settings') {
+      refreshSettings = true;
+      continue;
+    }
+    if (arg === '--profile') {
+      const raw = readRequiredValue(args, i, '--profile (expected: profile id or name)');
+      const normalized = raw.trim();
+      if (!normalized) fail('Invalid --profile value: empty');
+      profileQuery = normalized;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--profile=')) {
+      const normalized = arg.slice('--profile='.length).trim();
+      if (!normalized) fail('Invalid --profile value: empty');
+      profileQuery = normalized;
+      continue;
+    }
+    if (arg === '--happy-starting-mode') {
+      startingMode = readRequiredValue(args, i, '--happy-starting-mode');
+      i += 1;
+      continue;
+    }
+    if (arg === '--started-by') {
+      const value = readRequiredValue(args, i, '--started-by (expected: daemon|terminal)');
+      if (value !== 'daemon' && value !== 'terminal') {
+        fail(`Invalid --started-by value: ${value}. Expected: daemon|terminal`);
+      }
+      startedBy = value;
+      i += 1;
+      continue;
+    }
+    if (arg === '--permission-mode') {
+      const value = readRequiredValue(
+        args,
+        i,
+        `--permission-mode. Valid values: ${PERMISSION_INTENTS.join(', ')}. Examples: ${PERMISSION_MODE_EXAMPLES.join(' | ')}`,
+      );
+      const parsed = parsePermissionModeAlias(value);
+      if (!parsed) {
+        fail(
+          `Invalid --permission-mode value: ${value}. Valid values: ${PERMISSION_INTENTS.join(', ')}. Examples: ${PERMISSION_MODE_EXAMPLES.join(' | ')}`,
+        );
+      }
+      permissionMode = parsed;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--permission-mode=')) {
+      const value = arg.slice('--permission-mode='.length).trim();
+      if (!value) {
+        fail(`Missing value for --permission-mode. Valid values: ${PERMISSION_INTENTS.join(', ')}`);
+      }
+      const parsed = parsePermissionModeAlias(value);
+      if (!parsed) {
+        fail(
+          `Invalid --permission-mode value: ${value}. Valid values: ${PERMISSION_INTENTS.join(', ')}. Examples: ${PERMISSION_MODE_EXAMPLES.join(' | ')}`,
+        );
+      }
+      permissionMode = parsed;
+      continue;
+    }
+    if (arg === '--permission-mode-updated-at') {
+      const raw = readRequiredValue(args, i, '--permission-mode-updated-at (expected: unix ms timestamp)');
+      const parsedAt = Number(raw);
+      if (!Number.isFinite(parsedAt) || parsedAt <= 0) {
+        fail(`Invalid --permission-mode-updated-at value: ${raw}. Expected a positive number (unix ms)`);
+      }
+      permissionModeUpdatedAt = Math.floor(parsedAt);
+      i += 1;
+      continue;
+    }
+    if (arg === '--agent-mode') {
+      const raw = readRequiredValue(args, i, '--agent-mode (expected: ACP session mode id)');
+      const normalized = raw.trim();
+      if (!normalized) fail('Invalid --agent-mode value: empty');
+      agentModeId = normalized;
+      i += 1;
+      continue;
+    }
+    if (arg === '--agent-mode-updated-at') {
+      const raw = readRequiredValue(args, i, '--agent-mode-updated-at (expected: unix ms timestamp)');
+      const parsedAt = Number(raw);
+      if (!Number.isFinite(parsedAt) || parsedAt <= 0) {
+        fail(`Invalid --agent-mode-updated-at value: ${raw}. Expected a positive number (unix ms)`);
+      }
+      agentModeUpdatedAt = Math.floor(parsedAt);
+      i += 1;
+      continue;
+    }
+    if (arg === '--model') {
+      const raw = readRequiredValue(args, i, '--model (expected: model id)');
+      const normalized = raw.trim();
+      if (!normalized) fail('Invalid --model value: empty');
+      modelId = normalized;
+      if (options.forwardModelFlag) {
+        providerArgs.push(arg, normalized);
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === '--model-updated-at') {
+      const raw = readRequiredValue(args, i, '--model-updated-at (expected: unix ms timestamp)');
+      const parsedAt = Number(raw);
+      if (!Number.isFinite(parsedAt) || parsedAt <= 0) {
+        fail(`Invalid --model-updated-at value: ${raw}. Expected a positive number (unix ms)`);
+      }
+      modelUpdatedAt = Math.floor(parsedAt);
+      i += 1;
+      continue;
+    }
+    if (arg === '--account-settings-version-hint') {
+      if (readOptionalValue(args, i)) {
+        i += 1;
+      }
+      continue;
+    }
+    if (arg === '--existing-session') {
+      const value = readOptionalValue(args, i);
+      if (value) {
+        existingSessionId = value;
+        i += 1;
+      }
+      continue;
+    }
+    if (arg === '--resume' || arg === '-r') {
+      const value = readOptionalValue(args, i);
+      if (options.forwardResumeFlag) {
+        providerArgs.push(arg);
+      }
+      if (value) {
+        resume = value;
+        if (options.forwardResumeFlag) {
+          providerArgs.push(value);
+        }
+        i += 1;
+      }
+      continue;
+    }
+    if (arg === '--yolo') {
+      permissionMode = 'yolo';
+      if (options.yoloProviderArgs) {
+        providerArgs.push(...options.yoloProviderArgs);
+      }
+      continue;
+    }
+    if (directoryFlags.has(arg)) {
+      const value = readOptionalValue(args, i);
+      if (value) {
+        directory = value.trim() || undefined;
+        i += 1;
+      }
+      continue;
+    }
+
+    providerArgs.push(arg);
+  }
+
+  return {
+    ...(startedBy ? { startedBy } : {}),
+    refreshSettings,
+    ...(profileQuery ? { profileQuery } : {}),
+    ...(permissionMode ? { permissionMode } : {}),
+    ...(typeof permissionModeUpdatedAt === 'number' ? { permissionModeUpdatedAt } : {}),
+    ...(agentModeId ? { agentModeId } : {}),
+    ...(typeof agentModeUpdatedAt === 'number' ? { agentModeUpdatedAt } : {}),
+    ...(modelId ? { modelId } : {}),
+    ...(typeof modelUpdatedAt === 'number' ? { modelUpdatedAt } : {}),
+    ...(existingSessionId ? { existingSessionId } : {}),
+    ...(resume ? { resume } : {}),
+    ...(startingMode ? { startingMode } : {}),
+    ...(directory ? { directory } : {}),
+    helpRequested,
+    versionRequested,
+    providerArgs,
+  };
+}

--- a/apps/cli/src/cli/providerSessionArgPartition.ts
+++ b/apps/cli/src/cli/providerSessionArgPartition.ts
@@ -1,3 +1,12 @@
+/**
+ * Partitions Happier-owned session flags from provider-native CLI arguments.
+ *
+ * The parser validates shared session metadata such as permission modes,
+ * profiles, model hints, resume flags, and provider-specific aliases, then
+ * leaves unrecognized tokens in providerArgs for the provider executable.
+ * Invalid Happier-owned values use the CLI failure path so provider wrappers
+ * stop before launching a session with ambiguous intent.
+ */
 import chalk from 'chalk';
 
 import { isPermissionMode, type PermissionMode } from '@/api/types';
@@ -6,35 +15,35 @@ import {
   parsePermissionModeAlias as parsePermissionModeAliasShared,
 } from '@happier-dev/agents';
 
-export type ProviderSessionArgPartitionResult = Readonly<{
-  startedBy?: 'daemon' | 'terminal';
-  refreshSettings: boolean;
-  profileQuery?: string;
-  permissionMode?: PermissionMode;
-  permissionModeUpdatedAt?: number;
-  agentModeId?: string;
-  agentModeUpdatedAt?: number;
-  modelId?: string;
-  modelUpdatedAt?: number;
-  existingSessionId?: string;
-  resume?: string;
-  startingMode?: 'local' | 'remote' | string;
-  directory?: string;
-  providerArgs: string[];
-  helpRequested: boolean;
-  versionRequested: boolean;
-  versionFlag?: string;
-}>;
+export interface ProviderSessionArgPartitionResult {
+  readonly startedBy?: 'daemon' | 'terminal';
+  readonly refreshSettings: boolean;
+  readonly profileQuery?: string;
+  readonly permissionMode?: PermissionMode;
+  readonly permissionModeUpdatedAt?: number;
+  readonly agentModeId?: string;
+  readonly agentModeUpdatedAt?: number;
+  readonly modelId?: string;
+  readonly modelUpdatedAt?: number;
+  readonly existingSessionId?: string;
+  readonly resume?: string;
+  readonly startingMode?: 'local' | 'remote' | string;
+  readonly directory?: string;
+  readonly providerArgs: string[];
+  readonly helpRequested: boolean;
+  readonly versionRequested: boolean;
+  readonly versionFlag?: string;
+}
 
-export type ProviderSessionArgPartitionOptions = Readonly<{
-  args: readonly string[];
-  providerSubcommand?: string | null;
-  directoryFlags?: readonly string[];
-  forwardModelFlag?: boolean;
-  forwardResumeFlag?: boolean;
-  yoloProviderArgs?: readonly string[];
-  versionFlags?: readonly string[];
-}>;
+export interface ProviderSessionArgPartitionOptions {
+  readonly args: readonly string[];
+  readonly providerSubcommand?: string | null;
+  readonly directoryFlags?: readonly string[];
+  readonly forwardModelFlag?: boolean;
+  readonly forwardResumeFlag?: boolean;
+  readonly yoloProviderArgs?: readonly string[];
+  readonly versionFlags?: readonly string[];
+}
 
 const PERMISSION_MODE_EXAMPLES = [
   '--permission-mode read-only',
@@ -58,10 +67,14 @@ function readRequiredValue(args: readonly string[], index: number, label: string
     fail(`Missing value for ${label}`);
   }
   const value = args[index + 1];
-  if (typeof value !== 'string' || value.length === 0) {
+  if (typeof value !== 'string' || value.length === 0 || value.startsWith('-')) {
     fail(`Missing value for ${label}`);
   }
   return value;
+}
+
+function isNumericOptionValue(value: string | undefined): boolean {
+  return typeof value === 'string' && /^-?\d+$/.test(value.trim());
 }
 
 function readOptionalValue(args: readonly string[], index: number): string | undefined {
@@ -220,7 +233,7 @@ export function partitionProviderSessionArgs(options: ProviderSessionArgPartitio
       continue;
     }
     if (arg === '--account-settings-version-hint') {
-      if (readOptionalValue(args, i)) {
+      if (isNumericOptionValue(args[i + 1])) {
         i += 1;
       }
       continue;

--- a/apps/cli/src/cli/runBackendSessionCliCommand.test.ts
+++ b/apps/cli/src/cli/runBackendSessionCliCommand.test.ts
@@ -553,6 +553,39 @@ describe('runBackendSessionCliCommand', () => {
     }
   });
 
+  it('forwards provider subcommand context when showing combined help', async () => {
+    const root = join(tmpdir(), `happier-codex-subcommand-help-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    const codexPath = join(root, process.platform === 'win32' ? 'codex.cmd' : 'codex');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(codexPath, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n', 'utf8');
+    if (process.platform !== 'win32') chmodSync(codexPath, 0o755);
+    process.env.HAPPIER_CODEX_PATH = codexPath;
+    spawnSyncSpy.mockReturnValue({ status: 0, signal: null, error: undefined } as any);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const loadRun = vi.fn();
+
+    try {
+      await runBackendSessionCliCommand({
+        context: { args: ['codex', 'exec', '--help'], terminalRuntime: null } as any,
+        loadRun,
+        agentIdForAccountSettings: 'codex' as any,
+      });
+
+      expect(spawnSyncSpy).toHaveBeenCalledWith(
+        codexPath,
+        ['exec', '--help'],
+        expect.objectContaining({
+          stdio: 'inherit',
+          windowsHide: true,
+        }),
+      );
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('codex exec --help'));
+      expect(loadRun).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('short-circuits --version to the resolved provider CLI without auth or session startup', async () => {
     const root = join(tmpdir(), `happier-codex-version-${Date.now()}-${Math.random().toString(16).slice(2)}`);
     const codexPath = join(root, process.platform === 'win32' ? 'codex.cmd' : 'codex');
@@ -576,6 +609,43 @@ describe('runBackendSessionCliCommand', () => {
       expect(spawnSyncSpy).toHaveBeenCalledWith(
         codexPath,
         ['--version'],
+        expect.objectContaining({
+          stdio: 'inherit',
+          windowsHide: true,
+        }),
+      );
+      expect(loadRun).not.toHaveBeenCalled();
+      expect(readCredentialsSpy).not.toHaveBeenCalled();
+      expect(authSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('short-circuits Codex -V to the resolved provider CLI without auth or session startup', async () => {
+    const root = join(tmpdir(), `happier-codex-version-uppercase-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    const codexPath = join(root, process.platform === 'win32' ? 'codex.cmd' : 'codex');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(codexPath, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n', 'utf8');
+    if (process.platform !== 'win32') chmodSync(codexPath, 0o755);
+    process.env.HAPPIER_CODEX_PATH = codexPath;
+    spawnSyncSpy.mockReturnValue({ status: 0, signal: null, error: undefined } as any);
+
+    const readCredentialsSpy = vi.spyOn(persistenceModule, 'readCredentials').mockResolvedValue({ token: 'x' } as any);
+    const authSpy = vi.spyOn(authModule, 'authAndSetupMachineIfNeeded').mockResolvedValue({ credentials: { token: 'x' } } as any);
+    const loadRun = vi.fn();
+
+    try {
+      await runBackendSessionCliCommand({
+        context: { args: ['codex', '-V'], terminalRuntime: null } as any,
+        loadRun,
+        agentIdForAccountSettings: 'codex' as any,
+        versionFlags: ['-v', '-V', '--version'],
+      });
+
+      expect(spawnSyncSpy).toHaveBeenCalledWith(
+        codexPath,
+        ['-V'],
         expect.objectContaining({
           stdio: 'inherit',
           windowsHide: true,

--- a/apps/cli/src/cli/runBackendSessionCliCommand.test.ts
+++ b/apps/cli/src/cli/runBackendSessionCliCommand.test.ts
@@ -514,7 +514,7 @@ describe('runBackendSessionCliCommand', () => {
     }
   });
 
-  it('short-circuits --help to the resolved provider CLI without auth or session startup', async () => {
+  it('shows combined Happier and provider help without auth or session startup', async () => {
     const root = join(tmpdir(), `happier-codex-help-${Date.now()}-${Math.random().toString(16).slice(2)}`);
     const codexPath = join(root, process.platform === 'win32' ? 'codex.cmd' : 'codex');
     mkdirSync(root, { recursive: true });
@@ -522,6 +522,7 @@ describe('runBackendSessionCliCommand', () => {
     if (process.platform !== 'win32') chmodSync(codexPath, 0o755);
     process.env.HAPPIER_CODEX_PATH = codexPath;
     spawnSyncSpy.mockReturnValue({ status: 0, signal: null, error: undefined } as any);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     const readCredentialsSpy = vi.spyOn(persistenceModule, 'readCredentials').mockResolvedValue({ token: 'x' } as any);
     const authSpy = vi.spyOn(authModule, 'authAndSetupMachineIfNeeded').mockResolvedValue({ credentials: { token: 'x' } } as any);
@@ -542,6 +543,8 @@ describe('runBackendSessionCliCommand', () => {
           windowsHide: true,
         }),
       );
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('happier'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('codex CLI Options'));
       expect(loadRun).not.toHaveBeenCalled();
       expect(readCredentialsSpy).not.toHaveBeenCalled();
       expect(authSpy).not.toHaveBeenCalled();

--- a/apps/cli/src/cli/runBackendSessionCliCommand.ts
+++ b/apps/cli/src/cli/runBackendSessionCliCommand.ts
@@ -27,7 +27,7 @@ import { buildRootHelpText } from '@/cli/buildRootHelpText';
 import { acquireSessionRunnerLock } from '@/daemon/sessionRunnerLock';
 import { isInteractiveTerminal } from '@/terminal/prompts/promptInput';
 import { promptSecret } from '@/terminal/prompts/promptSecret';
-import { maybePassthroughProviderCliInfoRequest } from '@/cli/providerCliPassthrough';
+import { maybePassthroughProviderCliInfoRequest, passthroughProviderCliArgs } from '@/cli/providerCliPassthrough';
 import { selfMigrateDaemonSpawnedSessionProcessOutOfDaemonServiceCgroup } from '@/daemon/platform/linux/daemonSpawnedSessionCgroupSelfMigration';
 
 type CommonBackendRunOptions = ParsedSessionStartArgs & {
@@ -80,6 +80,7 @@ export async function runBackendSessionCliCommand<Extra extends Record<string, u
   loadAccountSettings?: boolean;
   directoryFlags?: readonly string[];
   forwardModelFlag?: boolean;
+  versionFlags?: readonly string[];
   resolveExtraOptions?: (args: string[], parsed: ProviderSessionArgPartitionResult) => Extra;
 }): Promise<void> {
   let releaseSessionRunnerLock: (() => Promise<void>) | null = null;
@@ -91,18 +92,21 @@ export async function runBackendSessionCliCommand<Extra extends Record<string, u
       providerSubcommand: agentId,
       directoryFlags: params.directoryFlags,
       forwardModelFlag: params.forwardModelFlag,
+      versionFlags: params.versionFlags,
     });
 
     if (agentId && parsed.helpRequested) {
+      const providerHelpArgs = [...parsed.providerArgs, '--help'];
+      const providerHelpCommand = `${agentId} ${providerHelpArgs.join(' ')}`;
       console.log(`${buildRootHelpText()}
 ${chalk.gray('─'.repeat(60))}
-${chalk.bold.cyan(`${agentId} CLI Options (from \`${agentId} --help\`):`)}
+${chalk.bold.cyan(`${agentId} CLI Options (from \`${providerHelpCommand}\`):`)}
 `);
-      maybePassthroughProviderCliInfoRequest({ agentId, args: ['--help'] });
+      passthroughProviderCliArgs({ agentId, providerArgs: providerHelpArgs });
       return;
     }
 
-    if (agentId && parsed.versionRequested && maybePassthroughProviderCliInfoRequest({ agentId, args: ['--version'] })) {
+    if (agentId && parsed.versionRequested && maybePassthroughProviderCliInfoRequest({ agentId, args: [parsed.versionFlag ?? '--version'] })) {
       return;
     }
 

--- a/apps/cli/src/cli/runBackendSessionCliCommand.ts
+++ b/apps/cli/src/cli/runBackendSessionCliCommand.ts
@@ -20,10 +20,10 @@ import { resolveProfileForAgent } from '@/settings/profiles/resolveProfileForAge
 import { isPermissionMode, type PermissionMode } from '@/api/types';
 import {
   applyDeprecatedSessionStartAliasesForAgent,
-  parseSessionStartArgs,
-  readOptionalFlagValue,
   type ParsedSessionStartArgs,
 } from '@/cli/sessionStartArgs';
+import { partitionProviderSessionArgs, type ProviderSessionArgPartitionResult } from '@/cli/providerSessionArgPartition';
+import { buildRootHelpText } from '@/cli/buildRootHelpText';
 import { acquireSessionRunnerLock } from '@/daemon/sessionRunnerLock';
 import { isInteractiveTerminal } from '@/terminal/prompts/promptInput';
 import { promptSecret } from '@/terminal/prompts/promptSecret';
@@ -35,6 +35,7 @@ type CommonBackendRunOptions = ParsedSessionStartArgs & {
   terminalRuntime: CommandContext['terminalRuntime'];
   existingSessionId: string | undefined;
   resume: string | undefined;
+  providerArgs: string[];
   accountSettingsContext: AccountSettingsContext | null;
   experimentalCodexAcp?: boolean;
   codexBackendMode?: CodexBackendMode;
@@ -59,38 +60,67 @@ function pickProviderRunOptions(extras: Record<string, unknown>): Pick<CommonBac
   return out;
 }
 
+function pickSessionStartArgs(parsed: ProviderSessionArgPartitionResult): ParsedSessionStartArgs {
+  return {
+    startedBy: parsed.startedBy,
+    permissionMode: parsed.permissionMode,
+    permissionModeUpdatedAt: parsed.permissionModeUpdatedAt,
+    agentModeId: parsed.agentModeId,
+    agentModeUpdatedAt: parsed.agentModeUpdatedAt,
+    modelId: parsed.modelId,
+    modelUpdatedAt: parsed.modelUpdatedAt,
+  };
+}
+
 export async function runBackendSessionCliCommand<Extra extends Record<string, unknown>>(params: {
   context: CommandContext;
   loadRun: () => Promise<(opts: CommonBackendRunOptions & Extra) => Promise<void>>;
   agentIdForDeprecatedAliases?: AgentId;
   agentIdForAccountSettings?: AgentId;
   loadAccountSettings?: boolean;
-  resolveExtraOptions?: (args: string[]) => Extra;
+  directoryFlags?: readonly string[];
+  forwardModelFlag?: boolean;
+  resolveExtraOptions?: (args: string[], parsed: ProviderSessionArgPartitionResult) => Extra;
 }): Promise<void> {
   let releaseSessionRunnerLock: (() => Promise<void>) | null = null;
 
   try {
     const agentId = params.agentIdForAccountSettings ?? params.agentIdForDeprecatedAliases;
-    if (agentId && maybePassthroughProviderCliInfoRequest({ agentId, args: params.context.args })) {
+    const parsed = partitionProviderSessionArgs({
+      args: params.context.args,
+      providerSubcommand: agentId,
+      directoryFlags: params.directoryFlags,
+      forwardModelFlag: params.forwardModelFlag,
+    });
+
+    if (agentId && parsed.helpRequested) {
+      console.log(`${buildRootHelpText()}
+${chalk.gray('─'.repeat(60))}
+${chalk.bold.cyan(`${agentId} CLI Options (from \`${agentId} --help\`):`)}
+`);
+      maybePassthroughProviderCliInfoRequest({ agentId, args: ['--help'] });
       return;
     }
 
-    const refreshSettings = params.context.args.includes('--refresh-settings');
+    if (agentId && parsed.versionRequested && maybePassthroughProviderCliInfoRequest({ agentId, args: ['--version'] })) {
+      return;
+    }
 
-    const parsed = parseSessionStartArgs(params.context.args);
+    const refreshSettings = parsed.refreshSettings;
+
+    const sessionStartArgs = pickSessionStartArgs(parsed);
     const resolved = params.agentIdForDeprecatedAliases
-      ? applyDeprecatedSessionStartAliasesForAgent({ agentId: params.agentIdForDeprecatedAliases, ...parsed })
-      : { ...parsed, warnings: [] as string[] };
+      ? applyDeprecatedSessionStartAliasesForAgent({ agentId: params.agentIdForDeprecatedAliases, ...sessionStartArgs })
+      : { ...sessionStartArgs, warnings: [] as string[] };
 
     for (const warning of resolved.warnings) {
       console.error(chalk.yellow(warning));
     }
 
-    const existingSessionId = readOptionalFlagValue(params.context.args, '--existing-session');
-    const resume = readOptionalFlagValue(params.context.args, '--resume');
-    const profileQueryRaw = readOptionalFlagValue(params.context.args, '--profile');
-    const profileQuery = typeof profileQueryRaw === 'string' ? profileQueryRaw.trim() : '';
-    const extraOptions = params.resolveExtraOptions ? params.resolveExtraOptions(params.context.args) : ({} as Extra);
+    const existingSessionId = parsed.existingSessionId;
+    const resume = parsed.resume;
+    const profileQuery = parsed.profileQuery ?? '';
+    const extraOptions = params.resolveExtraOptions ? params.resolveExtraOptions(params.context.args, parsed) : ({} as Extra);
     const startedBy = resolved.startedBy ?? 'terminal';
 
     const selfMigration = await selfMigrateDaemonSpawnedSessionProcessOutOfDaemonServiceCgroup();
@@ -207,6 +237,7 @@ export async function runBackendSessionCliCommand<Extra extends Record<string, u
       modelUpdatedAt: resolved.modelUpdatedAt,
       existingSessionId: normalizedExistingSessionId || undefined,
       resume,
+      providerArgs: parsed.providerArgs,
       accountSettingsContext,
       ...providerSpawnExtras,
       ...extraOptions,

--- a/apps/cli/src/cli/sessionStartArgs.test.ts
+++ b/apps/cli/src/cli/sessionStartArgs.test.ts
@@ -49,12 +49,12 @@ describe('parseSessionStartArgs', () => {
 
   it('accepts bypass-permissions as bypassPermissions', () => {
     const parsed = parseWithTrap(['happier', '--permission-mode', 'bypass-permissions']);
-    expect(parsed.permissionMode).toBe('yolo');
+    expect(parsed.permissionMode).toBe('bypassPermissions');
   });
 
   it('accepts accept-edits as acceptEdits', () => {
     const parsed = parseWithTrap(['happier', '--permission-mode', 'accept-edits']);
-    expect(parsed.permissionMode).toBe('safe-yolo');
+    expect(parsed.permissionMode).toBe('acceptEdits');
   });
 
   it('accepts ask as default', () => {

--- a/apps/cli/src/cli/sessionStartArgs.ts
+++ b/apps/cli/src/cli/sessionStartArgs.ts
@@ -1,11 +1,6 @@
-import chalk from 'chalk';
-import { isPermissionMode, type PermissionMode } from '@/api/types';
-import {
-  PERMISSION_INTENTS,
-  getAgentSessionModesKind,
-  parsePermissionIntentAlias as parsePermissionIntentAliasShared,
-  type AgentId,
-} from '@happier-dev/agents';
+import type { PermissionMode } from '@/api/types';
+import { getAgentSessionModesKind, type AgentId } from '@happier-dev/agents';
+import { partitionProviderSessionArgs } from '@/cli/providerSessionArgPartition';
 
 export type ParsedSessionStartArgs = {
   startedBy: 'daemon' | 'terminal' | undefined;
@@ -17,135 +12,20 @@ export type ParsedSessionStartArgs = {
   modelUpdatedAt: number | undefined;
 };
 
-const PERMISSION_MODE_EXAMPLES = [
-  '--permission-mode read-only',
-  '--permission-mode yolo',
-  '--permission-mode accept-edits',
-] as const;
-
-function parsePermissionModeAlias(raw: string): PermissionMode | null {
-  const parsed = parsePermissionIntentAliasShared(raw);
-  if (!parsed) return null;
-  // Defensive: keep CLI's PermissionMode as the gate until the type is fully unified.
-  return isPermissionMode(parsed) ? parsed : null;
-}
-
 export function parseSessionStartArgs(args: string[]): ParsedSessionStartArgs {
-  let startedBy: 'daemon' | 'terminal' | undefined = undefined;
-  let permissionMode: PermissionMode | undefined = undefined;
-  let permissionModeUpdatedAt: number | undefined = undefined;
-  let agentModeId: string | undefined = undefined;
-  let agentModeUpdatedAt: number | undefined = undefined;
-  let modelId: string | undefined = undefined;
-  let modelUpdatedAt: number | undefined = undefined;
+  const parsed = partitionProviderSessionArgs({
+    args: args[0] === 'happier' ? args.slice(1) : args,
+  });
 
-  for (let i = 1; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === '--started-by') {
-      if (i + 1 >= args.length) {
-        console.error(chalk.red('Missing value for --started-by (expected: daemon|terminal)'));
-        process.exit(1);
-      }
-      const value = args[++i];
-      if (value !== 'daemon' && value !== 'terminal') {
-        console.error(chalk.red(`Invalid --started-by value: ${value}. Expected: daemon|terminal`));
-        process.exit(1);
-      }
-      startedBy = value;
-    } else if (arg === '--permission-mode') {
-      if (i + 1 >= args.length) {
-        console.error(
-          chalk.red(
-            `Missing value for --permission-mode. Valid values: ${PERMISSION_INTENTS.join(', ')}. Examples: ${PERMISSION_MODE_EXAMPLES.join(
-              ' | ',
-            )}`,
-          ),
-        );
-        process.exit(1);
-      }
-      const value = args[++i];
-      const parsed = parsePermissionModeAlias(value);
-      if (!parsed) {
-        console.error(
-          chalk.red(
-            `Invalid --permission-mode value: ${value}. Valid values: ${PERMISSION_INTENTS.join(', ')}. Examples: ${PERMISSION_MODE_EXAMPLES.join(
-              ' | ',
-            )}`,
-          ),
-        );
-        process.exit(1);
-      }
-      permissionMode = parsed;
-    } else if (arg === '--permission-mode-updated-at') {
-      if (i + 1 >= args.length) {
-        console.error(chalk.red('Missing value for --permission-mode-updated-at (expected: unix ms timestamp)'));
-        process.exit(1);
-      }
-      const raw = args[++i];
-      const parsedAt = Number(raw);
-      if (!Number.isFinite(parsedAt) || parsedAt <= 0) {
-        console.error(chalk.red(`Invalid --permission-mode-updated-at value: ${raw}. Expected a positive number (unix ms)`));
-        process.exit(1);
-      }
-      permissionModeUpdatedAt = Math.floor(parsedAt);
-    } else if (arg === '--agent-mode') {
-      if (i + 1 >= args.length) {
-        console.error(chalk.red('Missing value for --agent-mode (expected: ACP session mode id)'));
-        process.exit(1);
-      }
-      const raw = args[++i];
-      const normalized = typeof raw === 'string' ? raw.trim() : '';
-      if (!normalized) {
-        console.error(chalk.red('Invalid --agent-mode value: empty'));
-        process.exit(1);
-      }
-      agentModeId = normalized;
-    } else if (arg === '--agent-mode-updated-at') {
-      if (i + 1 >= args.length) {
-        console.error(chalk.red('Missing value for --agent-mode-updated-at (expected: unix ms timestamp)'));
-        process.exit(1);
-      }
-      const raw = args[++i];
-      const parsedAt = Number(raw);
-      if (!Number.isFinite(parsedAt) || parsedAt <= 0) {
-        console.error(chalk.red(`Invalid --agent-mode-updated-at value: ${raw}. Expected a positive number (unix ms)`));
-        process.exit(1);
-      }
-      agentModeUpdatedAt = Math.floor(parsedAt);
-    } else if (arg === '--model') {
-      if (i + 1 >= args.length) {
-        console.error(chalk.red('Missing value for --model (expected: model id)'));
-        process.exit(1);
-      }
-      const raw = args[++i];
-      const normalized = typeof raw === 'string' ? raw.trim() : '';
-      if (!normalized) {
-        console.error(chalk.red('Invalid --model value: empty'));
-        process.exit(1);
-      }
-      modelId = normalized;
-    } else if (arg === '--model-updated-at') {
-      if (i + 1 >= args.length) {
-        console.error(chalk.red('Missing value for --model-updated-at (expected: unix ms timestamp)'));
-        process.exit(1);
-      }
-      const raw = args[++i];
-      const parsedAt = Number(raw);
-      if (!Number.isFinite(parsedAt) || parsedAt <= 0) {
-        console.error(chalk.red(`Invalid --model-updated-at value: ${raw}. Expected a positive number (unix ms)`));
-        process.exit(1);
-      }
-      modelUpdatedAt = Math.floor(parsedAt);
-    } else if (arg === '--account-settings-version-hint') {
-      if (i + 1 < args.length && !args[i + 1]?.startsWith('-')) {
-        i += 1;
-      }
-    } else if (arg === '--yolo') {
-      permissionMode = 'yolo';
-    }
-  }
-
-  return { startedBy, permissionMode, permissionModeUpdatedAt, agentModeId, agentModeUpdatedAt, modelId, modelUpdatedAt };
+  return {
+    startedBy: parsed.startedBy,
+    permissionMode: parsed.permissionMode,
+    permissionModeUpdatedAt: parsed.permissionModeUpdatedAt,
+    agentModeId: parsed.agentModeId,
+    agentModeUpdatedAt: parsed.agentModeUpdatedAt,
+    modelId: parsed.modelId,
+    modelUpdatedAt: parsed.modelUpdatedAt,
+  };
 }
 
 export function readOptionalFlagValue(args: string[], flag: string): string | undefined {

--- a/apps/stack/scripts/testkit/core/env_scope.mjs
+++ b/apps/stack/scripts/testkit/core/env_scope.mjs
@@ -71,8 +71,12 @@ export function filterEnvForSpawn(env = process.env, { keepKeys = [], keepPrefix
 }
 
 export function withPatchedProcessEnv(t, overrides = {}) {
+  const effectiveOverrides =
+    process.platform === 'win32' && Object.prototype.hasOwnProperty.call(overrides, 'PATH')
+      ? { ...overrides, Path: overrides.PATH }
+      : overrides;
   const previous = new Map();
-  for (const [key, value] of Object.entries(overrides)) {
+  for (const [key, value] of Object.entries(effectiveOverrides)) {
     previous.set(key, Object.prototype.hasOwnProperty.call(process.env, key) ? process.env[key] : undefined);
     if (value == null) delete process.env[key];
     else process.env[key] = String(value);

--- a/apps/stack/scripts/testkit/core/expo_command_shims.mjs
+++ b/apps/stack/scripts/testkit/core/expo_command_shims.mjs
@@ -1,0 +1,29 @@
+import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function writeExpoShimPairCaptureInvocation({ binDir, outputPath }) {
+  await mkdir(binDir, { recursive: true });
+
+  const expoPath = join(binDir, 'expo');
+  await writeFile(
+    expoPath,
+    [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'echo "shim=posix bin=$0 args=$*" >> "${OUTPUT_PATH:?}"',
+      'exit 0',
+    ].join('\n') + '\n',
+    'utf-8',
+  );
+  await chmod(expoPath, 0o755);
+
+  await writeFile(
+    join(binDir, 'expo.cmd'),
+    [
+      '@echo off',
+      `echo shim=cmd bin=%~f0 args=%*>>"${outputPath}"`,
+      'exit /b 0',
+    ].join('\r\n') + '\r\n',
+    'utf-8',
+  );
+}

--- a/apps/stack/scripts/testkit/core/expo_command_shims.mjs
+++ b/apps/stack/scripts/testkit/core/expo_command_shims.mjs
@@ -10,7 +10,7 @@ export async function writeExpoShimPairCaptureInvocation({ binDir, outputPath })
     [
       '#!/usr/bin/env bash',
       'set -euo pipefail',
-      'echo "shim=posix bin=$0 args=$*" >> "${OUTPUT_PATH:?}"',
+      `echo "shim=posix bin=$0 args=$*" >> ${JSON.stringify(outputPath)}`,
       'exit 0',
     ].join('\n') + '\n',
     'utf-8',

--- a/apps/stack/scripts/utils/expo/command.mjs
+++ b/apps/stack/scripts/utils/expo/command.mjs
@@ -12,11 +12,15 @@ const DEFAULT_EXPO_EXPORT_MAX_WORKERS_NONINTERACTIVE = 1;
 
 async function resolveExpoBin(runnerDir) {
   const workspaceBin = join(runnerDir, 'node_modules', '.bin', 'expo');
+  const workspaceCmdBin = `${workspaceBin}.cmd`;
+  if (process.platform === 'win32' && (await pathExists(workspaceCmdBin))) return workspaceCmdBin;
   if (await pathExists(workspaceBin)) return workspaceBin;
 
   const monorepoRoot = coerceHappyMonorepoRootFromPath(runnerDir);
   if (monorepoRoot) {
     const rootBin = join(monorepoRoot, 'node_modules', '.bin', 'expo');
+    const rootCmdBin = `${rootBin}.cmd`;
+    if (process.platform === 'win32' && (await pathExists(rootCmdBin))) return rootCmdBin;
     if (await pathExists(rootBin)) return rootBin;
   }
 

--- a/apps/stack/scripts/utils/expo/command_heap_limit_env.test.mjs
+++ b/apps/stack/scripts/utils/expo/command_heap_limit_env.test.mjs
@@ -278,7 +278,7 @@ test('expoExec prefers the Windows cmd shim when both Expo shims exist', async (
 
   withPatchedProcessEnv(t, {
     PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
-    OUTPUT_PATH: outputPath,
+    OUTPUT_PATH: null,
     HAPPIER_STACK_SKIP_REFRESH_DEPS: '1',
     HAPPIER_STACK_ENV_FILE: null,
   });

--- a/apps/stack/scripts/utils/expo/command_heap_limit_env.test.mjs
+++ b/apps/stack/scripts/utils/expo/command_heap_limit_env.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 
 import { expoExec, expoSpawn } from './command.mjs';
 
@@ -30,6 +30,20 @@ async function writeYarnStub({ binDir }) {
     'utf-8'
   );
   await chmod(yarnPath, 0o755);
+
+  const yarnCmdPath = join(binDir, 'yarn.cmd');
+  await writeFile(
+    yarnCmdPath,
+    [
+      '@echo off',
+      'if "%~1"=="--version" (',
+      '  echo 1.22.22',
+      '  exit /b 0',
+      ')',
+      'exit /b 0',
+    ].join('\r\n') + '\r\n',
+    'utf-8'
+  );
 }
 
 async function writeExpoStubCaptureNodeOptions({ expoPath }) {
@@ -54,11 +68,55 @@ async function writeExpoStubCaptureNodeOptions({ expoPath }) {
     'utf-8'
   );
   await chmod(expoPath, 0o755);
+
+  await writeFile(
+    `${expoPath}.cmd`,
+    [
+      '@echo off',
+      'echo NODE_OPTIONS=%NODE_OPTIONS%>>"%OUTPUT_PATH%"',
+      'if not "%EXPECT_MAX_OLD_SPACE_SIZE%"=="" (',
+      '  echo %NODE_OPTIONS% | findstr /C:"--max-old-space-size=%EXPECT_MAX_OLD_SPACE_SIZE%" >nul',
+      '  if errorlevel 1 exit /b 11',
+      ')',
+      'exit /b 0',
+    ].join('\r\n') + '\r\n',
+    'utf-8'
+  );
+}
+
+async function writeExpoShimPairCaptureInvocation({ binDir, outputPath }) {
+  await mkdir(binDir, { recursive: true });
+
+  const expoPath = join(binDir, 'expo');
+  await writeFile(
+    expoPath,
+    [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'echo "shim=posix bin=$0 args=$*" >> "${OUTPUT_PATH:?}"',
+      'exit 0',
+    ].join('\n') + '\n',
+    'utf-8'
+  );
+  await chmod(expoPath, 0o755);
+
+  await writeFile(
+    join(binDir, 'expo.cmd'),
+    [
+      '@echo off',
+      `echo shim=cmd bin=%~f0 args=%*>>"${outputPath}"`,
+      'exit /b 0',
+    ].join('\r\n') + '\r\n',
+    'utf-8'
+  );
 }
 
 function applyEnvOverrides(t, vars) {
+  const effectiveVars = process.platform === 'win32' && Object.prototype.hasOwnProperty.call(vars, 'PATH')
+    ? { ...vars, Path: vars.PATH }
+    : vars;
   const previous = {};
-  for (const key of Object.keys(vars)) {
+  for (const key of Object.keys(effectiveVars)) {
     previous[key] = process.env[key];
   }
   t.after(() => {
@@ -67,7 +125,7 @@ function applyEnvOverrides(t, vars) {
       else process.env[key] = value;
     }
   });
-  for (const [key, value] of Object.entries(vars)) {
+  for (const [key, value] of Object.entries(effectiveVars)) {
     if (value == null) delete process.env[key];
     else process.env[key] = String(value);
   }
@@ -102,7 +160,7 @@ test('expoExec defaults Expo heap limit to 8192MB (unless overridden)', async (t
   await writeExpoStubCaptureNodeOptions({ expoPath });
 
   applyEnvOverrides(t, {
-    PATH: `${binDir}:/usr/bin:/bin`,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     EXPECT_MAX_OLD_SPACE_SIZE: '8192',
     HAPPIER_STACK_EXPO_MAX_OLD_SPACE_SIZE_MB: null,
@@ -140,7 +198,7 @@ test('expoExec honors HAPPIER_STACK_EXPO_MAX_OLD_SPACE_SIZE_MB override', async 
   await writeExpoStubCaptureNodeOptions({ expoPath });
 
   applyEnvOverrides(t, {
-    PATH: `${binDir}:/usr/bin:/bin`,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     EXPECT_MAX_OLD_SPACE_SIZE: '4096',
     HAPPIER_STACK_EXPO_MAX_OLD_SPACE_SIZE_MB: '4096',
@@ -178,7 +236,7 @@ test('expoExec overrides NODE_OPTIONS --max-old-space-size unless explicitly ove
   await writeExpoStubCaptureNodeOptions({ expoPath });
 
   applyEnvOverrides(t, {
-    PATH: `${binDir}:/usr/bin:/bin`,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     EXPECT_MAX_OLD_SPACE_SIZE: '8192',
     HAPPIER_STACK_EXPO_MAX_OLD_SPACE_SIZE_MB: null,
@@ -217,7 +275,7 @@ test('expoSpawn applies the same heap limit behavior', async (t) => {
   await writeExpoStubCaptureNodeOptions({ expoPath });
 
   applyEnvOverrides(t, {
-    PATH: `${binDir}:/usr/bin:/bin`,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     EXPECT_MAX_OLD_SPACE_SIZE: '8192',
     HAPPIER_STACK_EXPO_MAX_OLD_SPACE_SIZE_MB: null,
@@ -241,4 +299,47 @@ test('expoSpawn applies the same heap limit behavior', async (t) => {
 
   const logged = await readFile(outputPath, 'utf-8');
   assert.match(logged, /--max-old-space-size=8192/);
+});
+
+test('expoExec prefers the Windows cmd shim when both Expo shims exist', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'hs-expo-windows-cmd-shim-'));
+  t.after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  await writeMinimalRepo({ root });
+  await mkdir(join(root, 'node_modules'), { recursive: true });
+  await mkdir(join(root, 'apps', 'ui', 'node_modules'), { recursive: true });
+
+  const binDir = join(root, 'bin');
+  await writeYarnStub({ binDir });
+
+  const outputPath = join(root, 'expo-invocation.txt');
+  await writeFile(outputPath, '', 'utf-8');
+  await writeExpoShimPairCaptureInvocation({
+    binDir: join(root, 'apps', 'ui', 'node_modules', '.bin'),
+    outputPath,
+  });
+
+  applyEnvOverrides(t, {
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+    OUTPUT_PATH: outputPath,
+    HAPPIER_STACK_SKIP_REFRESH_DEPS: '1',
+    HAPPIER_STACK_ENV_FILE: null,
+  });
+
+  await expoExec({
+    dir: join(root, 'apps', 'ui'),
+    projectDir: join(root, 'apps', 'ui'),
+    args: ['--help'],
+    env: process.env,
+    quiet: true,
+  });
+
+  const logged = await readFile(outputPath, 'utf-8');
+  if (process.platform === 'win32') {
+    assert.match(logged, /shim=cmd/);
+  } else {
+    assert.match(logged, /shim=posix/);
+  }
 });

--- a/apps/stack/scripts/utils/expo/command_heap_limit_env.test.mjs
+++ b/apps/stack/scripts/utils/expo/command_heap_limit_env.test.mjs
@@ -4,6 +4,8 @@ import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 
+import { writeExpoShimPairCaptureInvocation } from '../../testkit/core/expo_command_shims.mjs';
+import { withPatchedProcessEnv } from '../../testkit/core/env_scope.mjs';
 import { expoExec, expoSpawn } from './command.mjs';
 
 async function writeJson(path, value) {
@@ -84,53 +86,6 @@ async function writeExpoStubCaptureNodeOptions({ expoPath }) {
   );
 }
 
-async function writeExpoShimPairCaptureInvocation({ binDir, outputPath }) {
-  await mkdir(binDir, { recursive: true });
-
-  const expoPath = join(binDir, 'expo');
-  await writeFile(
-    expoPath,
-    [
-      '#!/usr/bin/env bash',
-      'set -euo pipefail',
-      'echo "shim=posix bin=$0 args=$*" >> "${OUTPUT_PATH:?}"',
-      'exit 0',
-    ].join('\n') + '\n',
-    'utf-8'
-  );
-  await chmod(expoPath, 0o755);
-
-  await writeFile(
-    join(binDir, 'expo.cmd'),
-    [
-      '@echo off',
-      `echo shim=cmd bin=%~f0 args=%*>>"${outputPath}"`,
-      'exit /b 0',
-    ].join('\r\n') + '\r\n',
-    'utf-8'
-  );
-}
-
-function applyEnvOverrides(t, vars) {
-  const effectiveVars = process.platform === 'win32' && Object.prototype.hasOwnProperty.call(vars, 'PATH')
-    ? { ...vars, Path: vars.PATH }
-    : vars;
-  const previous = {};
-  for (const key of Object.keys(effectiveVars)) {
-    previous[key] = process.env[key];
-  }
-  t.after(() => {
-    for (const [key, value] of Object.entries(previous)) {
-      if (value == null) delete process.env[key];
-      else process.env[key] = value;
-    }
-  });
-  for (const [key, value] of Object.entries(effectiveVars)) {
-    if (value == null) delete process.env[key];
-    else process.env[key] = String(value);
-  }
-}
-
 async function writeMinimalRepo({ root }) {
   await mkdir(join(root, 'apps', 'ui'), { recursive: true });
   await mkdir(join(root, 'apps', 'cli'), { recursive: true });
@@ -159,7 +114,7 @@ test('expoExec defaults Expo heap limit to 8192MB (unless overridden)', async (t
   const expoPath = join(root, 'node_modules', '.bin', 'expo');
   await writeExpoStubCaptureNodeOptions({ expoPath });
 
-  applyEnvOverrides(t, {
+  withPatchedProcessEnv(t, {
     PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     EXPECT_MAX_OLD_SPACE_SIZE: '8192',
@@ -197,7 +152,7 @@ test('expoExec honors HAPPIER_STACK_EXPO_MAX_OLD_SPACE_SIZE_MB override', async 
   const expoPath = join(root, 'node_modules', '.bin', 'expo');
   await writeExpoStubCaptureNodeOptions({ expoPath });
 
-  applyEnvOverrides(t, {
+  withPatchedProcessEnv(t, {
     PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     EXPECT_MAX_OLD_SPACE_SIZE: '4096',
@@ -235,7 +190,7 @@ test('expoExec overrides NODE_OPTIONS --max-old-space-size unless explicitly ove
   const expoPath = join(root, 'node_modules', '.bin', 'expo');
   await writeExpoStubCaptureNodeOptions({ expoPath });
 
-  applyEnvOverrides(t, {
+  withPatchedProcessEnv(t, {
     PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     EXPECT_MAX_OLD_SPACE_SIZE: '8192',
@@ -274,7 +229,7 @@ test('expoSpawn applies the same heap limit behavior', async (t) => {
   const expoPath = join(root, 'node_modules', '.bin', 'expo');
   await writeExpoStubCaptureNodeOptions({ expoPath });
 
-  applyEnvOverrides(t, {
+  withPatchedProcessEnv(t, {
     PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     EXPECT_MAX_OLD_SPACE_SIZE: '8192',
@@ -321,7 +276,7 @@ test('expoExec prefers the Windows cmd shim when both Expo shims exist', async (
     outputPath,
   });
 
-  applyEnvOverrides(t, {
+  withPatchedProcessEnv(t, {
     PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     HAPPIER_STACK_SKIP_REFRESH_DEPS: '1',

--- a/apps/stack/scripts/utils/expo/command_workspace_deps_built.test.mjs
+++ b/apps/stack/scripts/utils/expo/command_workspace_deps_built.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 
 import { expoExec } from './command.mjs';
 
@@ -43,6 +43,30 @@ async function writeYarnStub({ binDir, outputPath }) {
     'utf-8',
   );
   await chmod(yarnPath, 0o755);
+  await writeFile(
+    join(binDir, 'yarn.cmd'),
+    [
+      '@echo off',
+      'echo %CD% :: %*>>"%OUTPUT_PATH%"',
+      'if "%~1"=="--version" (',
+      '  echo 1.22.22',
+      '  exit /b 0',
+      ')',
+      'if "%~1"=="install" exit /b 0',
+      'if "%~1"=="-s" if "%~2"=="build" (',
+      '  if /I "%CD%"=="' + join(binDir, '..', 'packages', 'protocol') + '" (',
+      '    if not exist dist mkdir dist',
+      "    >dist\\index.js echo export const ok = true;",
+      "    >dist\\rpcErrors.js echo export const ok = true;",
+      "    >dist\\index.d.ts echo export declare const ok: boolean;",
+      "    >dist\\rpcErrors.d.ts echo export declare const ok: boolean;",
+      '  )',
+      '  exit /b 0',
+      ')',
+      'exit /b 0',
+    ].join('\r\n') + '\r\n',
+    'utf-8',
+  );
   await writeFile(outputPath, '', 'utf-8');
 }
 
@@ -64,6 +88,18 @@ async function writeExpoStub({ expoPath }) {
     'utf-8',
   );
   await chmod(expoPath, 0o755);
+  await writeFile(
+    `${expoPath}.cmd`,
+    [
+      '@echo off',
+      'if not exist "..\\..\\packages\\protocol\\dist\\rpcErrors.js" (',
+      '  echo missing ..\\..\\packages\\protocol\\dist\\rpcErrors.js 1>&2',
+      '  exit /b 3',
+      ')',
+      'exit /b 0',
+    ].join('\r\n') + '\r\n',
+    'utf-8',
+  );
 }
 
 async function writeExpoStubCaptureCwd({ expoPath }) {
@@ -86,6 +122,19 @@ async function writeExpoStubCaptureCwd({ expoPath }) {
     'utf-8',
   );
   await chmod(expoPath, 0o755);
+  await writeFile(
+    `${expoPath}.cmd`,
+    [
+      '@echo off',
+      'echo expo:cwd=%CD% bin=%~f0 args=%*>>"%OUTPUT_PATH%"',
+      'if not exist "..\\..\\packages\\protocol\\dist\\rpcErrors.js" (',
+      '  echo missing ..\\..\\packages\\protocol\\dist\\rpcErrors.js 1>&2',
+      '  exit /b 3',
+      ')',
+      'exit /b 0',
+    ].join('\r\n') + '\r\n',
+    'utf-8',
+  );
 }
 
 function escapeRegExp(value) {
@@ -93,8 +142,11 @@ function escapeRegExp(value) {
 }
 
 function applyEnvOverrides(t, vars) {
+  const effectiveVars = process.platform === 'win32' && Object.prototype.hasOwnProperty.call(vars, 'PATH')
+    ? { ...vars, Path: vars.PATH }
+    : vars;
   const previous = {};
-  for (const key of Object.keys(vars)) {
+  for (const key of Object.keys(effectiveVars)) {
     previous[key] = process.env[key];
   }
   t.after(() => {
@@ -103,7 +155,7 @@ function applyEnvOverrides(t, vars) {
       else process.env[key] = value;
     }
   });
-  for (const [key, value] of Object.entries(vars)) {
+  for (const [key, value] of Object.entries(effectiveVars)) {
     if (value == null) delete process.env[key];
     else process.env[key] = String(value);
   }
@@ -157,7 +209,7 @@ test('expoExec builds workspace dist deps for the projectDir (not the runnerDir)
   await writeExpoStub({ expoPath });
 
   applyEnvOverrides(t, {
-    PATH: `${binDir}:/usr/bin:/bin`,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     HAPPIER_STACK_ENV_FILE: null,
   });
@@ -227,7 +279,7 @@ test('expoExec falls back to the monorepo root expo bin when runnerDir lacks nod
   await writeExpoStubCaptureCwd({ expoPath });
 
   applyEnvOverrides(t, {
-    PATH: `${binDir}:/usr/bin:/bin`,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     HAPPIER_STACK_ENV_FILE: null,
   });
@@ -245,6 +297,6 @@ test('expoExec falls back to the monorepo root expo bin when runnerDir lacks nod
   assert.match(argvLog, /expo:cwd=/);
   // macOS can report tmp paths via `/private/var/...` even if `mkdtemp()` returns `/var/...`.
   // Only assert stable suffixes.
-  assert.match(argvLog, /expo:cwd=.*\/apps\/ui\b/);
-  assert.match(argvLog, /bin=.*\/node_modules\/\.bin\/expo\b/);
+  assert.match(argvLog, /expo:cwd=.*[\\/]apps[\\/]ui\b/);
+  assert.match(argvLog, /bin=.*[\\/]node_modules[\\/]\.bin[\\/]expo(?:\.cmd)?\b/);
 });

--- a/apps/stack/scripts/utils/expo/command_workspace_deps_built.test.mjs
+++ b/apps/stack/scripts/utils/expo/command_workspace_deps_built.test.mjs
@@ -4,6 +4,7 @@ import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 
+import { withPatchedProcessEnv } from '../../testkit/core/env_scope.mjs';
 import { expoExec } from './command.mjs';
 
 async function writeJson(path, value) {
@@ -141,26 +142,6 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function applyEnvOverrides(t, vars) {
-  const effectiveVars = process.platform === 'win32' && Object.prototype.hasOwnProperty.call(vars, 'PATH')
-    ? { ...vars, Path: vars.PATH }
-    : vars;
-  const previous = {};
-  for (const key of Object.keys(effectiveVars)) {
-    previous[key] = process.env[key];
-  }
-  t.after(() => {
-    for (const [key, value] of Object.entries(previous)) {
-      if (value == null) delete process.env[key];
-      else process.env[key] = value;
-    }
-  });
-  for (const [key, value] of Object.entries(effectiveVars)) {
-    if (value == null) delete process.env[key];
-    else process.env[key] = String(value);
-  }
-}
-
 test('expoExec builds workspace dist deps for the projectDir (not the runnerDir)', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'hs-expo-workspace-deps-built-'));
   t.after(async () => {
@@ -208,7 +189,7 @@ test('expoExec builds workspace dist deps for the projectDir (not the runnerDir)
   const expoPath = join(root, 'node_modules', '.bin', 'expo');
   await writeExpoStub({ expoPath });
 
-  applyEnvOverrides(t, {
+  withPatchedProcessEnv(t, {
     PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     HAPPIER_STACK_ENV_FILE: null,
@@ -278,7 +259,7 @@ test('expoExec falls back to the monorepo root expo bin when runnerDir lacks nod
   const expoPath = join(root, 'node_modules', '.bin', 'expo');
   await writeExpoStubCaptureCwd({ expoPath });
 
-  applyEnvOverrides(t, {
+  withPatchedProcessEnv(t, {
     PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
     OUTPUT_PATH: outputPath,
     HAPPIER_STACK_ENV_FILE: null,

--- a/packages/agents/src/manifest.ts
+++ b/packages/agents/src/manifest.ts
@@ -54,7 +54,6 @@ export const AGENTS_CORE = {
                 openai: ['token'],
             },
         },
-        nativeCliPassthroughSubcommands: ['resume', 'fork'],
         resume: { vendorResume: 'experimental', vendorResumeIdField: 'codexSessionId' },
         sessionStorage: { direct: true, persisted: true },
         sessionCapabilities: {

--- a/packages/agents/src/manifest.ts
+++ b/packages/agents/src/manifest.ts
@@ -54,6 +54,7 @@ export const AGENTS_CORE = {
                 openai: ['token'],
             },
         },
+        nativeCliPassthroughSubcommands: ['resume', 'fork'],
         resume: { vendorResume: 'experimental', vendorResumeIdField: 'codexSessionId' },
         sessionStorage: { direct: true, persisted: true },
         sessionCapabilities: {

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -141,5 +141,10 @@ export type AgentCore = Readonly<{
        */
       supportedKindsByServiceId?: Readonly<Partial<Record<ConnectedServiceId, ReadonlyArray<ConnectedServiceKind>>>>;
     }> | null;
+    /**
+     * Native provider CLI subcommands that Happier should pass through before
+     * invoking its own provider command handler.
+     */
+    nativeCliPassthroughSubcommands?: ReadonlyArray<string>;
     runtimeKinds?: AnyAgentRuntimeKindsManifest | null;
 }> & AgentCoreRuntimeControlSurface;

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -141,10 +141,5 @@ export type AgentCore = Readonly<{
        */
       supportedKindsByServiceId?: Readonly<Partial<Record<ConnectedServiceId, ReadonlyArray<ConnectedServiceKind>>>>;
     }> | null;
-    /**
-     * Native provider CLI subcommands that Happier should pass through before
-     * invoking its own provider command handler.
-     */
-    nativeCliPassthroughSubcommands?: ReadonlyArray<string>;
     runtimeKinds?: AnyAgentRuntimeKindsManifest | null;
 }> & AgentCoreRuntimeControlSurface;


### PR DESCRIPTION
## Summary
- add Codex app-server runtime support for native thread title sync
- add generalized provider passthrough handling for native Codex and Claude commands
- forward provider-native Codex args through initial and resumed local launch paths
- harden Happier-owned argument parsing and Windows Expo shim test helpers

## Validation
- Passed: `yarn workspace @happier-dev/cli vitest run src/cli/providerSessionArgPartition.test.ts src/backends/codex/cli/command.test.ts src/backends/claude/cli/command.help.test.ts`
- Passed: `yarn workspace @happier-dev/cli vitest run src/backends/codex/codexLocalLauncher.integration.test.ts --config vitest.integration.config.ts`
- Passed: `yarn workspace @happier-dev/cli vitest run src/backends/codex/runCodex.fastStart.integration.test.ts --config vitest.integration.config.ts`
- Passed: `node --test apps/stack/scripts/utils/expo/command_heap_limit_env.test.mjs`
- Passed: `yarn workspace @happier-dev/cli typecheck`
- Passed: `git diff --check`
- Broader note: `yarn workspace @happier-dev/cli test:integration src/backends/codex/codexLocalLauncher.integration.test.ts` runs the sharded integration lane, not just the requested file. The Codex launcher file passed, but that broad shard run surfaced unrelated Claude integration failures in `claudeLocalLauncher.integration.test.ts` and `runClaude.fastStart.integration.test.ts`.

## Notes
- Head branch: `jiuchuanll:ll-dev-fixAndOptimize-0505`
- Base branch: `dev`
- Follow-up commit pushed: `ab93fcc866cf4ad6a8c27fbff68a4b2bfb251f6c`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native thread title sync for Happier "change title" tool calls; CLI argument partitioning and provider-arg forwarding; codex launcher/run paths now accept and forward codexArgs and resume IDs.
* **Bug Fixes**
  * Avoids syncing blank/failed titles; improved remote-switch handling for fresh-remote flows; better Windows command/shim selection and PATH handling.
* **Tests**
  * Numerous new and extended tests for title sync, launcher behavior, provider CLI flows, and Windows compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/happier-dev/happier/pull/168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
