### PR TITLE
Disable transcript static markdown placeholders

### DIFF
--- a/apps/ui/sources/components/markdown/MarkdownView.staticRenderPlaceholder.test.tsx
+++ b/apps/ui/sources/components/markdown/MarkdownView.staticRenderPlaceholder.test.tsx
@@ -152,4 +152,24 @@ describe('MarkdownView (static render placeholder)', () => {
 
         expect(screen.findByTestId('markdown-static-render-placeholder')).toBe(null);
     });
+
+    it('allows callers to opt native static markdown out of the placeholder', async () => {
+        animatedCapture.platformOS = 'android';
+        const { MarkdownView } = await import('./MarkdownView');
+
+        const screen = await renderScreen(
+            <MarkdownView
+                markdown="Hello **world**"
+                profile="transcript"
+                staticRenderPlaceholderEnabled={false}
+            />,
+        );
+
+        await act(async () => {
+            vi.advanceTimersByTime(1_000);
+        });
+
+        expect(screen.findByTestId('markdown-static-render-placeholder')).toBe(null);
+        expect(animatedCapture.loopStartCount).toBe(0);
+    });
 });

--- a/apps/ui/sources/components/markdown/MarkdownView.tsx
+++ b/apps/ui/sources/components/markdown/MarkdownView.tsx
@@ -25,6 +25,7 @@ export const MarkdownView = React.memo((props: {
     streamingMode?: MarkdownStreamingMode;
     streamingAnimated?: boolean;
     streamingRevealPreset?: StreamingTextRevealPreset;
+    staticRenderPlaceholderEnabled?: boolean;
 }) => {
     const profile = normalizeMarkdownRenderingProfile({
         profile: props.profile,
@@ -44,6 +45,7 @@ export const MarkdownView = React.memo((props: {
             streamingMode={props.streamingMode === 'streaming' ? 'streaming' : 'static'}
             streamingAnimated={props.streamingAnimated === true}
             streamingRevealPreset={props.streamingRevealPreset}
+            staticRenderPlaceholderEnabled={props.staticRenderPlaceholderEnabled !== false}
         />
     );
 });

--- a/apps/ui/sources/components/markdown/rendering/MarkdownViewRenderer.tsx
+++ b/apps/ui/sources/components/markdown/rendering/MarkdownViewRenderer.tsx
@@ -23,6 +23,7 @@ type MarkdownViewRendererProps = Readonly<{
     streamingMode: MarkdownStreamingMode;
     streamingAnimated: boolean;
     streamingRevealPreset?: StreamingTextRevealPreset;
+    staticRenderPlaceholderEnabled: boolean;
 }>;
 
 export const MarkdownViewRenderer = React.memo((props: MarkdownViewRendererProps) => {
@@ -37,7 +38,11 @@ export const MarkdownViewRenderer = React.memo((props: MarkdownViewRendererProps
     }), [preparedMarkdown, props.streamingMode]);
     const streamingReveal = props.streamingMode === 'streaming' && props.streamingAnimated === true;
     const staticRenderPlaceholder = useDelayedStaticMarkdownRenderPlaceholder({
-        enabled: Platform.OS !== 'web' && props.streamingMode === 'static' && props.markdown.trim().length > 0,
+        enabled:
+            props.staticRenderPlaceholderEnabled === true
+            && Platform.OS !== 'web'
+            && props.streamingMode === 'static'
+            && props.markdown.trim().length > 0,
         contentKey: props.markdown,
     });
 

--- a/apps/ui/sources/components/sessions/transcript/MessageView.copyButtonHitSlop.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.copyButtonHitSlop.test.tsx
@@ -143,6 +143,7 @@ describe('MessageView (copy button hitSlop)', () => {
             const markdownView = screen.findByType('MarkdownView' as any);
             expect(markdownView.props.selectable).toBe(expectedSelectable);
             expect(markdownView.props.profile).toBe('transcript');
+            expect(markdownView.props.staticRenderPlaceholderEnabled).toBe(false);
             expect(markdownView.props.textStyle).toMatchObject({
                 fontSize: 16,
                 lineHeight: 24,

--- a/apps/ui/sources/components/sessions/transcript/MessageView.streamingSmoothing.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.streamingSmoothing.test.tsx
@@ -201,6 +201,7 @@ describe('MessageView (streaming smoothing)', () => {
         );
 
         expect(captured.markdownProps).toHaveLength(1);
+        expect(captured.markdownProps[0]?.staticRenderPlaceholderEnabled).toBe(false);
         captured.markdownProps.length = 0;
         captured.extractMentionsCalls = 0;
 
@@ -225,6 +226,7 @@ describe('MessageView (streaming smoothing)', () => {
             streamingMode: 'streaming',
             streamingAnimated: true,
             streamingRevealPreset: 'subtle',
+            staticRenderPlaceholderEnabled: false,
         });
         expect(screen.findByTestId('transcript-streaming-plain:m1')).toBe(null);
         expect(captured.extractMentionsCalls).toBe(0);
@@ -251,6 +253,7 @@ describe('MessageView (streaming smoothing)', () => {
             streamingMode: 'streaming',
             streamingAnimated: true,
             streamingRevealPreset: 'subtle',
+            staticRenderPlaceholderEnabled: false,
         });
         expect(screen.findByTestId('transcript-streaming-plain:m1')).toBe(null);
         captured.markdownProps.length = 0;
@@ -264,6 +267,7 @@ describe('MessageView (streaming smoothing)', () => {
         expect(captured.markdownProps).toHaveLength(1);
         expect(captured.markdownProps[0]?.markdown).toBe('Hello world!');
         expect(captured.markdownProps[0]?.streamingMode).toBeUndefined();
+        expect(captured.markdownProps[0]?.staticRenderPlaceholderEnabled).toBe(false);
         expect(captured.extractMentionsCalls).toBeGreaterThan(0);
     });
 

--- a/apps/ui/sources/components/sessions/transcript/MessageView.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.tsx
@@ -468,7 +468,15 @@ function UserTextBlock(props: {
                 });
               }}
             />
-            <MarkdownView markdown={renderedMarkdownText} onOptionPress={handleOptionPress} onLinkPress={handleMarkdownLinkPress} selectable={true} profile="transcript" textStyle={styles.transcriptMarkdownText} />
+            <MarkdownView
+              markdown={renderedMarkdownText}
+              onOptionPress={handleOptionPress}
+              onLinkPress={handleMarkdownLinkPress}
+              selectable={true}
+              profile="transcript"
+              textStyle={styles.transcriptMarkdownText}
+              staticRenderPlaceholderEnabled={false}
+            />
             {sessionMediaInlineImages.length > 0 ? (
               <SessionMediaInlineImages
                 sessionId={props.sessionId}
@@ -796,6 +804,7 @@ function AgentTextBlock(props: {
                     selectable={true}
                     profile="thinking"
                     textStyle={thinkingMarkdownTextStyle}
+                    staticRenderPlaceholderEnabled={false}
                   />
                 </ThinkingTimelineRow>
             ) : (
@@ -810,6 +819,7 @@ function AgentTextBlock(props: {
                   streamingMode="streaming"
                   streamingAnimated={streamingRevealAnimationEnabled}
                   streamingRevealPreset={streamingRevealPreset}
+                  staticRenderPlaceholderEnabled={false}
                 />
               ) : shouldRenderStreamingPlain ? (
                 <Text
@@ -827,6 +837,7 @@ function AgentTextBlock(props: {
                   selectable={true}
                   profile={props.message.isThinking ? 'thinking' : 'transcript'}
                   textStyle={props.message.isThinking ? styles.thinkingMarkdownText : styles.transcriptMarkdownText}
+                  staticRenderPlaceholderEnabled={false}
                 />
               )
             )


### PR DESCRIPTION
## Summary
- add an explicit opt-out for static markdown render placeholders
- disable the placeholder in transcript message markdown paths so assistant/tool boundaries do not accumulate skeleton rows
- add regression coverage for the opt-out and transcript wiring

## Testing
- not run locally in this worktree because node_modules are absent

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable control over static render placeholders in markdown rendering for native platforms. Placeholders can now be individually enabled or disabled during content streaming.

* **Tests**
  * Enhanced test coverage to verify placeholder behavior with the new configuration option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/happier-dev/happier/pull/171)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->