### PR TITLE
fix(server): actively checkpoint sqlite WAL to prevent checkpoint starvation

### DIFF
--- a/apps/server/sources/startServer.sqliteWalCheckpoint.integration.spec.ts
+++ b/apps/server/sources/startServer.sqliteWalCheckpoint.integration.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    createStartServerDbMocks,
+    installStartServerDbModuleMock,
+    installStartServerCommonWiringMocks,
+} from "@/testkit/startServerMocks";
+import { createStartServerHarness } from "@/testkit/startServerHarness";
+
+const sqliteWalCheckpointMocks = vi.hoisted(() => {
+    const stop = vi.fn(async () => {});
+    return {
+        resolveInterval: vi.fn(() => 1000),
+        startWorker: vi.fn(() => ({ stop })),
+        stop,
+    };
+});
+
+const callOrder: string[] = [];
+
+const dbDisconnect = vi.fn(async () => {
+    callOrder.push("db.$disconnect");
+});
+
+const startServerDbMocks = createStartServerDbMocks({
+    getDbProviderFromEnv: () => "sqlite",
+});
+startServerDbMocks.dbDisconnect.mockImplementation(dbDisconnect);
+
+installStartServerDbModuleMock(startServerDbMocks);
+
+installStartServerCommonWiringMocks();
+
+vi.mock("@/storage/sqliteWalCheckpoint", () => ({
+    resolveSqliteWalCheckpointIntervalMsFromEnv: sqliteWalCheckpointMocks.resolveInterval,
+    startSqliteWalCheckpointWorker: sqliteWalCheckpointMocks.startWorker,
+}));
+
+// Avoid hanging in tests: startServer calls awaitShutdown().
+vi.mock("@/utils/process/shutdown", async () => {
+    const actual = await vi.importActual<any>("@/utils/process/shutdown");
+    return { ...actual, awaitShutdown: vi.fn(async () => {}) };
+});
+
+describe("startServer sqlite WAL checkpoint shutdown ordering", () => {
+    const startServerHarness = createStartServerHarness();
+
+    beforeEach(() => {
+        callOrder.length = 0;
+        startServerDbMocks.reset();
+        startServerDbMocks.dbDisconnect.mockImplementation(dbDisconnect);
+        sqliteWalCheckpointMocks.resolveInterval.mockReset().mockReturnValue(1000);
+        sqliteWalCheckpointMocks.startWorker
+            .mockReset()
+            .mockImplementation(() => ({ stop: sqliteWalCheckpointMocks.stop }));
+        sqliteWalCheckpointMocks.stop.mockReset().mockImplementation(async () => {
+            callOrder.push("sqliteWalCheckpoint.stop");
+        });
+        startServerHarness.reset();
+    });
+
+    afterEach(() => {
+        startServerHarness.restore();
+    });
+
+    it("stops the sqlite WAL checkpoint worker before disconnecting Prisma", async () => {
+        startServerHarness.prepareImport({
+            SERVER_ROLE: "api",
+            REDIS_URL: undefined,
+            HAPPY_DB_PROVIDER: "sqlite",
+            HAPPIER_DB_PROVIDER: "sqlite",
+            DATABASE_URL: "file:/tmp/happier-start-server-sqlite-shutdown-order.sqlite",
+            HAPPY_SERVER_LIGHT_DATA_DIR: undefined,
+            HAPPIER_SERVER_LIGHT_DATA_DIR: undefined,
+        });
+
+        const { startServer } = await import("./startServer");
+        const { initiateShutdown } = await import("@/utils/process/shutdown");
+
+        await startServer("light");
+        await initiateShutdown("test");
+
+        expect(sqliteWalCheckpointMocks.startWorker).toHaveBeenCalledTimes(1);
+        expect(callOrder).toEqual(["sqliteWalCheckpoint.stop", "db.$disconnect"]);
+    });
+});

--- a/apps/server/sources/startServer.sqliteWalCheckpoint.integration.spec.ts
+++ b/apps/server/sources/startServer.sqliteWalCheckpoint.integration.spec.ts
@@ -9,6 +9,7 @@ import { createStartServerHarness } from "@/testkit/startServerHarness";
 const sqliteWalCheckpointMocks = vi.hoisted(() => {
     const stop = vi.fn(async () => {});
     return {
+        resolveBusyTimeout: vi.fn(() => 5000),
         resolveInterval: vi.fn(() => 1000),
         startWorker: vi.fn(() => ({ stop })),
         stop,
@@ -31,6 +32,7 @@ installStartServerDbModuleMock(startServerDbMocks);
 installStartServerCommonWiringMocks();
 
 vi.mock("@/storage/sqliteWalCheckpoint", () => ({
+    resolveSqliteWalCheckpointBusyTimeoutMsFromEnv: sqliteWalCheckpointMocks.resolveBusyTimeout,
     resolveSqliteWalCheckpointIntervalMsFromEnv: sqliteWalCheckpointMocks.resolveInterval,
     startSqliteWalCheckpointWorker: sqliteWalCheckpointMocks.startWorker,
 }));
@@ -48,6 +50,10 @@ describe("startServer sqlite WAL checkpoint shutdown ordering", () => {
         callOrder.length = 0;
         startServerDbMocks.reset();
         startServerDbMocks.dbDisconnect.mockImplementation(dbDisconnect);
+        startServerDbMocks.sqliteMaintenanceClientDisconnect.mockImplementation(async () => {
+            callOrder.push("sqliteMaintenanceClient.$disconnect");
+        });
+        sqliteWalCheckpointMocks.resolveBusyTimeout.mockReset().mockReturnValue(5000);
         sqliteWalCheckpointMocks.resolveInterval.mockReset().mockReturnValue(1000);
         sqliteWalCheckpointMocks.startWorker
             .mockReset()
@@ -80,6 +86,44 @@ describe("startServer sqlite WAL checkpoint shutdown ordering", () => {
         await initiateShutdown("test");
 
         expect(sqliteWalCheckpointMocks.startWorker).toHaveBeenCalledTimes(1);
-        expect(callOrder).toEqual(["sqliteWalCheckpoint.stop", "db.$disconnect"]);
+        expect(sqliteWalCheckpointMocks.startWorker).toHaveBeenCalledWith(expect.objectContaining({
+            client: startServerDbMocks.sqliteMaintenanceClient,
+        }));
+        expect(startServerDbMocks.applySqliteRuntimePragmas).toHaveBeenCalledWith(
+            startServerDbMocks.sqliteMaintenanceClient,
+            expect.objectContaining({
+                HAPPIER_SQLITE_BUSY_TIMEOUT_MS: "5000",
+                HAPPY_SQLITE_BUSY_TIMEOUT_MS: "5000",
+            }),
+        );
+        expect(callOrder).toEqual([
+            "sqliteWalCheckpoint.stop",
+            "sqliteMaintenanceClient.$disconnect",
+            "db.$disconnect",
+        ]);
+    });
+
+    it("does not open a sqlite maintenance client when WAL checkpointing is disabled", async () => {
+        sqliteWalCheckpointMocks.resolveInterval.mockReturnValue(0);
+        startServerHarness.prepareImport({
+            SERVER_ROLE: "api",
+            REDIS_URL: undefined,
+            HAPPY_DB_PROVIDER: "sqlite",
+            HAPPIER_DB_PROVIDER: "sqlite",
+            DATABASE_URL: "file:/tmp/happier-start-server-sqlite-shutdown-disabled.sqlite",
+            HAPPY_SERVER_LIGHT_DATA_DIR: undefined,
+            HAPPIER_SERVER_LIGHT_DATA_DIR: undefined,
+        });
+
+        const { startServer } = await import("./startServer");
+        const { initiateShutdown } = await import("@/utils/process/shutdown");
+
+        await startServer("light");
+        await initiateShutdown("test");
+
+        expect(startServerDbMocks.createDbSqliteMaintenanceClient).not.toHaveBeenCalled();
+        expect(sqliteWalCheckpointMocks.resolveBusyTimeout).not.toHaveBeenCalled();
+        expect(sqliteWalCheckpointMocks.startWorker).not.toHaveBeenCalled();
+        expect(callOrder).toEqual(["db.$disconnect"]);
     });
 });

--- a/apps/server/sources/startServer.ts
+++ b/apps/server/sources/startServer.ts
@@ -116,31 +116,36 @@ export async function startServer(flavor: ServerFlavor): Promise<void> {
         throw new Error(`Unsupported HAPPY_FILES_BACKEND/HAPPIER_FILES_BACKEND: ${String(filesBackend)}`);
     }
 
+    const sqliteWalCheckpointIntervalMs = dbProvider === 'sqlite'
+        ? resolveSqliteWalCheckpointIntervalMsFromEnv(process.env)
+        : null;
+
     // Storage
     await db.$connect();
+    // Actively checkpoint the SQLite WAL so it cannot be starved by long-lived
+    // readers and grow without bound, which slows queries until they hit the
+    // Prisma timeout.
+    const sqliteWalCheckpointWorker = sqliteWalCheckpointIntervalMs === null
+        ? null
+        : startSqliteWalCheckpointWorker({
+            client: db,
+            intervalMs: sqliteWalCheckpointIntervalMs,
+        });
     if (dbProvider === 'pglite') {
         // When using embedded pglite, ensure Prisma disconnect happens before stopping the socket server.
         onShutdown('db', async () => {
             await db.$disconnect();
             await shutdownDbPglite();
         });
+    } else if (dbProvider === 'sqlite') {
+        onShutdown('db', async () => {
+            await sqliteWalCheckpointWorker?.stop();
+            await db.$disconnect();
+        });
     } else {
         onShutdown('db', async () => {
             await db.$disconnect();
         });
-    }
-    if (dbProvider === 'sqlite') {
-        // Actively checkpoint the WAL so it cannot be starved by long-lived readers
-        // and grow without bound (which slows queries until they hit the Prisma timeout).
-        const walCheckpointWorker = startSqliteWalCheckpointWorker({
-            client: db,
-            intervalMs: resolveSqliteWalCheckpointIntervalMsFromEnv(process.env),
-        });
-        if (walCheckpointWorker) {
-            onShutdown('db:sqlite-wal-checkpoint', async () => {
-                await walCheckpointWorker.stop();
-            });
-        }
     }
     onShutdown('keepAlive:activity-cache', async () => {
         await activityCache.shutdown();

--- a/apps/server/sources/startServer.ts
+++ b/apps/server/sources/startServer.ts
@@ -8,6 +8,7 @@ import { initEncrypt } from '@/modules/encrypt';
 import { initGithub } from '@/app/auth/providers/github/webhooks';
 import { loadFiles, initFilesLocalFromEnv, initFilesS3FromEnv } from '@/storage/blob/files';
 import { db, getDbProviderFromEnv, initDbMysql, initDbPostgres, initDbPglite, initDbSqlite, shutdownDbPglite } from '@/storage/db';
+import { resolveSqliteWalCheckpointIntervalMsFromEnv, startSqliteWalCheckpointWorker } from '@/storage/sqliteWalCheckpoint';
 import { log } from '@/utils/logging/log';
 import { awaitShutdown, onShutdown } from '@/utils/process/shutdown';
 import {
@@ -127,6 +128,19 @@ export async function startServer(flavor: ServerFlavor): Promise<void> {
         onShutdown('db', async () => {
             await db.$disconnect();
         });
+    }
+    if (dbProvider === 'sqlite') {
+        // Actively checkpoint the WAL so it cannot be starved by long-lived readers
+        // and grow without bound (which slows queries until they hit the Prisma timeout).
+        const walCheckpointWorker = startSqliteWalCheckpointWorker({
+            client: db,
+            intervalMs: resolveSqliteWalCheckpointIntervalMsFromEnv(process.env),
+        });
+        if (walCheckpointWorker) {
+            onShutdown('db:sqlite-wal-checkpoint', async () => {
+                await walCheckpointWorker.stop();
+            });
+        }
     }
     onShutdown('keepAlive:activity-cache', async () => {
         await activityCache.shutdown();

--- a/apps/server/sources/startServer.ts
+++ b/apps/server/sources/startServer.ts
@@ -7,8 +7,22 @@ import { startTimeout } from '@/app/presence/timeout';
 import { initEncrypt } from '@/modules/encrypt';
 import { initGithub } from '@/app/auth/providers/github/webhooks';
 import { loadFiles, initFilesLocalFromEnv, initFilesS3FromEnv } from '@/storage/blob/files';
-import { db, getDbProviderFromEnv, initDbMysql, initDbPostgres, initDbPglite, initDbSqlite, shutdownDbPglite } from '@/storage/db';
-import { resolveSqliteWalCheckpointIntervalMsFromEnv, startSqliteWalCheckpointWorker } from '@/storage/sqliteWalCheckpoint';
+import {
+    applySqliteRuntimePragmas,
+    createDbSqliteMaintenanceClient,
+    db,
+    getDbProviderFromEnv,
+    initDbMysql,
+    initDbPostgres,
+    initDbPglite,
+    initDbSqlite,
+    shutdownDbPglite,
+} from '@/storage/db';
+import {
+    resolveSqliteWalCheckpointBusyTimeoutMsFromEnv,
+    resolveSqliteWalCheckpointIntervalMsFromEnv,
+    startSqliteWalCheckpointWorker,
+} from '@/storage/sqliteWalCheckpoint';
 import { log } from '@/utils/logging/log';
 import { awaitShutdown, onShutdown } from '@/utils/process/shutdown';
 import {
@@ -119,18 +133,40 @@ export async function startServer(flavor: ServerFlavor): Promise<void> {
     const sqliteWalCheckpointIntervalMs = dbProvider === 'sqlite'
         ? resolveSqliteWalCheckpointIntervalMsFromEnv(process.env)
         : null;
+    const shouldStartSqliteWalCheckpointWorker =
+        sqliteWalCheckpointIntervalMs !== null && sqliteWalCheckpointIntervalMs > 0;
+    const sqliteWalCheckpointBusyTimeoutMs = shouldStartSqliteWalCheckpointWorker
+        ? resolveSqliteWalCheckpointBusyTimeoutMsFromEnv(process.env)
+        : null;
 
     // Storage
     await db.$connect();
+    let sqliteWalCheckpointClient: typeof db | null = null;
+    try {
+        if (shouldStartSqliteWalCheckpointWorker) {
+            sqliteWalCheckpointClient = await createDbSqliteMaintenanceClient();
+            await sqliteWalCheckpointClient.$connect();
+            await applySqliteRuntimePragmas(sqliteWalCheckpointClient, {
+                ...process.env,
+                HAPPIER_SQLITE_BUSY_TIMEOUT_MS: String(sqliteWalCheckpointBusyTimeoutMs),
+                HAPPY_SQLITE_BUSY_TIMEOUT_MS: String(sqliteWalCheckpointBusyTimeoutMs),
+            });
+        }
+    } catch (error) {
+        await sqliteWalCheckpointClient?.$disconnect().catch(() => {});
+        await db.$disconnect().catch(() => {});
+        throw error;
+    }
     // Actively checkpoint the SQLite WAL so it cannot be starved by long-lived
     // readers and grow without bound, which slows queries until they hit the
     // Prisma timeout.
-    const sqliteWalCheckpointWorker = sqliteWalCheckpointIntervalMs === null
-        ? null
-        : startSqliteWalCheckpointWorker({
-            client: db,
+    let sqliteWalCheckpointWorker: ReturnType<typeof startSqliteWalCheckpointWorker> = null;
+    if (sqliteWalCheckpointClient && sqliteWalCheckpointIntervalMs !== null) {
+        sqliteWalCheckpointWorker = startSqliteWalCheckpointWorker({
+            client: sqliteWalCheckpointClient,
             intervalMs: sqliteWalCheckpointIntervalMs,
         });
+    }
     if (dbProvider === 'pglite') {
         // When using embedded pglite, ensure Prisma disconnect happens before stopping the socket server.
         onShutdown('db', async () => {
@@ -140,7 +176,11 @@ export async function startServer(flavor: ServerFlavor): Promise<void> {
     } else if (dbProvider === 'sqlite') {
         onShutdown('db', async () => {
             await sqliteWalCheckpointWorker?.stop();
-            await db.$disconnect();
+            try {
+                await sqliteWalCheckpointClient?.$disconnect();
+            } finally {
+                await db.$disconnect();
+            }
         });
     } else {
         onShutdown('db', async () => {

--- a/apps/server/sources/storage/prisma.sqlitePragmas.integration.spec.ts
+++ b/apps/server/sources/storage/prisma.sqlitePragmas.integration.spec.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { renderPrismaCompatibleSqliteDatabaseUrl } from "@happier-dev/cli-common/firstPartyRuntime";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { db, resolveSqliteStartupDiagnosticsFromEnv } from "@/storage/db";
+import { db, resolveSqliteRuntimePragmasFromEnv, resolveSqliteStartupDiagnosticsFromEnv } from "@/storage/db";
 import { createLightSqliteHarness, type LightSqliteHarness } from "@/testkit/lightSqliteHarness";
 
 describe("storage/prisma sqlite pragmas", () => {
@@ -49,6 +49,18 @@ describe("storage/prisma sqlite pragmas", () => {
         expect(Number(timeout)).toBe(30000);
         expect(Number(journalSizeLimit)).toBe(64 * 1024 * 1024);
         expect(timeoutRows.flat().map((row) => Number(row.timeout))).toEqual(Array.from({ length: 16 }, () => 30000));
+    });
+
+    it("accepts negative journal_size_limit values as SQLite no-limit opt-out", () => {
+        expect(resolveSqliteRuntimePragmasFromEnv({
+            HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES: "-1",
+        }).journalSizeLimitBytes).toBe(-1);
+    });
+
+    it("treats zero journal_size_limit as an explicit minimum-size limit", () => {
+        expect(resolveSqliteRuntimePragmasFromEnv({
+            HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES: "0",
+        }).journalSizeLimitBytes).toBe(0);
     });
 
     it("observes consistent synchronous mode when sqlite connection_limit is explicit", async () => {

--- a/apps/server/sources/storage/prisma.sqlitePragmas.integration.spec.ts
+++ b/apps/server/sources/storage/prisma.sqlitePragmas.integration.spec.ts
@@ -35,6 +35,9 @@ describe("storage/prisma sqlite pragmas", () => {
         const [{ timeout }] = await db.$queryRawUnsafe<Array<{ timeout: number | bigint }>>(
             "SELECT timeout FROM pragma_busy_timeout;",
         );
+        const [{ journal_size_limit: journalSizeLimit }] = await db.$queryRawUnsafe<
+            Array<{ journal_size_limit: number | bigint }>
+        >("SELECT journal_size_limit FROM pragma_journal_size_limit;");
         const timeoutRows = await Promise.all(
             Array.from({ length: 16 }, () =>
                 db.$queryRawUnsafe<Array<{ timeout: number | bigint }>>("SELECT timeout FROM pragma_busy_timeout;"),
@@ -44,6 +47,7 @@ describe("storage/prisma sqlite pragmas", () => {
         expect(journalMode.toLowerCase()).toBe("wal");
         expect(Number(synchronous)).toBe(1); // NORMAL
         expect(Number(timeout)).toBe(30000);
+        expect(Number(journalSizeLimit)).toBe(64 * 1024 * 1024);
         expect(timeoutRows.flat().map((row) => Number(row.timeout))).toEqual(Array.from({ length: 16 }, () => 30000));
     });
 
@@ -92,6 +96,7 @@ describe("storage/prisma sqlite pragmas", () => {
             journalMode: "DELETE",
             synchronous: "FULL",
             busyTimeoutMs: 45000,
+            journalSizeLimitBytes: 64 * 1024 * 1024,
             databaseUrlSocketTimeoutSeconds: 45,
             databaseUrlConnectionLimit: 1,
             databaseUrlConnectionLimitStatus: "configured",

--- a/apps/server/sources/storage/prisma.ts
+++ b/apps/server/sources/storage/prisma.ts
@@ -152,6 +152,11 @@ async function initDbFromGeneratedClient(provider: "mysql" | "sqlite"): Promise<
     if (_db || _pglite || _pgliteServer) {
         throw new Error("Database client is already initialized.");
     }
+    _provider = provider;
+    _db = await createGeneratedPrismaClient(provider);
+}
+
+async function createGeneratedPrismaClient(provider: "mysql" | "sqlite"): Promise<PrismaClientType> {
     const entrypoint =
         provider === "mysql"
             ? resolveGeneratedClientEntrypoint("../../generated/mysql-client")
@@ -173,8 +178,11 @@ async function initDbFromGeneratedClient(provider: "mysql" | "sqlite"): Promise<
     if (!mod?.PrismaClient) {
         throw new Error(`Invalid generated Prisma client module: ${entrypoint}`);
     }
-    _provider = provider;
-    _db = new mod.PrismaClient() as PrismaClientType;
+    return new mod.PrismaClient() as PrismaClientType;
+}
+
+export async function createDbSqliteMaintenanceClient(): Promise<PrismaClientType> {
+    return createGeneratedPrismaClient("sqlite");
 }
 
 export async function initDbMysql(): Promise<void> {
@@ -332,7 +340,7 @@ function resolveSqliteJournalSizeLimitBytesFromEnv(env: NodeJS.ProcessEnv): numb
         env.HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES ?? env.HAPPY_SQLITE_JOURNAL_SIZE_LIMIT_BYTES ?? "",
     ).trim();
     if (!raw) return DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES;
-    if (!/^\d+$/.test(raw)) {
+    if (!/^-?\d+$/.test(raw)) {
         throw new Error(
             `Invalid HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES/HAPPY_SQLITE_JOURNAL_SIZE_LIMIT_BYTES: ${raw}`,
         );
@@ -343,6 +351,7 @@ function resolveSqliteJournalSizeLimitBytesFromEnv(env: NodeJS.ProcessEnv): numb
             `Invalid HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES/HAPPY_SQLITE_JOURNAL_SIZE_LIMIT_BYTES: ${raw}`,
         );
     }
+    // SQLite treats negative values as "no limit"; 0 is an explicit minimum-size limit.
     return parsed;
 }
 

--- a/apps/server/sources/storage/prisma.ts
+++ b/apps/server/sources/storage/prisma.ts
@@ -282,6 +282,7 @@ export type SqliteRuntimePragmas = Readonly<{
     journalMode: SqliteJournalMode;
     synchronous: SqliteSynchronousMode;
     busyTimeoutMs: number;
+    journalSizeLimitBytes: number;
 }>;
 
 export type SqliteDatabaseUrlConnectionLimitStatus = "configured" | "missing" | "invalid";
@@ -291,10 +292,16 @@ export type SqliteStartupDiagnostics = Readonly<{
     journalMode: SqliteJournalMode;
     synchronous: SqliteSynchronousMode;
     busyTimeoutMs: number;
+    journalSizeLimitBytes: number;
     databaseUrlSocketTimeoutSeconds: number | null;
     databaseUrlConnectionLimit: number | null;
     databaseUrlConnectionLimitStatus: SqliteDatabaseUrlConnectionLimitStatus;
 }>;
+
+// Cap the WAL file retained after a checkpoint. SQLite's default (-1) means "no limit",
+// which is what allows the WAL to grow without bound between checkpoints. This bounds
+// retained WAL size as a safety net alongside the active checkpoint worker.
+const DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024;
 
 function resolveSqliteJournalModeFromEnv(env: NodeJS.ProcessEnv): SqliteJournalMode {
     const raw = String(env.HAPPIER_SQLITE_JOURNAL_MODE ?? env.HAPPY_SQLITE_JOURNAL_MODE ?? "").trim();
@@ -320,11 +327,31 @@ function resolveSqliteBusyTimeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
     return resolveLightSqliteBusyTimeoutMsFromEnv(env);
 }
 
+function resolveSqliteJournalSizeLimitBytesFromEnv(env: NodeJS.ProcessEnv): number {
+    const raw = String(
+        env.HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES ?? env.HAPPY_SQLITE_JOURNAL_SIZE_LIMIT_BYTES ?? "",
+    ).trim();
+    if (!raw) return DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES;
+    if (!/^\d+$/.test(raw)) {
+        throw new Error(
+            `Invalid HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES/HAPPY_SQLITE_JOURNAL_SIZE_LIMIT_BYTES: ${raw}`,
+        );
+    }
+    const parsed = Number(raw);
+    if (!Number.isSafeInteger(parsed)) {
+        throw new Error(
+            `Invalid HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES/HAPPY_SQLITE_JOURNAL_SIZE_LIMIT_BYTES: ${raw}`,
+        );
+    }
+    return parsed;
+}
+
 export function resolveSqliteRuntimePragmasFromEnv(env: NodeJS.ProcessEnv): SqliteRuntimePragmas {
     return {
         journalMode: resolveSqliteJournalModeFromEnv(env),
         synchronous: resolveSqliteSynchronousModeFromEnv(env),
         busyTimeoutMs: resolveSqliteBusyTimeoutMsFromEnv(env),
+        journalSizeLimitBytes: resolveSqliteJournalSizeLimitBytesFromEnv(env),
     };
 }
 
@@ -358,6 +385,7 @@ export function resolveSqliteStartupDiagnosticsFromEnv(env: NodeJS.ProcessEnv): 
         journalMode: pragmas.journalMode,
         synchronous: pragmas.synchronous,
         busyTimeoutMs: pragmas.busyTimeoutMs,
+        journalSizeLimitBytes: pragmas.journalSizeLimitBytes,
         databaseUrlSocketTimeoutSeconds: parsePositiveInteger(readSqliteDatabaseUrlSearchParam(env, "socket_timeout")),
         databaseUrlConnectionLimit,
         databaseUrlConnectionLimitStatus,
@@ -371,6 +399,7 @@ export async function applySqliteRuntimePragmas(client: PrismaClientType, env: N
     await client.$queryRawUnsafe(`PRAGMA journal_mode=${pragmas.journalMode};`);
     await client.$queryRawUnsafe(`PRAGMA synchronous=${pragmas.synchronous};`);
     await client.$queryRawUnsafe(`PRAGMA busy_timeout=${pragmas.busyTimeoutMs};`);
+    await client.$queryRawUnsafe(`PRAGMA journal_size_limit=${pragmas.journalSizeLimitBytes};`);
 }
 
 export async function shutdownDbPglite(): Promise<void> {

--- a/apps/server/sources/storage/sqliteWalCheckpoint.integration.spec.ts
+++ b/apps/server/sources/storage/sqliteWalCheckpoint.integration.spec.ts
@@ -1,0 +1,53 @@
+import { statSync } from "node:fs";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { db } from "@/storage/db";
+import { checkpointSqliteWal } from "@/storage/sqliteWalCheckpoint";
+import { createLightSqliteHarness, type LightSqliteHarness } from "@/testkit/lightSqliteHarness";
+
+function walSizeBytes(dbPath: string): number {
+    try {
+        return statSync(`${dbPath}-wal`).size;
+    } catch {
+        return 0;
+    }
+}
+
+describe("storage/sqliteWalCheckpoint (integration)", () => {
+    let harness: LightSqliteHarness | null = null;
+
+    afterEach(async () => {
+        if (harness) {
+            await harness.close();
+            harness = null;
+        }
+    });
+
+    it("truncates the WAL file back to zero (prevents checkpoint starvation growth)", async () => {
+        harness = await createLightSqliteHarness({
+            tempDirPrefix: "happier-wal-checkpoint-",
+            initAuth: false,
+            initEncrypt: false,
+            initFiles: false,
+        });
+
+        // Grow the WAL with committed writes. Stay under the ~4MB default autocheckpoint
+        // threshold so the WAL is non-empty when we checkpoint explicitly.
+        await db.$executeRawUnsafe("CREATE TABLE IF NOT EXISTS _wal_probe (id INTEGER PRIMARY KEY, payload TEXT);");
+        const payload = "x".repeat(1024);
+        for (let i = 0; i < 500; i++) {
+            await db.$executeRawUnsafe("INSERT INTO _wal_probe (payload) VALUES (?);", payload);
+        }
+
+        // The WAL file is allocated and non-empty before an explicit truncate checkpoint.
+        // (Passive autocheckpoint may move frames into the db, but it never shrinks the
+        // -wal file itself — only TRUNCATE/RESTART does, which is the behavior under test.)
+        expect(walSizeBytes(harness.dbPath)).toBeGreaterThan(0);
+
+        const result = await checkpointSqliteWal(db);
+
+        expect(result.busy).toBe(0);
+        expect(walSizeBytes(harness.dbPath)).toBe(0);
+    });
+});

--- a/apps/server/sources/storage/sqliteWalCheckpoint.spec.ts
+++ b/apps/server/sources/storage/sqliteWalCheckpoint.spec.ts
@@ -28,6 +28,21 @@ describe("resolveSqliteWalCheckpointIntervalMsFromEnv", () => {
     it("rejects non-numeric values", () => {
         expect(() => resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "soon" })).toThrow();
     });
+
+    it("rejects values that are not safe integers", () => {
+        expect(() =>
+            resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "99999999999999999999" }),
+        ).toThrow();
+    });
+
+    it("rejects intervals beyond the 32-bit setInterval bound", () => {
+        expect(resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "2147483647" })).toBe(
+            2_147_483_647,
+        );
+        expect(() =>
+            resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "2147483648" }),
+        ).toThrow();
+    });
 });
 
 describe("startSqliteWalCheckpointWorker", () => {

--- a/apps/server/sources/storage/sqliteWalCheckpoint.spec.ts
+++ b/apps/server/sources/storage/sqliteWalCheckpoint.spec.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PrismaClientType } from "@/storage/prisma";
+import {
+    resolveSqliteWalCheckpointIntervalMsFromEnv,
+    startSqliteWalCheckpointWorker,
+    type SqliteWalCheckpointResult,
+} from "@/storage/sqliteWalCheckpoint";
+
+// The worker only forwards this to the injected runCheckpoint, so a sentinel is enough.
+const client = {} as unknown as PrismaClientType;
+const ok: SqliteWalCheckpointResult = { busy: 0, logFrames: 0, checkpointedFrames: 0 };
+
+describe("resolveSqliteWalCheckpointIntervalMsFromEnv", () => {
+    it("defaults to 60s when unset", () => {
+        expect(resolveSqliteWalCheckpointIntervalMsFromEnv({})).toBe(60_000);
+    });
+
+    it("treats 0 as disabled", () => {
+        expect(resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "0" })).toBe(0);
+    });
+
+    it("reads an explicit interval and the HAPPY_ alias", () => {
+        expect(resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "5000" })).toBe(5000);
+        expect(resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPY_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "1500" })).toBe(1500);
+    });
+
+    it("rejects non-numeric values", () => {
+        expect(() => resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "soon" })).toThrow();
+    });
+});
+
+describe("startSqliteWalCheckpointWorker", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("returns null when disabled", () => {
+        expect(startSqliteWalCheckpointWorker({ client, intervalMs: 0, runCheckpoint: async () => ok })).toBeNull();
+    });
+
+    it("checkpoints once per interval and stops after stop()", async () => {
+        vi.useFakeTimers();
+        let calls = 0;
+        const handle = startSqliteWalCheckpointWorker({
+            client,
+            intervalMs: 1000,
+            runCheckpoint: async () => {
+                calls += 1;
+                return ok;
+            },
+        });
+        expect(handle).not.toBeNull();
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(calls).toBe(1);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(calls).toBe(2);
+
+        await handle!.stop();
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(calls).toBe(2);
+    });
+
+    it("does not overlap checkpoints when one is slower than the interval", async () => {
+        vi.useFakeTimers();
+        let started = 0;
+        const releases: Array<() => void> = [];
+
+        const handle = startSqliteWalCheckpointWorker({
+            client,
+            intervalMs: 1000,
+            runCheckpoint: async () => {
+                started += 1;
+                await new Promise<void>((resolve) => {
+                    releases.push(resolve);
+                });
+                return ok;
+            },
+        });
+
+        await vi.advanceTimersByTimeAsync(1000); // run #1 starts, blocks on its gate
+        expect(started).toBe(1);
+        await vi.advanceTimersByTimeAsync(1000); // tick again: in-flight, must skip
+        expect(started).toBe(1);
+
+        releases[0](); // let run #1 finish
+        await vi.advanceTimersByTimeAsync(1000); // next tick runs #2
+        expect(started).toBe(2);
+
+        releases.forEach((release) => release());
+        await handle!.stop();
+    });
+
+    it("stop() waits for an in-flight checkpoint", async () => {
+        vi.useFakeTimers();
+        let finished = false;
+        let release!: () => void;
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        const handle = startSqliteWalCheckpointWorker({
+            client,
+            intervalMs: 1000,
+            runCheckpoint: async () => {
+                await gate;
+                finished = true;
+                return ok;
+            },
+        });
+
+        await vi.advanceTimersByTimeAsync(1000); // run in flight, blocked on gate
+        let stopResolved = false;
+        const stopPromise = handle!.stop().then(() => {
+            stopResolved = true;
+        });
+        await Promise.resolve();
+        expect(stopResolved).toBe(false); // still awaiting the in-flight checkpoint
+        expect(finished).toBe(false);
+
+        release();
+        await stopPromise;
+        expect(finished).toBe(true);
+    });
+});

--- a/apps/server/sources/storage/sqliteWalCheckpoint.spec.ts
+++ b/apps/server/sources/storage/sqliteWalCheckpoint.spec.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { PrismaClientType } from "@/storage/prisma";
 import {
+    checkpointSqliteWal,
+    resolveSqliteWalCheckpointBusyTimeoutMsFromEnv,
     resolveSqliteWalCheckpointIntervalMsFromEnv,
     startSqliteWalCheckpointWorker,
     type SqliteWalCheckpointResult,
@@ -42,6 +44,71 @@ describe("resolveSqliteWalCheckpointIntervalMsFromEnv", () => {
         expect(() =>
             resolveSqliteWalCheckpointIntervalMsFromEnv({ HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: "2147483648" }),
         ).toThrow();
+    });
+});
+
+describe("resolveSqliteWalCheckpointBusyTimeoutMsFromEnv", () => {
+    it("defaults to a bounded wait for reader gaps", () => {
+        expect(resolveSqliteWalCheckpointBusyTimeoutMsFromEnv({})).toBe(5_000);
+    });
+
+    it("reads an explicit timeout and the HAPPY_ alias", () => {
+        expect(resolveSqliteWalCheckpointBusyTimeoutMsFromEnv({
+            HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS: "2500",
+        })).toBe(2500);
+        expect(resolveSqliteWalCheckpointBusyTimeoutMsFromEnv({
+            HAPPY_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS: "1500",
+        })).toBe(1500);
+    });
+
+    it("allows 0 for an explicitly opportunistic checkpoint", () => {
+        expect(resolveSqliteWalCheckpointBusyTimeoutMsFromEnv({
+            HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS: "0",
+        })).toBe(0);
+    });
+
+    it("rejects invalid or unsafe timeout values", () => {
+        expect(() =>
+            resolveSqliteWalCheckpointBusyTimeoutMsFromEnv({
+                HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS: "soon",
+            }),
+        ).toThrow();
+        expect(() =>
+            resolveSqliteWalCheckpointBusyTimeoutMsFromEnv({
+                HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS: "99999999999999999999",
+            }),
+        ).toThrow();
+        expect(() =>
+            resolveSqliteWalCheckpointBusyTimeoutMsFromEnv({
+                HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS: "2147483648",
+            }),
+        ).toThrow();
+    });
+});
+
+describe("checkpointSqliteWal", () => {
+    it("reads documented SQLite column names first", async () => {
+        const fakeClient = {
+            $queryRawUnsafe: vi.fn(async () => [{ busy: 1n, log: 7n, checkpointed: 3n }]),
+        } as unknown as PrismaClientType;
+
+        await expect(checkpointSqliteWal(fakeClient)).resolves.toEqual({
+            busy: 1,
+            logFrames: 7,
+            checkpointedFrames: 3,
+        });
+    });
+
+    it("falls back to positional column order for driver-shaped rows", async () => {
+        const fakeClient = {
+            $queryRawUnsafe: vi.fn(async () => [{ 0: 0, 1: 11, 2: 9 }]),
+        } as unknown as PrismaClientType;
+
+        await expect(checkpointSqliteWal(fakeClient)).resolves.toEqual({
+            busy: 0,
+            logFrames: 11,
+            checkpointedFrames: 9,
+        });
     });
 });
 

--- a/apps/server/sources/storage/sqliteWalCheckpoint.ts
+++ b/apps/server/sources/storage/sqliteWalCheckpoint.ts
@@ -6,14 +6,18 @@ import { log } from "@/utils/logging/log";
 // Passive autocheckpoint can be starved indefinitely by long-lived / overlapping
 // read transactions (e.g. session-message subscriptions). When that happens the
 // WAL grows without bound, every read slows down as it scans WAL frames, and writes
-// eventually exceed Prisma's query timeout and surface as `Socket timeout` errors —
-// the server looks "crashed" while the CPU sits idle. An actively-driven
-// `wal_checkpoint(TRUNCATE)` keeps the WAL bounded regardless of reader pressure.
+// can eventually exceed Prisma's query timeout and surface as `Socket timeout`
+// errors. An actively-driven `wal_checkpoint(TRUNCATE)` gives the server a
+// best-effort maintenance loop that truncates the WAL whenever SQLite can get a
+// reader gap.
 const DEFAULT_WAL_CHECKPOINT_INTERVAL_MS = 60_000;
+const DEFAULT_WAL_CHECKPOINT_BUSY_TIMEOUT_MS = 5_000;
 
 // `setInterval` stores its delay in a 32-bit signed int. A larger value is silently
 // coerced to 1ms (with a TimeoutOverflowWarning), which would turn this into a hot loop.
 const MAX_TIMER_INTERVAL_MS = 2_147_483_647;
+// SQLite's busy timeout API also takes a signed 32-bit millisecond value.
+const MAX_SQLITE_BUSY_TIMEOUT_MS = 2_147_483_647;
 
 export type SqliteWalCheckpointResult = Readonly<{
     // SQLite returns 1 when the checkpoint could not run to completion because the
@@ -52,6 +56,38 @@ export function resolveSqliteWalCheckpointIntervalMsFromEnv(env: NodeJS.ProcessE
     if (parsed > MAX_TIMER_INTERVAL_MS) {
         throw new Error(
             `HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS/HAPPY_SQLITE_WAL_CHECKPOINT_INTERVAL_MS must be <= ${MAX_TIMER_INTERVAL_MS}: ${raw}`,
+        );
+    }
+    return parsed;
+}
+
+/**
+ * Resolve how long a TRUNCATE checkpoint may wait for reader/writer gaps.
+ *
+ * Env: `HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS` / `HAPPY_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS`
+ *  - unset            -> default (5s)
+ *  - "0"              -> opportunistic only
+ *  - positive integer -> that many ms
+ */
+export function resolveSqliteWalCheckpointBusyTimeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
+    const raw = String(
+        env.HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS ?? env.HAPPY_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS ?? "",
+    ).trim();
+    if (!raw) return DEFAULT_WAL_CHECKPOINT_BUSY_TIMEOUT_MS;
+    if (!/^\d+$/.test(raw)) {
+        throw new Error(
+            `Invalid HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS/HAPPY_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS: ${raw}`,
+        );
+    }
+    const parsed = Number(raw);
+    if (!Number.isSafeInteger(parsed)) {
+        throw new Error(
+            `Invalid HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS/HAPPY_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS: ${raw}`,
+        );
+    }
+    if (parsed > MAX_SQLITE_BUSY_TIMEOUT_MS) {
+        throw new Error(
+            `HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS/HAPPY_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS must be <= ${MAX_SQLITE_BUSY_TIMEOUT_MS}: ${raw}`,
         );
     }
     return parsed;
@@ -125,7 +161,6 @@ export function startSqliteWalCheckpointWorker(
                 inFlight = null;
             }
         })();
-        await inFlight;
     };
 
     const timer = setInterval(() => {

--- a/apps/server/sources/storage/sqliteWalCheckpoint.ts
+++ b/apps/server/sources/storage/sqliteWalCheckpoint.ts
@@ -1,6 +1,5 @@
+import type { PrismaClientType } from "@/storage/prisma";
 import { log } from "@/utils/logging/log";
-
-import type { PrismaClientType } from "./prisma";
 
 // Active WAL checkpoint cadence for the light/sqlite server.
 //
@@ -11,6 +10,10 @@ import type { PrismaClientType } from "./prisma";
 // the server looks "crashed" while the CPU sits idle. An actively-driven
 // `wal_checkpoint(TRUNCATE)` keeps the WAL bounded regardless of reader pressure.
 const DEFAULT_WAL_CHECKPOINT_INTERVAL_MS = 60_000;
+
+// `setInterval` stores its delay in a 32-bit signed int. A larger value is silently
+// coerced to 1ms (with a TimeoutOverflowWarning), which would turn this into a hot loop.
+const MAX_TIMER_INTERVAL_MS = 2_147_483_647;
 
 export type SqliteWalCheckpointResult = Readonly<{
     // SQLite returns 1 when the checkpoint could not run to completion because the
@@ -46,6 +49,11 @@ export function resolveSqliteWalCheckpointIntervalMsFromEnv(env: NodeJS.ProcessE
             `Invalid HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS/HAPPY_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: ${raw}`,
         );
     }
+    if (parsed > MAX_TIMER_INTERVAL_MS) {
+        throw new Error(
+            `HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS/HAPPY_SQLITE_WAL_CHECKPOINT_INTERVAL_MS must be <= ${MAX_TIMER_INTERVAL_MS}: ${raw}`,
+        );
+    }
     return parsed;
 }
 
@@ -54,17 +62,19 @@ export function resolveSqliteWalCheckpointIntervalMsFromEnv(env: NodeJS.ProcessE
  * Returns SQLite's `(busy, log, checkpointed)` triple.
  */
 export async function checkpointSqliteWal(client: PrismaClientType): Promise<SqliteWalCheckpointResult> {
-    // `PRAGMA wal_checkpoint(TRUNCATE)` returns exactly three integer columns in the
-    // order (busy, log, checkpointed). Read positionally so we do not depend on the
-    // driver's column-naming of pragma results.
+    // `PRAGMA wal_checkpoint(TRUNCATE)` returns three integer columns documented as
+    // (busy, log, checkpointed). Prefer SQLite's documented column names, falling back
+    // to positional order, so we are robust to driver-specific result shaping either way.
     const rows = await client.$queryRawUnsafe<Array<Record<string, number | bigint>>>(
         "PRAGMA wal_checkpoint(TRUNCATE);",
     );
-    const values = rows[0] ? Object.values(rows[0]).map((value) => Number(value)) : [];
+    const row = rows[0] ?? {};
+    const positional = Object.values(row);
+    const read = (name: string, index: number): number => Number(row[name] ?? positional[index] ?? 0);
     return {
-        busy: values[0] ?? 0,
-        logFrames: values[1] ?? 0,
-        checkpointedFrames: values[2] ?? 0,
+        busy: read("busy", 0),
+        logFrames: read("log", 1),
+        checkpointedFrames: read("checkpointed", 2),
     };
 }
 

--- a/apps/server/sources/storage/sqliteWalCheckpoint.ts
+++ b/apps/server/sources/storage/sqliteWalCheckpoint.ts
@@ -1,0 +1,135 @@
+import { log } from "@/utils/logging/log";
+
+import type { PrismaClientType } from "./prisma";
+
+// Active WAL checkpoint cadence for the light/sqlite server.
+//
+// Passive autocheckpoint can be starved indefinitely by long-lived / overlapping
+// read transactions (e.g. session-message subscriptions). When that happens the
+// WAL grows without bound, every read slows down as it scans WAL frames, and writes
+// eventually exceed Prisma's query timeout and surface as `Socket timeout` errors —
+// the server looks "crashed" while the CPU sits idle. An actively-driven
+// `wal_checkpoint(TRUNCATE)` keeps the WAL bounded regardless of reader pressure.
+const DEFAULT_WAL_CHECKPOINT_INTERVAL_MS = 60_000;
+
+export type SqliteWalCheckpointResult = Readonly<{
+    // SQLite returns 1 when the checkpoint could not run to completion because the
+    // database was busy (e.g. a reader held the WAL), 0 otherwise.
+    busy: number;
+    // Size of the WAL log in frames before the checkpoint.
+    logFrames: number;
+    // Number of frames moved back into the database file.
+    checkpointedFrames: number;
+}>;
+
+/**
+ * Resolve the interval (ms) between active WAL checkpoints.
+ *
+ * Env: `HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS` / `HAPPY_SQLITE_WAL_CHECKPOINT_INTERVAL_MS`
+ *  - unset            -> default (60s)
+ *  - "0"              -> disabled
+ *  - positive integer -> that many ms
+ */
+export function resolveSqliteWalCheckpointIntervalMsFromEnv(env: NodeJS.ProcessEnv): number {
+    const raw = String(
+        env.HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS ?? env.HAPPY_SQLITE_WAL_CHECKPOINT_INTERVAL_MS ?? "",
+    ).trim();
+    if (!raw) return DEFAULT_WAL_CHECKPOINT_INTERVAL_MS;
+    if (!/^\d+$/.test(raw)) {
+        throw new Error(
+            `Invalid HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS/HAPPY_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: ${raw}`,
+        );
+    }
+    const parsed = Number(raw);
+    if (!Number.isSafeInteger(parsed)) {
+        throw new Error(
+            `Invalid HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS/HAPPY_SQLITE_WAL_CHECKPOINT_INTERVAL_MS: ${raw}`,
+        );
+    }
+    return parsed;
+}
+
+/**
+ * Run a single TRUNCATE checkpoint, resetting the WAL file to zero bytes when it can.
+ * Returns SQLite's `(busy, log, checkpointed)` triple.
+ */
+export async function checkpointSqliteWal(client: PrismaClientType): Promise<SqliteWalCheckpointResult> {
+    // `PRAGMA wal_checkpoint(TRUNCATE)` returns exactly three integer columns in the
+    // order (busy, log, checkpointed). Read positionally so we do not depend on the
+    // driver's column-naming of pragma results.
+    const rows = await client.$queryRawUnsafe<Array<Record<string, number | bigint>>>(
+        "PRAGMA wal_checkpoint(TRUNCATE);",
+    );
+    const values = rows[0] ? Object.values(rows[0]).map((value) => Number(value)) : [];
+    return {
+        busy: values[0] ?? 0,
+        logFrames: values[1] ?? 0,
+        checkpointedFrames: values[2] ?? 0,
+    };
+}
+
+export type SqliteWalCheckpointWorkerHandle = Readonly<{ stop: () => Promise<void> }>;
+
+export type StartSqliteWalCheckpointWorkerOptions = Readonly<{
+    client: PrismaClientType;
+    intervalMs: number;
+    // Injectable for tests; defaults to a real TRUNCATE checkpoint.
+    runCheckpoint?: (client: PrismaClientType) => Promise<SqliteWalCheckpointResult>;
+}>;
+
+/**
+ * Start a background worker that periodically issues `PRAGMA wal_checkpoint(TRUNCATE)`.
+ *
+ * Returns `null` when checkpointing is disabled (`intervalMs <= 0`). The returned
+ * handle's `stop()` clears the timer and awaits any in-flight checkpoint so it is
+ * safe to call during shutdown even though shutdown handlers run concurrently.
+ */
+export function startSqliteWalCheckpointWorker(
+    options: StartSqliteWalCheckpointWorkerOptions,
+): SqliteWalCheckpointWorkerHandle | null {
+    if (options.intervalMs <= 0) {
+        return null;
+    }
+    const runCheckpoint = options.runCheckpoint ?? checkpointSqliteWal;
+
+    let stopped = false;
+    let inFlight: Promise<void> | null = null;
+
+    const run = async (): Promise<void> => {
+        if (stopped || inFlight) return;
+        inFlight = (async () => {
+            try {
+                const result = await runCheckpoint(options.client);
+                if (result.busy !== 0) {
+                    log(
+                        { module: "storage", event: "sqlite-wal-checkpoint-busy", sqliteWalCheckpoint: result },
+                        "SQLite WAL checkpoint could not fully complete (database busy)",
+                    );
+                }
+            } catch (error) {
+                log(
+                    { module: "storage", event: "sqlite-wal-checkpoint-failed", error },
+                    "SQLite WAL checkpoint failed",
+                );
+            } finally {
+                inFlight = null;
+            }
+        })();
+        await inFlight;
+    };
+
+    const timer = setInterval(() => {
+        void run();
+    }, options.intervalMs);
+    timer.unref?.();
+
+    return {
+        stop: async () => {
+            stopped = true;
+            clearInterval(timer);
+            if (inFlight) {
+                await inFlight;
+            }
+        },
+    };
+}

--- a/apps/server/sources/testkit/startServerMocks.ts
+++ b/apps/server/sources/testkit/startServerMocks.ts
@@ -76,6 +76,16 @@ export function createStartServerDbMocks(options: StartServerDbMockOptions = {})
   const initDbPglite = vi.fn()
   const initDbMysql = vi.fn()
   const initDbSqlite = vi.fn()
+  const sqliteMaintenanceClientConnect = vi.fn()
+  const sqliteMaintenanceClientDisconnect = vi.fn()
+  const sqliteMaintenanceClientQueryRawUnsafe = vi.fn()
+  const sqliteMaintenanceClient = {
+    $connect: (...args: any[]) => sqliteMaintenanceClientConnect(...args),
+    $disconnect: (...args: any[]) => sqliteMaintenanceClientDisconnect(...args),
+    $queryRawUnsafe: (...args: any[]) => sqliteMaintenanceClientQueryRawUnsafe(...args),
+  }
+  const createDbSqliteMaintenanceClient = vi.fn()
+  const applySqliteRuntimePragmas = vi.fn()
   const shutdownDbPglite = vi.fn()
   const getDbProviderFromEnv = vi.fn<StartServerDbProviderReader>()
   const simpleCacheFindUnique = vi.fn()
@@ -92,6 +102,11 @@ export function createStartServerDbMocks(options: StartServerDbMockOptions = {})
     initDbPglite.mockReset().mockImplementation(async () => {})
     initDbMysql.mockReset().mockImplementation(async () => {})
     initDbSqlite.mockReset().mockImplementation(async () => {})
+    sqliteMaintenanceClientConnect.mockReset().mockImplementation(async () => {})
+    sqliteMaintenanceClientDisconnect.mockReset().mockImplementation(async () => {})
+    sqliteMaintenanceClientQueryRawUnsafe.mockReset().mockImplementation(async () => [])
+    createDbSqliteMaintenanceClient.mockReset().mockImplementation(async () => sqliteMaintenanceClient)
+    applySqliteRuntimePragmas.mockReset().mockImplementation(async () => {})
     shutdownDbPglite.mockReset().mockImplementation(async () => {})
     getDbProviderFromEnv.mockReset().mockImplementation(options.getDbProviderFromEnv ?? ((_env, fallback) => fallback))
     simpleCacheFindUnique.mockReset().mockResolvedValue(null)
@@ -118,6 +133,8 @@ export function createStartServerDbMocks(options: StartServerDbMockOptions = {})
       initDbPglite: (...args: any[]) => initDbPglite(...args),
       initDbMysql: (...args: any[]) => initDbMysql(...args),
       initDbSqlite: (...args: any[]) => initDbSqlite(...args),
+      createDbSqliteMaintenanceClient: (...args: any[]) => createDbSqliteMaintenanceClient(...args),
+      applySqliteRuntimePragmas: (...args: any[]) => applySqliteRuntimePragmas(...args),
       shutdownDbPglite: (...args: any[]) => shutdownDbPglite(...args),
       isPrismaErrorCode: (...args: [unknown, string]) => isPrismaErrorCode(...args),
     },
@@ -131,6 +148,12 @@ export function createStartServerDbMocks(options: StartServerDbMockOptions = {})
     initDbPglite,
     initDbMysql,
     initDbSqlite,
+    sqliteMaintenanceClient,
+    sqliteMaintenanceClientConnect,
+    sqliteMaintenanceClientDisconnect,
+    sqliteMaintenanceClientQueryRawUnsafe,
+    createDbSqliteMaintenanceClient,
+    applySqliteRuntimePragmas,
     shutdownDbPglite,
     isPrismaErrorCode,
     reset,


### PR DESCRIPTION
## What & why

Fixes #189.

On the **light/sqlite flavor**, the relay periodically stalled: writes failed with Prisma `Socket timeout (the database failed to respond to a query within the configured timeout)`, the app showed sessions/machine offline ("crashed"), and only a manual restart + `wal_checkpoint(TRUNCATE)` recovered it.

Root cause is **WAL checkpoint starvation**. There was no application-level WAL checkpoint management, so under continuous overlapping readers (e.g. session-message subscriptions) the passive autocheckpoint never reset the WAL. The WAL grew without bound, reads slowed as they scanned WAL frames, and operations eventually exceeded Prisma's query timeout. CPU stayed near-idle throughout (lock/IO wait, not load). Observed in the wild with the WAL frozen at 37MB for 11+ hours while autocheckpoint sat at ~4MB.

## Change

- **Active WAL checkpoint worker** (`sources/storage/sqliteWalCheckpoint.ts`): periodic `PRAGMA wal_checkpoint(TRUNCATE)` for the sqlite provider, wired into `startServer` and stopped on shutdown (`stop()` awaits any in-flight checkpoint, since shutdown handlers run concurrently). Interval via `HAPPIER_SQLITE_WAL_CHECKPOINT_INTERVAL_MS` (default `60000`, `0` disables). Overlap-guarded; errors are logged, not thrown.
- **`PRAGMA journal_size_limit`** added to `applySqliteRuntimePragmas` (default 64MiB, `HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES`) as a retained-WAL safety net, surfaced in `SqliteStartupDiagnostics`.

This bounds the WAL regardless of reader pressure, which is the durable fix; `busy_timeout` alone does not address it because the failure is the query/socket timeout firing under WAL bloat, not lock acquisition.

## Tests

- `sqliteWalCheckpoint.spec.ts` (unit): interval resolver (default/disabled/alias/invalid); worker returns null when disabled, checkpoints once per interval, stops after `stop()`, does not overlap a slow checkpoint, and `stop()` awaits the in-flight run.
- `sqliteWalCheckpoint.integration.spec.ts`: real light/sqlite harness — grows the WAL, then `checkpointSqliteWal` returns `busy=0` and truncates the `-wal` file back to **0 bytes**.
- Extended `prisma.sqlitePragmas.integration.spec.ts` to assert `journal_size_limit` is applied and the new diagnostics field.

### Validation run locally
- `vitest` unit (storage lane): 45 passed
- `vitest` integration (sqlite pragmas + WAL checkpoint): passed
- `tsc --noEmit` (server `yarn build`): clean

## Notes / out of scope

The failing write paths in the incident (`usageReport.upsert`, session update) run outside `inTx()` so they don't get its retry; routing them through `inTx` and ensuring `socket_timeout >= busy_timeout` are reasonable follow-ups but kept out of this PR to stay focused on the root cause.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784755753&installation_id=129174028&pr_number=190&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F190&signature=b23bca0e9cf1bee492ce880cb84e3c45e70a5d2aad595ad12d5e92cc469421b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic SQLite WAL checkpointing that periodically truncates WAL on a configurable interval, with graceful shutdown that stops the worker before disconnecting database resources.
  * Added runtime support for SQLite `journal_size_limit`, including applying the pragma and surfacing it in sanitized startup diagnostics.
  * Added environment configuration for the WAL checkpoint busy timeout used during maintenance.

* **Tests**
  * Added integration coverage confirming WAL file growth is prevented and truncation occurs, plus shutdown ordering for SQLite WAL checkpoint worker stop behavior.
  * Expanded unit/integration tests for interval/busy-timeout configuration and Prisma SQLite pragma diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add background SQLite WAL checkpoint worker to prevent checkpoint starvation
> - Adds [`startSqliteWalCheckpointWorker`](https://github.com/happier-dev/happier/pull/190/files#diff-71b070edcfe48e930faed777b4a893b82ffae4f0efafcf1a95455e3bc3fc38d2) that runs `PRAGMA wal_checkpoint(TRUNCATE)` on a configurable interval (default 60s) using a dedicated maintenance Prisma client, avoiding overlapping runs and logging busy/failure events.
> - Adds [`createDbSqliteMaintenanceClient`](https://github.com/happier-dev/happier/pull/190/files#diff-c7a6e17f06e79f0a431255aa2c6e5c6a8894b8c8a43320c76e28143ef5d97168) to create a separate SQLite Prisma client for checkpoint operations, with its own runtime pragmas and a configurable busy timeout (default 5s, env: `HAPPIER_SQLITE_WAL_CHECKPOINT_BUSY_TIMEOUT_MS`).
> - Applies `PRAGMA journal_size_limit` (default 64 MiB) on SQLite connections to cap retained WAL file size, configurable via `HAPPIER_SQLITE_JOURNAL_SIZE_LIMIT_BYTES`.
> - Updates [`startServer`](https://github.com/happier-dev/happier/pull/190/files#diff-3aa34c322afb3e107e9ea65eaf08406b38ad62703e6b8b9081afa749d14a7d8e) shutdown ordering: stops the checkpoint worker, disconnects the maintenance client, then disconnects the main Prisma client.
> - Behavioral Change: SQLite deployments now open a second Prisma client at startup unless the checkpoint interval is disabled by setting the interval env var to `0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf8bf50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->