### PR TITLE
Improve web modal performance and pending queue behavior

### DIFF
--- a/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.test.tsx
+++ b/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.test.tsx
@@ -431,6 +431,24 @@ describe('PendingMessagesTranscriptBlock', () => {
         expect(scroll.props.style?.maxHeight).toBe(64);
     });
 
+    it('expands the pending queue block when content overflows the compact height', async () => {
+        const PendingMessagesTranscriptBlock = await loadPendingMessagesTranscriptBlock();
+        const screen = await renderScreen(React.createElement(PendingMessagesTranscriptBlock, {
+                sessionId: 's1',
+                pendingMessages: [{ id: 'p1', text: 'hello', displayText: undefined, createdAt: 0, updatedAt: 0, localId: 'p1', rawRecord: {} }],
+                discardedMessages: [],
+            }));
+
+        const scroll = screen.findByType('ScrollView');
+        await act(async () => {
+            scroll.props.onContentSizeChange?.(0, 200);
+        });
+
+        const updatedScroll = screen.findByType('ScrollView');
+        expect(updatedScroll.props.style?.maxHeight).toBe(520);
+        expect(updatedScroll.props.style?.height).toBe(200);
+    });
+
     it('does not show discarded action icons until hover on web', async () => {
         const PendingMessagesTranscriptBlock = await loadPendingMessagesTranscriptBlock();
         const screen = await renderScreen(React.createElement(PendingMessagesTranscriptBlock, {

--- a/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.test.tsx
+++ b/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.test.tsx
@@ -37,13 +37,14 @@ const modalAlert = vi.fn();
 const reorderPendingMessages = vi.fn();
 
 let sessionValue: any = null;
+let settingValues: Record<string, unknown> = {};
 
 installPendingMessagesCommonModuleMocks({
     storage: async (importOriginal) => {
         const { createPartialStorageModuleMock } = await import('@/dev/testkit');
         return createPartialStorageModuleMock(importOriginal, {
             useSession: () => sessionValue,
-            useSetting: () => undefined,
+            useSetting: (key: string) => settingValues[key],
             storage: { getState: () => ({}) },
         });
     },
@@ -175,6 +176,7 @@ describe('PendingMessagesTranscriptBlock', () => {
         modalAlert.mockReset();
         reorderPendingMessages.mockReset();
         sessionValue = null;
+        settingValues = {};
     });
 
     function flattenStyle(style: any): Record<string, any> {
@@ -447,6 +449,27 @@ describe('PendingMessagesTranscriptBlock', () => {
         const updatedScroll = screen.findByType('ScrollView');
         expect(updatedScroll.props.style?.maxHeight).toBe(520);
         expect(updatedScroll.props.style?.height).toBe(200);
+    });
+
+    it('does not shrink overflow height when compact max-height is higher than the expanded fallback default', async () => {
+        settingValues = {
+            transcriptPendingQueueMaxHeightPx: 700,
+        };
+        const PendingMessagesTranscriptBlock = await loadPendingMessagesTranscriptBlock();
+        const screen = await renderScreen(React.createElement(PendingMessagesTranscriptBlock, {
+                sessionId: 's1',
+                pendingMessages: [{ id: 'p1', text: 'hello', displayText: undefined, createdAt: 0, updatedAt: 0, localId: 'p1', rawRecord: {} }],
+                discardedMessages: [],
+            }));
+
+        const scroll = screen.findByType('ScrollView');
+        await act(async () => {
+            scroll.props.onContentSizeChange?.(0, 900);
+        });
+
+        const updatedScroll = screen.findByType('ScrollView');
+        expect(updatedScroll.props.style?.maxHeight).toBe(700);
+        expect(updatedScroll.props.style?.height).toBe(700);
     });
 
     it('does not show discarded action icons until hover on web', async () => {

--- a/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.tsx
+++ b/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.tsx
@@ -54,6 +54,11 @@ export function PendingMessagesTranscriptBlock(props: Readonly<{
         typeof maxHeightSetting === 'number' && Number.isFinite(maxHeightSetting)
             ? Math.max(1, Math.trunc(maxHeightSetting))
             : settingsDefaults.transcriptPendingQueueMaxHeightPx;
+    const expandedMaxHeightSetting = useSetting('transcriptPendingQueueExpandedMaxHeightPx');
+    const expandedMaxHeightPx =
+        typeof expandedMaxHeightSetting === 'number' && Number.isFinite(expandedMaxHeightSetting)
+            ? Math.max(maxHeightPx, Math.trunc(expandedMaxHeightSetting))
+            : settingsDefaults.transcriptPendingQueueExpandedMaxHeightPx;
 
     const collapseThresholdCharsSetting = useSetting('transcriptPendingMessageCollapseThresholdChars');
     const collapseThresholdChars =
@@ -608,7 +613,10 @@ export function PendingMessagesTranscriptBlock(props: Readonly<{
 
     if (pendingCount <= 0 && discardedCount <= 0) return null;
 
-    const maxHeight = maxHeightPx;
+    const maxHeight =
+        typeof scrollContentHeightPx === 'number' && Number.isFinite(scrollContentHeightPx) && scrollContentHeightPx > maxHeightPx
+            ? expandedMaxHeightPx
+            : maxHeightPx;
     const headerLabel =
         pendingCount > 0
             ? `${t('session.pendingMessages.title')} (${pendingCount})`

--- a/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.tsx
+++ b/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.tsx
@@ -58,7 +58,7 @@ export function PendingMessagesTranscriptBlock(props: Readonly<{
     const expandedMaxHeightPx =
         typeof expandedMaxHeightSetting === 'number' && Number.isFinite(expandedMaxHeightSetting)
             ? Math.max(maxHeightPx, Math.trunc(expandedMaxHeightSetting))
-            : settingsDefaults.transcriptPendingQueueExpandedMaxHeightPx;
+            : Math.max(maxHeightPx, settingsDefaults.transcriptPendingQueueExpandedMaxHeightPx);
 
     const collapseThresholdCharsSetting = useSetting('transcriptPendingMessageCollapseThresholdChars');
     const collapseThresholdChars =

--- a/apps/ui/sources/components/ui/status/StatusDot.tsx
+++ b/apps/ui/sources/components/ui/status/StatusDot.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ViewStyle } from 'react-native';
+import { Platform, View, ViewStyle } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withRepeat, withTiming } from 'react-native-reanimated';
 
 export interface StatusDotProps {
@@ -9,7 +9,29 @@ export interface StatusDotProps {
     style?: ViewStyle;
 }
 
-export const StatusDot = React.memo(({ color, isPulsing, size = 6, style }: StatusDotProps) => {
+const STATUS_DOT_PULSE_STYLE_ID = 'happier-status-dot-pulse-style';
+let statusDotPulseStyleInjected = false;
+
+function injectStatusDotPulseStyle(): void {
+    if (statusDotPulseStyleInjected || Platform.OS !== 'web') return;
+    if (typeof document === 'undefined') return;
+
+    statusDotPulseStyleInjected = true;
+    if (document.getElementById(STATUS_DOT_PULSE_STYLE_ID)) return;
+
+    const style = document.createElement('style');
+    style.id = STATUS_DOT_PULSE_STYLE_ID;
+    style.textContent = [
+        '@keyframes happierStatusDotPulse {',
+        '  0% { opacity: 1; }',
+        '  50% { opacity: 0.3; }',
+        '  100% { opacity: 1; }',
+        '}',
+    ].join('\n');
+    document.head.appendChild(style);
+}
+
+const AnimatedStatusDot = React.memo(({ color, isPulsing, size = 6, style }: StatusDotProps) => {
     const opacity = useSharedValue(1);
 
     React.useEffect(() => {
@@ -22,7 +44,7 @@ export const StatusDot = React.memo(({ color, isPulsing, size = 6, style }: Stat
         } else {
             opacity.value = withTiming(1, { duration: 200 });
         }
-    }, [isPulsing]);
+    }, [isPulsing, opacity]);
 
     const animatedStyle = useAnimatedStyle(() => {
         return {
@@ -46,4 +68,44 @@ export const StatusDot = React.memo(({ color, isPulsing, size = 6, style }: Stat
             ]}
         />
     );
+});
+
+const webPulseStyle = {
+    animationName: 'happierStatusDotPulse',
+    animationDuration: '1000ms',
+    animationTimingFunction: 'ease-in-out',
+    animationIterationCount: 'infinite',
+    animationFillMode: 'both',
+} as ViewStyle;
+
+const WebStatusDot = React.memo(({ color, isPulsing, size = 6, style }: StatusDotProps) => {
+    React.useEffect(() => {
+        if (isPulsing) {
+            injectStatusDotPulseStyle();
+        }
+    }, [isPulsing]);
+
+    const baseStyle: ViewStyle = {
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: color,
+    };
+
+    return (
+        <View
+            style={[
+                baseStyle,
+                isPulsing ? webPulseStyle : null,
+                style,
+            ]}
+        />
+    );
+});
+
+export const StatusDot = React.memo((props: StatusDotProps) => {
+    if (Platform.OS === 'web') {
+        return <WebStatusDot {...props} />;
+    }
+    return <AnimatedStatusDot {...props} />;
 });

--- a/apps/ui/sources/modal/components/BaseModal.test.ts
+++ b/apps/ui/sources/modal/components/BaseModal.test.ts
@@ -79,18 +79,19 @@ describe('BaseModal (web)', () => {
         expect(screen.findAllByType('DialogOverlay' as any).length).toBe(0);
     });
 
-    it('uses the themed blurred modal backdrop on web', async () => {
+    it('uses the themed modal scrim on web without backdrop blur', async () => {
         const { BaseModal } = await import('./BaseModal');
         const screen = await renderBaseModalScreen(BaseModal);
 
         const overlay = screen.findAllByType('DialogOverlay' as any)?.[0];
         expect(overlay?.props.style).toMatchObject({
-            WebkitBackdropFilter: 'blur(2px)',
-            backdropFilter: 'blur(2px)',
-            backgroundColor: 'rgba(255, 255, 255, 0.52)',
+            backgroundColor: 'rgba(24, 23, 28, 0.2)',
         });
         expect(overlay?.props.style.opacity).toBeUndefined();
         expect(overlay?.props.style.transition).not.toContain('opacity');
+        expect(overlay?.props.style.transition).not.toContain('backdrop-filter');
+        expect(overlay?.props.style.WebkitBackdropFilter).toBeUndefined();
+        expect(overlay?.props.style.backdropFilter).toBeUndefined();
     });
 
     it('keeps the web modal mounted until the shared exit animation finishes', async () => {

--- a/apps/ui/sources/modal/components/BaseModal.tsx
+++ b/apps/ui/sources/modal/components/BaseModal.tsx
@@ -12,7 +12,7 @@ import { ModalPortalTargetProvider } from '@/modal/portal/ModalPortalTarget';
 import type { ModalPortalTarget } from '@/modal/portal/ModalPortalTarget';
 import { ModalBoundaryProvider } from '@/modal/context/ModalBoundaryContext';
 import { t } from '@/text';
-import { createBackdropNativeStyle, createBackdropWebStyle } from '@/components/ui/overlays/createBackdropLayerStyle';
+import { createBackdropNativeStyle } from '@/components/ui/overlays/createBackdropLayerStyle';
 import {
     OverlayMotionFrame,
     resolveOverlayMotionPreset,
@@ -235,15 +235,9 @@ export function BaseModal({
             position: 'fixed',
             inset: 0,
             zIndex: baseZ,
-            transition: [
-                `background-color ${visible ? motionTokens.overlay.modal.enterMs : motionTokens.overlay.modal.exitMs}ms cubic-bezier(0.2, 0, 0, 1)`,
-                `backdrop-filter ${visible ? motionTokens.overlay.modal.enterMs : motionTokens.overlay.modal.exitMs}ms cubic-bezier(0.2, 0, 0, 1)`,
-                `-webkit-backdrop-filter ${visible ? motionTokens.overlay.modal.enterMs : motionTokens.overlay.modal.exitMs}ms cubic-bezier(0.2, 0, 0, 1)`,
-            ].join(', '),
-            ...createBackdropWebStyle({
-                backgroundColor: visible ? (theme.colors.overlay.scrimWizard ?? theme.colors.overlay.scrim) : 'transparent',
-                blurPx: visible ? 2 : 0,
-            }),
+            transition: `background-color ${visible ? motionTokens.overlay.modal.enterMs : motionTokens.overlay.modal.exitMs}ms cubic-bezier(0.2, 0, 0, 1)`,
+            // Full-screen backdrop blur is disproportionately expensive on desktop Chrome.
+            backgroundColor: visible ? (theme.colors.overlay.scrimWizard ?? theme.colors.overlay.scrim) : 'transparent',
         };
 
         const contentStyle: React.CSSProperties = {

--- a/apps/ui/sources/sync/sync.optimisticThinking.test.ts
+++ b/apps/ui/sources/sync/sync.optimisticThinking.test.ts
@@ -487,7 +487,7 @@ describe('sync.sendMessage optimistic thinking', () => {
         });
     });
 
-    it('prefers session runtime RPC for active sessions so steering-capable agents receive the user message directly', async () => {
+    it('clears the local pending row after active-session runtime RPC accepts the message', async () => {
         const sessionId = 's_active_runtime_rpc';
         storage.getState().applySessions([createSession({ sessionId })]);
 
@@ -528,7 +528,7 @@ describe('sync.sendMessage optimistic thinking', () => {
         expect(emitWithAck).not.toHaveBeenCalled();
 
         const pending = storage.getState().sessionPending[sessionId]?.messages ?? [];
-        expect(pending.map((message) => message.text)).toEqual(['steer this']);
+        expect(pending).toEqual([]);
         expect(storage.getState().sessions[sessionId].optimisticThinkingAt ?? null).not.toBeNull();
 
         sessionRpcSpy.mockRestore();

--- a/apps/ui/sources/sync/sync.ts
+++ b/apps/ui/sources/sync/sync.ts
@@ -1482,9 +1482,8 @@ class Sync {
                         return await encryption.encryptRawRecord(content);
                     })();
 
-            // Track this outbound user message in the local pending queue until it is committed.
-            // This prevents “ghost” optimistic transcript items when the send fails, and it lets the UI
-            // show a pending bubble while we await ACK / catch-up.
+            // Track this outbound user message in the local pending queue until the active runtime accepts it
+            // or the lower-level commit path materializes it into transcript state.
             const createdAt = nowServerMs();
             storage.getState().upsertPendingMessage(sessionId, {
                 id: localId,
@@ -1515,6 +1514,7 @@ class Sync {
                         },
                         { timeoutMs: this.syncTuning.sessionRpcTimeoutMs },
                     );
+                    storage.getState().removePendingMessage(sessionId, localId);
                     await publishNextPromptPermissionModeIfNeeded();
                     return;
                 } catch (error) {

--- a/apps/ui/sources/theme.css
+++ b/apps/ui/sources/theme.css
@@ -57,6 +57,13 @@
         height: auto !important;
         min-height: 0 !important;
         max-height: min(820px, calc(100vh - 96px)) !important;
+        /*
+        Expo Router / Vaul uses a large filtered shadow here by default. On desktop
+        Chrome this keeps the modal on an expensive compositing path while scrolling.
+        */
+        filter: none !important;
+        box-shadow: 0 22px 48px rgba(0, 0, 0, 0.28) !important;
+        will-change: auto !important;
     }
 }
 
@@ -73,9 +80,7 @@
    Expo Router owns this element outside BaseModal, but it exposes a CSS variable
    for the overlay color and stable Vaul data attributes for the backdrop node. */
 [data-vaul-overlay] {
-    --expo-router-modal-overlay-background: var(--colors-overlay-scrim-wizard, rgba(255, 255, 255, 0.52));
-    -webkit-backdrop-filter: blur(2px);
-    backdrop-filter: blur(2px);
+    --expo-router-modal-overlay-background: var(--colors-overlay-scrim-wizard, rgba(24, 23, 28, 0.2));
 }
 
 /* Ensure scrollbars are visible on hover for macOS */

--- a/apps/ui/sources/theme.ts
+++ b/apps/ui/sources/theme.ts
@@ -76,7 +76,7 @@ export const lightTheme = {
             scrimSoft: 'rgba(0, 0, 0, 0.18)',
             scrim: 'rgba(0, 0, 0, 0.45)',
             scrimStrong: 'rgba(0, 0, 0, 0.6)',
-            scrimWizard: 'rgba(255, 255, 255, 0.52)',
+            scrimWizard: 'rgba(24, 23, 28, 0.2)',
             text: '#FFFFFF',
             textSecondary: 'rgba(255, 255, 255, 0.9)',
         },


### PR DESCRIPTION
## Summary
- replace the web status-dot pulse path with CSS and remove expensive modal backdrop/filter styling on desktop web
- deepen the modal scrim/shadow styling without reintroducing blur-based rendering costs
- expand the pending queue transcript block when content overflows the compact height
- clear local pending rows as soon as active-session runtime RPC accepts a send, instead of waiting for later transcript materialization

## Testing
- not run locally in this environment because the worktree does not have node_modules installed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pending message transcript expands when content exceeds compact height.
  * Status indicators use platform-optimized animations (web-native and native paths).

* **Bug Fixes**
  * Pending messages are cleared reliably when an active session accepts them.

* **Style**
  * Modal overlay/backdrop simplified and scrim color updated; desktop modal drawer shadow adjusted.

* **Tests**
  * Tests improved to better control settings and assert expanded/shrunk transcript behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/happier-dev/happier/pull/170)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->