### PR TITLE
fix(ui): serialize web terminal input writes

### DIFF
--- a/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.test.tsx
+++ b/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.test.tsx
@@ -86,4 +86,58 @@ describe('useEmbeddedTerminalTransportHandlers', () => {
         expect(inputSpy).toHaveBeenCalledTimes(1);
         expect(inputSpy).toHaveBeenCalledWith('machine-1', { terminalId: 'term-1', data: 'buffered' });
     });
+
+    it('does not start a second terminal input send while the previous send is still in flight', async () => {
+        let resolveFirst: (() => void) | undefined;
+        inputSpy
+            .mockImplementationOnce(() => new Promise<undefined>((resolve) => {
+                resolveFirst = () => resolve(undefined);
+            }))
+            .mockResolvedValueOnce(undefined);
+
+        const { useEmbeddedTerminalTransportHandlers } = await import('./useEmbeddedTerminalTransportHandlers');
+        const terminalIdRef: TerminalIdRef = { current: 'term-1' };
+        const hook = await renderHook(() =>
+            useEmbeddedTerminalTransportHandlers({ machineId: 'machine-1', terminalIdRef }),
+        );
+
+        hook.getCurrent().onInput('g');
+        await flushHookEffects({ cycles: 1, turns: 0, runOnlyPendingTimers: true });
+        expect(inputSpy).toHaveBeenNthCalledWith(1, 'machine-1', { terminalId: 'term-1', data: 'g' });
+
+        hook.getCurrent().onInput('it status');
+        await flushHookEffects({ cycles: 1, turns: 0, runOnlyPendingTimers: true });
+        expect(inputSpy).toHaveBeenCalledTimes(1);
+
+        resolveFirst!();
+        await flushHookEffects({ cycles: 3, turns: 3, runOnlyPendingTimers: true });
+
+        expect(inputSpy).toHaveBeenNthCalledWith(2, 'machine-1', { terminalId: 'term-1', data: 'it status' });
+    });
+
+    it('continues draining later buffered input after a send failure', async () => {
+        let rejectFirst: ((error?: unknown) => void) | undefined;
+        inputSpy
+            .mockImplementationOnce(() => new Promise<undefined>((_resolve, reject) => {
+                rejectFirst = reject;
+            }))
+            .mockResolvedValueOnce(undefined);
+
+        const { useEmbeddedTerminalTransportHandlers } = await import('./useEmbeddedTerminalTransportHandlers');
+        const terminalIdRef: TerminalIdRef = { current: 'term-1' };
+        const hook = await renderHook(() =>
+            useEmbeddedTerminalTransportHandlers({ machineId: 'machine-1', terminalIdRef }),
+        );
+
+        hook.getCurrent().onInput('git ');
+        await flushHookEffects({ cycles: 1, turns: 0, runOnlyPendingTimers: true });
+        expect(inputSpy).toHaveBeenCalledTimes(1);
+
+        hook.getCurrent().onInput('status');
+        rejectFirst!(new Error('transient'));
+        await flushHookEffects({ cycles: 3, turns: 3, runOnlyPendingTimers: true });
+
+        expect(inputSpy).toHaveBeenCalledTimes(2);
+        expect(inputSpy).toHaveBeenLastCalledWith('machine-1', { terminalId: 'term-1', data: 'status' });
+    });
 });

--- a/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.test.tsx
+++ b/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.test.tsx
@@ -109,7 +109,8 @@ describe('useEmbeddedTerminalTransportHandlers', () => {
         await flushHookEffects({ cycles: 1, turns: 0, runOnlyPendingTimers: true });
         expect(inputSpy).toHaveBeenCalledTimes(1);
 
-        resolveFirst!();
+        expect(resolveFirst).toBeDefined();
+        resolveFirst?.();
         await flushHookEffects({ cycles: 3, turns: 3, runOnlyPendingTimers: true });
 
         expect(inputSpy).toHaveBeenNthCalledWith(2, 'machine-1', { terminalId: 'term-1', data: 'it status' });
@@ -168,7 +169,8 @@ describe('useEmbeddedTerminalTransportHandlers', () => {
         await flushHookEffects({ cycles: 1, turns: 0, runOnlyPendingTimers: true });
         expect(inputSpy).toHaveBeenCalledTimes(1);
 
-        resolveFirst!();
+        expect(resolveFirst).toBeDefined();
+        resolveFirst?.();
         await flushHookEffects({ cycles: 3, turns: 3, runOnlyPendingTimers: true });
 
         expect(inputSpy).toHaveBeenNthCalledWith(2, 'machine-2', { terminalId: 'term-1', data: 'status' });

--- a/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.test.tsx
+++ b/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.test.tsx
@@ -140,4 +140,37 @@ describe('useEmbeddedTerminalTransportHandlers', () => {
         expect(inputSpy).toHaveBeenCalledTimes(2);
         expect(inputSpy).toHaveBeenLastCalledWith('machine-1', { terminalId: 'term-1', data: 'status' });
     });
+
+    it('uses the latest machine after rerender while a previous send is still in flight', async () => {
+        let resolveFirst: (() => void) | undefined;
+        inputSpy
+            .mockImplementationOnce(() => new Promise<undefined>((resolve) => {
+                resolveFirst = () => resolve(undefined);
+            }))
+            .mockResolvedValueOnce(undefined);
+
+        const { useEmbeddedTerminalTransportHandlers } = await import('./useEmbeddedTerminalTransportHandlers');
+        const terminalIdRef: TerminalIdRef = { current: 'term-1' };
+        const hook = await renderHook(
+            (props: Readonly<{ machineId: string | null; terminalIdRef: TerminalIdRef }>) =>
+                useEmbeddedTerminalTransportHandlers(props),
+            {
+                initialProps: { machineId: 'machine-1', terminalIdRef },
+            },
+        );
+
+        hook.getCurrent().onInput('git ');
+        await flushHookEffects({ cycles: 1, turns: 0, runOnlyPendingTimers: true });
+        expect(inputSpy).toHaveBeenNthCalledWith(1, 'machine-1', { terminalId: 'term-1', data: 'git ' });
+
+        await hook.rerender({ machineId: 'machine-2', terminalIdRef });
+        hook.getCurrent().onInput('status');
+        await flushHookEffects({ cycles: 1, turns: 0, runOnlyPendingTimers: true });
+        expect(inputSpy).toHaveBeenCalledTimes(1);
+
+        resolveFirst!();
+        await flushHookEffects({ cycles: 3, turns: 3, runOnlyPendingTimers: true });
+
+        expect(inputSpy).toHaveBeenNthCalledWith(2, 'machine-2', { terminalId: 'term-1', data: 'status' });
+    });
 });

--- a/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.ts
+++ b/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.ts
@@ -15,31 +15,36 @@ export function useEmbeddedTerminalTransportHandlers(params: Readonly<{
 
     const pendingInputRef = React.useRef('');
     const inputFlushTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-    const flushPendingInput = React.useCallback(() => {
-        if (!params.machineId) {
-            return;
-        }
+    const inputDrainTailRef = React.useRef<Promise<void>>(Promise.resolve());
 
-        const terminalId = params.terminalIdRef.current;
-        if (!terminalId) {
-            return;
-        }
+    // Terminal input must be serialized per terminal instance: async encryption happens before
+    // socket emission, so parallel machineTerminalInput calls can otherwise reach the daemon out of order.
+    const sendBufferedInput = React.useCallback(() => {
+        inputDrainTailRef.current = inputDrainTailRef.current.then(async () => {
+            while (true) {
+                if (!params.machineId) return;
+                const terminalId = params.terminalIdRef.current;
+                if (!terminalId) return;
 
-        const data = pendingInputRef.current;
-        pendingInputRef.current = '';
-        if (!data) {
-            return;
-        }
+                const data = pendingInputRef.current;
+                pendingInputRef.current = '';
+                if (!data) return;
 
-        void machineTerminalInput(params.machineId, { terminalId, data }).catch(() => {
-            // The read-loop owns error surfaces; ignore transient input failures.
+                try {
+                    await machineTerminalInput(params.machineId, { terminalId, data });
+                } catch {
+                    // The read-loop owns error surfaces; ignore transient failures, but keep draining future input.
+                }
+            }
+        }).catch(() => {
+            // Preserve drain chain after a rejected send.
         });
     }, [params.machineId, params.terminalIdRef]);
-    const flushPendingInputRef = React.useRef(flushPendingInput);
+    const sendBufferedInputRef = React.useRef(sendBufferedInput);
 
     React.useEffect(() => {
-        flushPendingInputRef.current = flushPendingInput;
-    }, [flushPendingInput]);
+        sendBufferedInputRef.current = sendBufferedInput;
+    }, [sendBufferedInput]);
 
     const onInput = React.useCallback((data: string) => {
         if (!data) return;
@@ -51,16 +56,16 @@ export function useEmbeddedTerminalTransportHandlers(params: Readonly<{
 
         inputFlushTimeoutRef.current = safeTimeoutSet(() => {
             inputFlushTimeoutRef.current = null;
-            flushPendingInput();
+            void sendBufferedInput();
         }, 0);
-    }, [flushPendingInput]);
+    }, [sendBufferedInput]);
 
     React.useEffect(() => {
         if (!params.machineId) return;
         if (!params.terminalIdRef.current) return;
         if (!pendingInputRef.current) return;
-        flushPendingInput();
-    }, [flushPendingInput, params.machineId, params.terminalIdRef]);
+        void sendBufferedInput();
+    }, [params.machineId, params.terminalIdRef, sendBufferedInput]);
 
     const resizeDebounceTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const pendingResizeRef = React.useRef<TerminalSize | null>(null);
@@ -99,7 +104,7 @@ export function useEmbeddedTerminalTransportHandlers(params: Readonly<{
     React.useEffect(() => {
         return () => {
             if (pendingInputRef.current) {
-                flushPendingInputRef.current();
+                void sendBufferedInputRef.current();
             }
             safeTimeoutClear(inputFlushTimeoutRef.current);
             inputFlushTimeoutRef.current = null;

--- a/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.ts
+++ b/apps/ui/sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.ts
@@ -21,23 +21,21 @@ export function useEmbeddedTerminalTransportHandlers(params: Readonly<{
     // socket emission, so parallel machineTerminalInput calls can otherwise reach the daemon out of order.
     const sendBufferedInput = React.useCallback(() => {
         inputDrainTailRef.current = inputDrainTailRef.current.then(async () => {
-            while (true) {
-                if (!params.machineId) return;
-                const terminalId = params.terminalIdRef.current;
-                if (!terminalId) return;
+            if (!params.machineId) return;
+            const terminalId = params.terminalIdRef.current;
+            if (!terminalId) return;
 
-                const data = pendingInputRef.current;
-                pendingInputRef.current = '';
-                if (!data) return;
+            const data = pendingInputRef.current;
+            pendingInputRef.current = '';
+            if (!data) return;
 
-                try {
-                    await machineTerminalInput(params.machineId, { terminalId, data });
-                } catch {
-                    // The read-loop owns error surfaces; ignore transient failures, but keep draining future input.
-                }
+            try {
+                await machineTerminalInput(params.machineId, { terminalId, data });
+            } catch {
+                // The read-loop owns error surfaces; ignore transient input failures.
             }
         }).catch(() => {
-            // Preserve drain chain after a rejected send.
+            // Defensive: keep the drain chain alive if surrounding logic unexpectedly throws.
         });
     }, [params.machineId, params.terminalIdRef]);
     const sendBufferedInputRef = React.useRef(sendBufferedInput);


### PR DESCRIPTION
## Summary

Serialize buffered web terminal input writes in `useEmbeddedTerminalTransportHandlers` so later keystrokes wait for the previous `machineTerminalInput` call to finish.

## Why

`machineTerminalInput` performs async work before the socket write. When multiple input flushes run in parallel, terminal input can reach the daemon out of order, which can corrupt typed commands in the embedded web terminal.

## How to test

1. `yarn --cwd apps/ui -s ensure:workspace:built && yarn --cwd apps/ui -s vitest run --config vitest.config.ts --no-file-parallelism sources/components/sessions/terminal/useEmbeddedTerminalTransportHandlers.test.tsx`
2. `NODE_OPTIONS=--max-old-space-size=8192 yarn --cwd apps/ui typecheck`
3. `yarn --cwd apps/ui test:unit` *(currently fails in unrelated shard-1 specs: `sources/__tests__/app/_layout.test.ts`, `sources/components/sessions/transcript/MessageView.structured.test.tsx`, and `sources/components/sessions/participants/composer/SessionParticipantComposer.authSurface.test.tsx`)*

## Screenshots / recording (UI changes)

Not applicable. This is a terminal transport ordering fix with unit coverage.

## Notes (optional)

The first plain `yarn --cwd apps/ui typecheck` attempt aborted with a V8 heap OOM at the default heap limit. The same package typecheck passed with `NODE_OPTIONS=--max-old-space-size=8192`.

AI-assisted contribution disclosure: This change was developed with AI-assisted tooling under my direction, including planning, implementation support, review, and validation. I verified the focused terminal hook test and UI typecheck locally.

## Checklist

- [x] PR targets `dev` (not `main`)
- [ ] I linked an issue/discussion (recommended for non-trivial changes)
- [x] I added/updated tests where feasible (or explained why not)
- [x] I updated docs if behavior changed
- [x] If AI-assisted, I disclosed it and listed what I personally verified

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784383392&installation_id=129174028&pr_number=183&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F183&signature=13c3e8f9a0f0554c97632a8047f35130bb2aa174f99ff0d7fdd09db11c57c909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for concurrent terminal input sending to ensure buffered input doesn’t double-send while a prior send is still in flight.
  * Added scenarios for transient send failures, confirming buffered input continues draining and later sends resume properly.
  * Verified rerender behavior uses the latest machine identifier for subsequent sends while preserving the current terminal identifier.
* **Refactor**
  * Updated terminal input flushing to use a serialized drain chain for more reliable, sequential delivery and improved resilience during send errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->