### PR TITLE
fix(cli): render assistant &lt;options&gt; blocks as a numbered list in the remote transcript view

### DIFF
--- a/apps/cli/src/backends/gemini/runGemini.ts
+++ b/apps/cli/src/backends/gemini/runGemini.ts
@@ -74,8 +74,7 @@ import {
 import { maybeUpdateGeminiSessionIdMetadata } from '@/backends/gemini/utils/geminiSessionIdMetadata';
 import { updateMetadataBestEffort } from '@/api/session/sessionWritesBestEffort';
 import {
-  parseOptionsFromText,
-  hasIncompleteOptions,
+  segmentTrailingOptions,
   formatOptionsXml,
 } from '@/utils/optionsParser';
 import { ConversationHistory } from '@/backends/gemini/utils/conversationHistory';
@@ -983,7 +982,11 @@ export async function runGemini(opts: {
         // Send accumulated response to mobile app ONLY when turn is complete
         // This prevents message fragmentation from Gemini's chunked responses
         if (hasAssistantOutput) {
-          const { text: messageText, options } = parseOptionsFromText(turnMessageState.accumulatedResponse);
+          const { before, options, hasIncompleteTrailingOptions } = segmentTrailingOptions(turnMessageState.accumulatedResponse);
+          // Trim the app-facing message (Gemini display concern) to stay
+          // byte-identical to the previous parseOptionsFromText behavior; the
+          // terminal formatter path preserves surrounding whitespace verbatim.
+          const messageText = before.trim();
           
           // Record assistant response in conversation history for context preservation
           conversationHistory.addAssistantMessage(messageText);
@@ -994,7 +997,7 @@ export async function runGemini(opts: {
             const optionsXml = formatOptionsXml(options);
             finalMessageText = messageText + optionsXml;
             logger.debug(`[gemini] Found ${options.length} options in response`);
-          } else if (hasIncompleteOptions(turnMessageState.accumulatedResponse)) {
+          } else if (hasIncompleteTrailingOptions) {
             logger.debug(`[gemini] Warning: Incomplete options block detected`);
           }
           

--- a/apps/cli/src/backends/gemini/runGemini.ts
+++ b/apps/cli/src/backends/gemini/runGemini.ts
@@ -77,7 +77,7 @@ import {
   parseOptionsFromText,
   hasIncompleteOptions,
   formatOptionsXml,
-} from '@/backends/gemini/utils/optionsParser';
+} from '@/utils/optionsParser';
 import { ConversationHistory } from '@/backends/gemini/utils/conversationHistory';
 import { createGeminiBackendMessageHandler } from '@/backends/gemini/runtime/createGeminiBackendMessageHandler';
 import { reportGeminiConnectedServiceRuntimeAuthFailureBestEffort } from '@/backends/gemini/connectedServices/surfaceGeminiConnectedServiceRuntimeAuthFailure';

--- a/apps/cli/src/ui/messageFormatter.ts
+++ b/apps/cli/src/ui/messageFormatter.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { SDKMessage, SDKAssistantMessage, SDKResultMessage, SDKSystemMessage, SDKUserMessage } from '@/backends/claude/sdk';
+import { formatTextWithOptionsForTerminal } from '@/utils/optionsParser';
 import { logger } from './logger';
 
 export type OnAssistantResultCallback = (result: SDKResultMessage) => void | Promise<void>;
@@ -76,7 +77,7 @@ export function formatClaudeMessage(
                 // Handle content array (can contain text blocks and tool use blocks)
                 for (const block of assistantMsg.message.content) {
                     if (block.type === 'text') {
-                        console.log(block.text);
+                        console.log(formatTextWithOptionsForTerminal(block.text ?? ''));
                     } else if (block.type === 'tool_use') {
                         console.log(chalk.yellow.bold(`\n🔧 Tool: ${block.name}`));
                         if (block.input) {
@@ -99,7 +100,7 @@ export function formatClaudeMessage(
             if (resultMsg.subtype === 'success') {
                 if ('result' in resultMsg && resultMsg.result) {
                     console.log(chalk.green.bold('\n✨ Summary:'));
-                    console.log(resultMsg.result);
+                    console.log(formatTextWithOptionsForTerminal(resultMsg.result));
                 }
                 
                 // Show usage stats

--- a/apps/cli/src/ui/messageFormatter.ts
+++ b/apps/cli/src/ui/messageFormatter.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import type { SDKMessage, SDKAssistantMessage, SDKResultMessage, SDKSystemMessage, SDKUserMessage } from '@/backends/claude/sdk';
-import { formatTextWithOptionsForTerminal } from '@/utils/optionsParser';
 import { logger } from './logger';
 
 export type OnAssistantResultCallback = (result: SDKResultMessage) => void | Promise<void>;
@@ -77,7 +76,7 @@ export function formatClaudeMessage(
                 // Handle content array (can contain text blocks and tool use blocks)
                 for (const block of assistantMsg.message.content) {
                     if (block.type === 'text') {
-                        console.log(formatTextWithOptionsForTerminal(block.text ?? ''));
+                        console.log(block.text);
                     } else if (block.type === 'tool_use') {
                         console.log(chalk.yellow.bold(`\n🔧 Tool: ${block.name}`));
                         if (block.input) {
@@ -100,7 +99,7 @@ export function formatClaudeMessage(
             if (resultMsg.subtype === 'success') {
                 if ('result' in resultMsg && resultMsg.result) {
                     console.log(chalk.green.bold('\n✨ Summary:'));
-                    console.log(formatTextWithOptionsForTerminal(resultMsg.result));
+                    console.log(resultMsg.result);
                 }
                 
                 // Show usage stats

--- a/apps/cli/src/ui/messageFormatterInk.test.ts
+++ b/apps/cli/src/ui/messageFormatterInk.test.ts
@@ -7,9 +7,20 @@ function buildAssistantMessage(text: string): SDKMessage {
     return {
         type: 'assistant',
         message: {
+            role: 'assistant',
             content: [{ type: 'text', text }],
         },
-    } as unknown as SDKAssistantMessage
+    } satisfies SDKAssistantMessage
+}
+
+function buildAssistantMessageFromTextBlocks(...texts: string[]): SDKMessage {
+    return {
+        type: 'assistant',
+        message: {
+            role: 'assistant',
+            content: texts.map((text) => ({ type: 'text', text })),
+        },
+    } satisfies SDKAssistantMessage
 }
 
 describe('formatClaudeMessageForInk', () => {
@@ -32,6 +43,21 @@ describe('formatClaudeMessageForInk', () => {
 
         const contents = messageBuffer.getMessages().map((m) => m.content)
         expect(contents).toContain(text)
+    })
+
+    it('assembles an options block split across two adjacent text blocks', () => {
+        const messageBuffer = new MessageBuffer()
+        const message = buildAssistantMessageFromTextBlocks(
+            'Should I proceed?\n\n<options>\n<option>Yes, go ahead</option>\n',
+            '<option>No, stop here</option>\n</options>',
+        )
+
+        formatClaudeMessageForInk(message, messageBuffer)
+
+        const contents = messageBuffer.getMessages().map((m) => m.content)
+        expect(contents).toContain('Should I proceed?\n\nOptions:\n  1. Yes, go ahead\n  2. No, stop here')
+        expect(contents.join('\n')).not.toContain('<options>')
+        expect(contents.join('\n')).not.toContain('<option>')
     })
 
     it('renders <options> blocks in the result summary as a numbered list', () => {

--- a/apps/cli/src/ui/messageFormatterInk.test.ts
+++ b/apps/cli/src/ui/messageFormatterInk.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import type { SDKAssistantMessage, SDKMessage, SDKResultMessage } from '@/backends/claude/sdk'
+import { MessageBuffer } from './ink/messageBuffer'
+import { formatClaudeMessageForInk } from './messageFormatterInk'
+
+function buildAssistantMessage(text: string): SDKMessage {
+    return {
+        type: 'assistant',
+        message: {
+            content: [{ type: 'text', text }],
+        },
+    } as unknown as SDKAssistantMessage
+}
+
+describe('formatClaudeMessageForInk', () => {
+    it('renders assistant <options> blocks as a numbered list instead of raw XML', () => {
+        const messageBuffer = new MessageBuffer()
+        const text = 'Should I proceed?\n\n<options>\n    <option>Yes, go ahead</option>\n    <option>No, stop here</option>\n</options>'
+
+        formatClaudeMessageForInk(buildAssistantMessage(text), messageBuffer)
+
+        const contents = messageBuffer.getMessages().map((m) => m.content)
+        expect(contents).toContain('Should I proceed?\n\nOptions:\n  1. Yes, go ahead\n  2. No, stop here')
+        expect(contents.join('\n')).not.toContain('<options>')
+    })
+
+    it('leaves assistant text without options untouched', () => {
+        const messageBuffer = new MessageBuffer()
+        const text = 'All done. Nothing to choose here.'
+
+        formatClaudeMessageForInk(buildAssistantMessage(text), messageBuffer)
+
+        const contents = messageBuffer.getMessages().map((m) => m.content)
+        expect(contents).toContain(text)
+    })
+
+    it('renders <options> blocks in the result summary as a numbered list', () => {
+        const messageBuffer = new MessageBuffer()
+        const resultMessage = {
+            type: 'result',
+            subtype: 'success',
+            result: 'Pick a next step.\n\n<options>\n<option>Continue</option>\n<option>Abort</option>\n</options>',
+        } as unknown as SDKResultMessage
+
+        formatClaudeMessageForInk(resultMessage, messageBuffer)
+
+        const contents = messageBuffer.getMessages().map((m) => m.content)
+        expect(contents).toContain('Pick a next step.\n\nOptions:\n  1. Continue\n  2. Abort')
+        expect(contents.join('\n')).not.toContain('<options>')
+    })
+})

--- a/apps/cli/src/ui/messageFormatterInk.ts
+++ b/apps/cli/src/ui/messageFormatterInk.ts
@@ -1,4 +1,5 @@
 import type { SDKMessage, SDKAssistantMessage, SDKResultMessage, SDKSystemMessage, SDKUserMessage } from '@/backends/claude/sdk'
+import { formatTextWithOptionsForTerminal } from '@/utils/optionsParser'
 import type { MessageBuffer } from './ink/messageBuffer'
 import { logger } from './logger'
 
@@ -72,7 +73,7 @@ export function formatClaudeMessageForInk(
                 
                 for (const block of assistantMsg.message.content) {
                     if (block.type === 'text') {
-                        messageBuffer.addMessage(block.text || '', 'assistant')
+                        messageBuffer.addMessage(formatTextWithOptionsForTerminal(block.text || ''), 'assistant')
                     } else if (block.type === 'tool_use') {
                         messageBuffer.addMessage(`🔧 Tool: ${block.name}`, 'tool')
                         if (block.input) {
@@ -95,7 +96,7 @@ export function formatClaudeMessageForInk(
             if (resultMsg.subtype === 'success') {
                 if ('result' in resultMsg && resultMsg.result) {
                     messageBuffer.addMessage('✨ Summary:', 'result')
-                    messageBuffer.addMessage(resultMsg.result || '', 'result')
+                    messageBuffer.addMessage(formatTextWithOptionsForTerminal(resultMsg.result || ''), 'result')
                 }
                 
                 if (resultMsg.usage) {

--- a/apps/cli/src/ui/messageFormatterInk.ts
+++ b/apps/cli/src/ui/messageFormatterInk.ts
@@ -70,11 +70,31 @@ export function formatClaudeMessageForInk(
             const assistantMsg = message as SDKAssistantMessage
             if (assistantMsg.message && assistantMsg.message.content) {
                 messageBuffer.addMessage('🤖 Assistant:', 'assistant')
-                
+
+                // Options can be split across adjacent SDK text blocks (the model
+                // streams one logical message as several contiguous text
+                // fragments). Assemble each contiguous run of text blocks into one
+                // string and format it ONCE so a trailing <options> block that
+                // spans the block boundary is still recognised. Flush the run on
+                // any non-text block or at the end of the content array.
+                let textRun = ''
+                let hasTextRun = false
+                const flushTextRun = (): void => {
+                    if (hasTextRun) {
+                        messageBuffer.addMessage(formatTextWithOptionsForTerminal(textRun), 'assistant')
+                        textRun = ''
+                        hasTextRun = false
+                    }
+                }
+
                 for (const block of assistantMsg.message.content) {
                     if (block.type === 'text') {
-                        messageBuffer.addMessage(formatTextWithOptionsForTerminal(block.text || ''), 'assistant')
+                        // Join with '' since SDK text blocks are already contiguous
+                        // fragments of the raw stream.
+                        textRun += block.text || ''
+                        hasTextRun = true
                     } else if (block.type === 'tool_use') {
+                        flushTextRun()
                         messageBuffer.addMessage(`🔧 Tool: ${block.name}`, 'tool')
                         if (block.input) {
                             const inputStr = JSON.stringify(block.input, null, 2)
@@ -85,8 +105,11 @@ export function formatClaudeMessageForInk(
                                 messageBuffer.addMessage(`Input: ${inputStr}`, 'tool')
                             }
                         }
+                    } else {
+                        flushTextRun()
                     }
                 }
+                flushTextRun()
             }
             break
         }

--- a/apps/cli/src/utils/optionsParser.test.ts
+++ b/apps/cli/src/utils/optionsParser.test.ts
@@ -74,8 +74,28 @@ describe('formatTextWithOptionsForTerminal', () => {
         expect(formatTextWithOptionsForTerminal(input)).toBe(input);
     });
 
+    it('formats every options block when a message contains more than one', () => {
+        const text = 'First question:\n<options>\n<option>A</option>\n<option>B</option>\n</options>\nSecond question:\n<options>\n<option>C</option>\n</options>';
+        const result = formatTextWithOptionsForTerminal(text);
+        expect(result).not.toContain('<options>');
+        expect(result).toContain('  1. A');
+        expect(result).toContain('  2. B');
+        expect(result).toContain('First question:');
+        expect(result).toContain('Second question:');
+        expect(result.match(/Options:/g)?.length).toBe(2);
+        expect(result).toContain('  1. C');
+    });
+
+    it('drops empty options blocks entirely', () => {
+        const result = formatTextWithOptionsForTerminal('Before\n<options>\n</options>\nAfter');
+        expect(result).not.toContain('<options>');
+        expect(result).toContain('Before');
+        expect(result).toContain('After');
+    });
+
     it('returns text unchanged for an incomplete options block', () => {
         const input = 'Question?\n<options>\n<option>Yes</option>';
         expect(formatTextWithOptionsForTerminal(input)).toBe(input);
-    });
+    
+});
 });

--- a/apps/cli/src/utils/optionsParser.test.ts
+++ b/apps/cli/src/utils/optionsParser.test.ts
@@ -2,53 +2,72 @@ import { describe, expect, it } from 'vitest';
 import {
     formatOptionsXml,
     formatTextWithOptionsForTerminal,
-    hasIncompleteOptions,
-    parseOptionsFromText,
+    segmentTrailingOptions,
 } from './optionsParser';
 
-describe('parseOptionsFromText', () => {
-    it('extracts options and returns text without the options block', () => {
+describe('segmentTrailingOptions', () => {
+    it('splits a trailing options block from the preceding prose', () => {
         const input = 'Which approach do you prefer?\n\n<options>\n    <option>Option A</option>\n    <option>Option B</option>\n</options>';
-        const result = parseOptionsFromText(input);
-        expect(result.text).toBe('Which approach do you prefer?');
+        const result = segmentTrailingOptions(input);
+        expect(result.before).toBe('Which approach do you prefer?\n\n');
         expect(result.options).toEqual(['Option A', 'Option B']);
+        expect(result.hasIncompleteTrailingOptions).toBe(false);
     });
 
-    it('returns trimmed text and empty options when no options block exists', () => {
-        const result = parseOptionsFromText('  Just a plain answer.  ');
-        expect(result.text).toBe('Just a plain answer.');
+    it('preserves surrounding whitespace in before exactly (no trim)', () => {
+        const input = '  Leading and trailing spaces.  \n<options>\n<option>Yes</option>\n</options>';
+        const result = segmentTrailingOptions(input);
+        expect(result.before).toBe('  Leading and trailing spaces.  \n');
+    });
+
+    it('returns the full text as before when there is no options block', () => {
+        const input = '  Just a plain answer.  ';
+        const result = segmentTrailingOptions(input);
+        expect(result.before).toBe(input);
         expect(result.options).toEqual([]);
+        expect(result.hasIncompleteTrailingOptions).toBe(false);
     });
 
     it('matches tags case-insensitively', () => {
         const input = 'Pick one:\n<OPTIONS>\n<OPTION>Yes</OPTION>\n<OPTION>No</OPTION>\n</OPTIONS>';
-        const result = parseOptionsFromText(input);
-        expect(result.text).toBe('Pick one:');
+        const result = segmentTrailingOptions(input);
+        expect(result.before).toBe('Pick one:\n');
         expect(result.options).toEqual(['Yes', 'No']);
     });
 
     it('ignores empty option tags', () => {
         const input = '<options><option></option><option>Keep me</option></options>';
-        const result = parseOptionsFromText(input);
+        const result = segmentTrailingOptions(input);
         expect(result.options).toEqual(['Keep me']);
     });
-});
 
-describe('hasIncompleteOptions', () => {
-    it('detects an opening tag without a closing tag', () => {
-        expect(hasIncompleteOptions('Question?\n<options>\n<option>Yes</option>')).toBe(true);
+    it('does NOT match an <options> block that is not at the end of the text', () => {
+        const input = 'See <options><option>A</option></options> then more prose follows.';
+        const result = segmentTrailingOptions(input);
+        expect(result.before).toBe(input);
+        expect(result.options).toEqual([]);
+        expect(result.hasIncompleteTrailingOptions).toBe(false);
     });
 
-    it('returns false for complete blocks and plain text', () => {
-        expect(hasIncompleteOptions('<options><option>Yes</option></options>')).toBe(false);
-        expect(hasIncompleteOptions('No options here')).toBe(false);
+    it('flags an unclosed trailing options block as incomplete', () => {
+        const result = segmentTrailingOptions('Question?\n<options>\n<option>Yes</option>');
+        expect(result.hasIncompleteTrailingOptions).toBe(true);
+        expect(result.options).toEqual([]);
+        expect(result.before).toBe('Question?\n<options>\n<option>Yes</option>');
+    });
+
+    it('only segments the LAST/trailing block when several appear', () => {
+        const input = 'Literal <options><option>X</option></options> in prose.\n<options>\n<option>Real</option>\n</options>';
+        const result = segmentTrailingOptions(input);
+        expect(result.before).toBe('Literal <options><option>X</option></options> in prose.\n');
+        expect(result.options).toEqual(['Real']);
     });
 });
 
 describe('formatOptionsXml', () => {
     it('round-trips options through XML', () => {
         const xml = formatOptionsXml(['One', 'Two']);
-        expect(parseOptionsFromText(xml).options).toEqual(['One', 'Two']);
+        expect(segmentTrailingOptions(xml).options).toEqual(['One', 'Two']);
     });
 
     it('returns an empty string for no options', () => {
@@ -57,7 +76,7 @@ describe('formatOptionsXml', () => {
 });
 
 describe('formatTextWithOptionsForTerminal', () => {
-    it('replaces the options block with a numbered list', () => {
+    it('replaces a trailing options block with a numbered list', () => {
         const input = 'Which approach do you prefer?\n\n<options>\n    <option>Option A</option>\n    <option>Option B</option>\n</options>';
         const result = formatTextWithOptionsForTerminal(input);
         expect(result).toBe('Which approach do you prefer?\n\nOptions:\n  1. Option A\n  2. Option B');
@@ -69,33 +88,43 @@ describe('formatTextWithOptionsForTerminal', () => {
         expect(formatTextWithOptionsForTerminal(input)).toBe('Options:\n  1. Yes\n  2. No');
     });
 
-    it('returns text unchanged when there is no options block', () => {
+    it('returns text unchanged when there is no options block (exact equality)', () => {
         const input = 'Plain answer with  spacing\npreserved.';
         expect(formatTextWithOptionsForTerminal(input)).toBe(input);
     });
 
-    it('formats every options block when a message contains more than one', () => {
-        const text = 'First question:\n<options>\n<option>A</option>\n<option>B</option>\n</options>\nSecond question:\n<options>\n<option>C</option>\n</options>';
-        const result = formatTextWithOptionsForTerminal(text);
-        expect(result).not.toContain('<options>');
-        expect(result).toContain('  1. A');
-        expect(result).toContain('  2. B');
-        expect(result).toContain('First question:');
-        expect(result).toContain('Second question:');
-        expect(result.match(/Options:/g)?.length).toBe(2);
-        expect(result).toContain('  1. C');
+    it('preserves leading and trailing whitespace of the prose exactly', () => {
+        const input = '\n\n  Choose:  \n<options>\n<option>A</option>\n<option>B</option>\n</options>';
+        expect(formatTextWithOptionsForTerminal(input)).toBe('\n\n  Choose:  \nOptions:\n  1. A\n  2. B');
     });
 
-    it('drops empty options blocks entirely', () => {
-        const result = formatTextWithOptionsForTerminal('Before\n<options>\n</options>\nAfter');
-        expect(result).not.toContain('<options>');
-        expect(result).toContain('Before');
-        expect(result).toContain('After');
+    it('leaves a fenced/literal <options> block in the MIDDLE of text untouched', () => {
+        const input = 'Here is how the markup looks:\n```xml\n<options>\n<option>A</option>\n<option>B</option>\n</options>\n```\nThat is the format.';
+        expect(formatTextWithOptionsForTerminal(input)).toBe(input);
     });
 
-    it('returns text unchanged for an incomplete options block', () => {
+    it('leaves a literal <options> block untouched when prose follows it', () => {
+        const input = 'The tag <options><option>A</option></options> is used for menus, note the syntax.';
+        expect(formatTextWithOptionsForTerminal(input)).toBe(input);
+    });
+
+    it('renders only the LAST block, leaving earlier literal ones raw', () => {
+        const input = 'Example markup: <options><option>X</option></options>\nNow pick one:\n<options>\n<option>Real A</option>\n<option>Real B</option>\n</options>';
+        const result = formatTextWithOptionsForTerminal(input);
+        expect(result).toBe('Example markup: <options><option>X</option></options>\nNow pick one:\nOptions:\n  1. Real A\n  2. Real B');
+        // The earlier literal block is preserved verbatim.
+        expect(result).toContain('<options><option>X</option></options>');
+        // Only one block was rendered as a list.
+        expect(result.match(/Options:/g)?.length).toBe(1);
+    });
+
+    it('drops an empty trailing options block, preserving before exactly', () => {
+        const input = 'Before the empty block\n<options>\n</options>';
+        expect(formatTextWithOptionsForTerminal(input)).toBe('Before the empty block\n');
+    });
+
+    it('returns text unchanged for an incomplete (unclosed) trailing block', () => {
         const input = 'Question?\n<options>\n<option>Yes</option>';
         expect(formatTextWithOptionsForTerminal(input)).toBe(input);
-    
-});
+    });
 });

--- a/apps/cli/src/utils/optionsParser.test.ts
+++ b/apps/cli/src/utils/optionsParser.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+    formatOptionsXml,
+    formatTextWithOptionsForTerminal,
+    hasIncompleteOptions,
+    parseOptionsFromText,
+} from './optionsParser';
+
+describe('parseOptionsFromText', () => {
+    it('extracts options and returns text without the options block', () => {
+        const input = 'Which approach do you prefer?\n\n<options>\n    <option>Option A</option>\n    <option>Option B</option>\n</options>';
+        const result = parseOptionsFromText(input);
+        expect(result.text).toBe('Which approach do you prefer?');
+        expect(result.options).toEqual(['Option A', 'Option B']);
+    });
+
+    it('returns trimmed text and empty options when no options block exists', () => {
+        const result = parseOptionsFromText('  Just a plain answer.  ');
+        expect(result.text).toBe('Just a plain answer.');
+        expect(result.options).toEqual([]);
+    });
+
+    it('matches tags case-insensitively', () => {
+        const input = 'Pick one:\n<OPTIONS>\n<OPTION>Yes</OPTION>\n<OPTION>No</OPTION>\n</OPTIONS>';
+        const result = parseOptionsFromText(input);
+        expect(result.text).toBe('Pick one:');
+        expect(result.options).toEqual(['Yes', 'No']);
+    });
+
+    it('ignores empty option tags', () => {
+        const input = '<options><option></option><option>Keep me</option></options>';
+        const result = parseOptionsFromText(input);
+        expect(result.options).toEqual(['Keep me']);
+    });
+});
+
+describe('hasIncompleteOptions', () => {
+    it('detects an opening tag without a closing tag', () => {
+        expect(hasIncompleteOptions('Question?\n<options>\n<option>Yes</option>')).toBe(true);
+    });
+
+    it('returns false for complete blocks and plain text', () => {
+        expect(hasIncompleteOptions('<options><option>Yes</option></options>')).toBe(false);
+        expect(hasIncompleteOptions('No options here')).toBe(false);
+    });
+});
+
+describe('formatOptionsXml', () => {
+    it('round-trips options through XML', () => {
+        const xml = formatOptionsXml(['One', 'Two']);
+        expect(parseOptionsFromText(xml).options).toEqual(['One', 'Two']);
+    });
+
+    it('returns an empty string for no options', () => {
+        expect(formatOptionsXml([])).toBe('');
+    });
+});
+
+describe('formatTextWithOptionsForTerminal', () => {
+    it('replaces the options block with a numbered list', () => {
+        const input = 'Which approach do you prefer?\n\n<options>\n    <option>Option A</option>\n    <option>Option B</option>\n</options>';
+        const result = formatTextWithOptionsForTerminal(input);
+        expect(result).toBe('Which approach do you prefer?\n\nOptions:\n  1. Option A\n  2. Option B');
+        expect(result).not.toContain('<options>');
+    });
+
+    it('renders a numbered list when the message is options-only', () => {
+        const input = '<options>\n<option>Yes</option>\n<option>No</option>\n</options>';
+        expect(formatTextWithOptionsForTerminal(input)).toBe('Options:\n  1. Yes\n  2. No');
+    });
+
+    it('returns text unchanged when there is no options block', () => {
+        const input = 'Plain answer with  spacing\npreserved.';
+        expect(formatTextWithOptionsForTerminal(input)).toBe(input);
+    });
+
+    it('returns text unchanged for an incomplete options block', () => {
+        const input = 'Question?\n<options>\n<option>Yes</option>';
+        expect(formatTextWithOptionsForTerminal(input)).toBe(input);
+    });
+});

--- a/apps/cli/src/utils/optionsParser.ts
+++ b/apps/cli/src/utils/optionsParser.ts
@@ -68,3 +68,20 @@ export function formatOptionsXml(options: string[]): string {
   return '\n<options>\n' + options.map(opt => `    <option>${opt}</option>`).join('\n') + '\n</options>';
 }
 
+/**
+ * Format assistant text for terminal display
+ * Replaces an <options>...</options> XML block with a readable numbered list
+ * so terminal surfaces (which have no tappable option buttons) do not show raw XML.
+ *
+ * @param text - The assistant text potentially containing an options XML block
+ * @returns The text with the options block rendered as a numbered list
+ */
+export function formatTextWithOptionsForTerminal(text: string): string {
+  const { text: textWithoutOptions, options } = parseOptionsFromText(text);
+  if (options.length === 0) {
+    return text;
+  }
+  const numberedList = options.map((option, index) => `  ${index + 1}. ${option}`).join('\n');
+  const optionsBlock = `Options:\n${numberedList}`;
+  return textWithoutOptions.length > 0 ? `${textWithoutOptions}\n\n${optionsBlock}` : optionsBlock;
+}

--- a/apps/cli/src/utils/optionsParser.ts
+++ b/apps/cli/src/utils/optionsParser.ts
@@ -6,53 +6,92 @@
  */
 
 /**
- * Check if text has an incomplete options block (opening tag but no closing tag)
- * 
- * @param text - The text to check
- * @returns true if there's an opening <options> tag without a closing </options> tag
+ * Single regex owning the <option> item grammar, shared by every consumer so the
+ * terminal formatter and the Gemini adapter never diverge.
+ * Matches one <option>...</option> pair (case-insensitive, non-greedy inner).
  */
-export function hasIncompleteOptions(text: string): boolean {
-  const hasOpeningTag = /<options>/i.test(text);
-  const hasClosingTag = /<\/options>/i.test(text);
-  return hasOpeningTag && !hasClosingTag;
-}
+const OPTION_ITEM_REGEX = /<option>(.*?)<\/option>/gi;
 
 /**
- * Parse XML options from text
- * Extracts <options><option>...</option></options> blocks and returns
- * the text without options and the parsed options array
- * 
- * @param text - The text containing options XML
- * @returns Object with text (without options) and options array
+ * Regex owning the TRAILING options-block grammar. Anchored to the END of the
+ * string (allowing whitespace after </options>), case-insensitive on tags, with
+ * a non-greedy inner (which never spans a nested <options> opener, so the block
+ * begins at the LAST opener) and tolerated whitespace around that inner. This
+ * is the sole matcher for a turn-final options block; literal or fenced
+ * <options> markup appearing earlier in the text is intentionally NOT matched.
  */
-export function parseOptionsFromText(text: string): { text: string; options: string[] } {
-  // Match <options>...</options> block (multiline, non-greedy)
-  const optionsRegex = /<options>\s*([\s\S]*?)\s*<\/options>/i;
-  const match = text.match(optionsRegex);
-  
-  if (!match) {
-    return { text: text.trim(), options: [] };
-  }
-  
-  // Extract options block content
-  const optionsBlock = match[1];
-  
-  // Parse individual <option> tags
-  const optionRegex = /<option>(.*?)<\/option>/gi;
+const TRAILING_OPTIONS_BLOCK_REGEX = /<options>\s*((?:(?!<options>)[\s\S])*?)\s*<\/options>\s*$/i;
+
+/**
+ * Parse the non-empty <option> texts out of an options-block inner string.
+ * 
+ * @param inner - The inner content between <options> and </options>
+ * @returns Array of trimmed, non-empty option strings (empty tags dropped)
+ */
+function parseOptionItems(inner: string): string[] {
   const options: string[] = [];
-  let optionMatch;
-  
-  while ((optionMatch = optionRegex.exec(optionsBlock)) !== null) {
+  let optionMatch: RegExpExecArray | null;
+  OPTION_ITEM_REGEX.lastIndex = 0;
+  while ((optionMatch = OPTION_ITEM_REGEX.exec(inner)) !== null) {
     const optionText = optionMatch[1].trim();
     if (optionText) {
       options.push(optionText);
     }
   }
-  
-  // Remove options block from text
-  const textWithoutOptions = text.replace(optionsRegex, '').trim();
-  
-  return { text: textWithoutOptions, options };
+  return options;
+}
+
+/**
+ * Detect a still-streaming (unclosed) trailing options block: the LAST
+ * <options> opener in `text` has no matching </options> after it.
+ * 
+ * @param text - The text to inspect
+ * @returns true when the final <options> opener is not yet closed
+ */
+function hasUnclosedTrailingOptions(text: string): boolean {
+  const openRegex = /<options>/gi;
+  let lastOpenEnd = -1;
+  let openMatch: RegExpExecArray | null;
+  while ((openMatch = openRegex.exec(text)) !== null) {
+    lastOpenEnd = openMatch.index + openMatch[0].length;
+  }
+  if (lastOpenEnd === -1) {
+    return false;
+  }
+  return !/<\/options>/i.test(text.slice(lastOpenEnd));
+}
+
+/**
+ * Canonical trailing-options segmenter — the sole owner of the options-block
+ * grammar, reused by the terminal formatter AND the Gemini adapter.
+ *
+ * Splits `text` into the prose BEFORE a turn-final <options> block and the
+ * parsed option list, WITHOUT mutating any surrounding whitespace. Only a
+ * <options>...</options> block anchored to the END of `text` (optionally
+ * followed by trailing whitespace) is recognised; literal or fenced <options>
+ * markup appearing mid-text stays part of `before`, untouched.
+ *
+ * @param text - The full assistant/turn text to segment
+ * @returns before (verbatim prose preceding the block, or the full text when no
+ *   trailing block matched), options (non-empty trimmed option strings), and
+ *   hasIncompleteTrailingOptions (true only for a trailing opener with no closer)
+ */
+export function segmentTrailingOptions(text: string): {
+  before: string;
+  options: string[];
+  hasIncompleteTrailingOptions: boolean;
+} {
+  const match = text.match(TRAILING_OPTIONS_BLOCK_REGEX);
+  if (!match) {
+    return {
+      before: text,
+      options: [],
+      hasIncompleteTrailingOptions: hasUnclosedTrailingOptions(text),
+    };
+  }
+  const before = text.slice(0, match.index);
+  const options = parseOptionItems(match[1]);
+  return { before, options, hasIncompleteTrailingOptions: false };
 }
 
 /**
@@ -69,37 +108,30 @@ export function formatOptionsXml(options: string[]): string {
 }
 
 /**
- * Format assistant text for terminal display
- * Replaces an <options>...</options> XML block with a readable numbered list
- * so terminal surfaces (which have no tappable option buttons) do not show raw XML.
+ * Format assistant text for terminal display.
+ * Replaces ONLY a turn-final <options>...</options> block with a readable
+ * numbered list so terminal surfaces (which have no tappable option buttons) do
+ * not show raw XML. Everything before the block — including all whitespace — is
+ * preserved verbatim; the only span that changes is the trailing options block.
+ * Literal or fenced <options> markup earlier in the text is left untouched, and
+ * a still-streaming (unclosed) trailing block passes through unchanged.
  *
- * @param text - The assistant text potentially containing an options XML block
- * @returns The text with the options block rendered as a numbered list
+ * @param text - The assistant text potentially ending in an options XML block
+ * @returns The text with a trailing options block rendered as a numbered list
  */
 export function formatTextWithOptionsForTerminal(text: string): string {
-  const blockRegex = /<options>\s*([\s\S]*?)\s*<\/options>/gi;
-  if (!blockRegex.test(text)) {
+  const { before, options, hasIncompleteTrailingOptions } = segmentTrailingOptions(text);
+  if (hasIncompleteTrailingOptions) {
+    // Don't rewrite a block that is still streaming in.
     return text;
   }
-  blockRegex.lastIndex = 0;
-  // Replace EVERY complete options block in place (a message may contain more than
-  // one), keeping surrounding prose in its original position. Incomplete blocks
-  // (opening tag without closing tag, e.g. mid-stream) pass through untouched.
-  const formatted = text.replace(blockRegex, (_match, inner: string) => {
-    const optionRegex = /<option>(.*?)<\/option>/gi;
-    const options: string[] = [];
-    let optionMatch: RegExpExecArray | null;
-    while ((optionMatch = optionRegex.exec(inner)) !== null) {
-      const optionText = optionMatch[1].trim();
-      if (optionText) {
-        options.push(optionText);
-      }
-    }
-    if (options.length === 0) {
-      return '';
-    }
-    const numberedList = options.map((option, index) => `  ${index + 1}. ${option}`).join('\n');
-    return `Options:\n${numberedList}`;
-  });
-  return formatted.replace(/\n{3,}/g, '\n\n').trim();
+  if (options.length === 0) {
+    // No trailing block (before === text) or a trailing block with no non-empty
+    // options (before drops the empty block); either way return before verbatim.
+    return before;
+  }
+  const numberedList = options
+    .map((option, index) => `  ${index + 1}. ${option}`)
+    .join('\n');
+  return `${before}Options:\n${numberedList}`;
 }

--- a/apps/cli/src/utils/optionsParser.ts
+++ b/apps/cli/src/utils/optionsParser.ts
@@ -77,11 +77,29 @@ export function formatOptionsXml(options: string[]): string {
  * @returns The text with the options block rendered as a numbered list
  */
 export function formatTextWithOptionsForTerminal(text: string): string {
-  const { text: textWithoutOptions, options } = parseOptionsFromText(text);
-  if (options.length === 0) {
+  const blockRegex = /<options>\s*([\s\S]*?)\s*<\/options>/gi;
+  if (!blockRegex.test(text)) {
     return text;
   }
-  const numberedList = options.map((option, index) => `  ${index + 1}. ${option}`).join('\n');
-  const optionsBlock = `Options:\n${numberedList}`;
-  return textWithoutOptions.length > 0 ? `${textWithoutOptions}\n\n${optionsBlock}` : optionsBlock;
+  blockRegex.lastIndex = 0;
+  // Replace EVERY complete options block in place (a message may contain more than
+  // one), keeping surrounding prose in its original position. Incomplete blocks
+  // (opening tag without closing tag, e.g. mid-stream) pass through untouched.
+  const formatted = text.replace(blockRegex, (_match, inner: string) => {
+    const optionRegex = /<option>(.*?)<\/option>/gi;
+    const options: string[] = [];
+    let optionMatch: RegExpExecArray | null;
+    while ((optionMatch = optionRegex.exec(inner)) !== null) {
+      const optionText = optionMatch[1].trim();
+      if (optionText) {
+        options.push(optionText);
+      }
+    }
+    if (options.length === 0) {
+      return '';
+    }
+    const numberedList = options.map((option, index) => `  ${index + 1}. ${option}`).join('\n');
+    return `Options:\n${numberedList}`;
+  });
+  return formatted.replace(/\n{3,}/g, '\n\n').trim();
 }


### PR DESCRIPTION
## Problem

The Happier base system prompt (`HAPPIER_BASE_SYSTEM_PROMPT_OPTIONS_V1`, `packages/protocol/src/prompts/systemPromptBaseV1.ts`) instructs agents to append quick-reply options as an `<options><option>…</option></options>` XML block. The mobile/web app extracts this at markdown render time (`apps/ui/sources/components/markdown/parseMarkdownBlock.ts`) and shows tappable buttons, and the Gemini backend extracts it at turn end (`optionsParser.ts`), but the Claude remote-mode terminal transcript view prints the raw XML to the user: `formatClaudeMessageForInk` (`apps/cli/src/ui/messageFormatterInk.ts`) passes assistant text blocks and the result summary straight to the Ink message buffer.

### Repro

Run `happier claude`, switch the session to remote mode, and from the app send a prompt that makes the agent ask a clarifying question. The terminal transcript shows the literal `<options>…</options>` block; the app shows buttons.

## Fix

- Move `optionsParser.ts` from `backends/gemini/utils` to `utils` (it is no longer Gemini-specific; import in `runGemini.ts` updated).
- Add `formatTextWithOptionsForTerminal()`, which replaces a complete options block with a readable `Options: 1./2./…` list. Incomplete or absent blocks pass through unchanged.
- Route assistant text + result summaries through it in `messageFormatterInk.ts` and the parallel `messageFormatter.ts`.

Behavior on every other surface is unchanged.

## How tested

`yarn workspace @happier-dev/cli typecheck`, `test:import-cycles`, and vitest are all green; added unit tests for the parser/formatter (`src/utils/optionsParser.test.ts`) and for `formatClaudeMessageForInk` via a real `MessageBuffer` (`src/ui/messageFormatterInk.test.ts`).

## Related leaks noticed while investigating (out of scope, happy to file separately)

1. ACP providers stream raw deltas into the terminal buffer (`acpCommonHandlers.ts`), so the XML also shows there — fixing needs a turn-end rewrite of the last buffer message.
2. Ready-notification preview text (`normalizeTurnAssistantText`) does not strip the block, so push previews can contain the collapsed XML.
3. In local/unified-terminal mode, Claude Code's own TUI shows the XML — only avoidable by disabling `codingPromptBehaviorV1.responseOptions`, a behavior change since the app mirrors local sessions.

## AI disclosure (per CONTRIBUTING)

Investigated and implemented with Claude under my direction; I defined the bug, the surface audit, and the fix shape, and verified typecheck + tests on my machine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786313781&installation_id=129174028&pr_number=197&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F197&signature=8616211950d42d6eb420efe1fe21cf22b9f730fb93e123352f2302e897965e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render assistant `<options>` blocks as numbered lists in the CLI terminal view
> - Adds `formatTextWithOptionsForTerminal` to [optionsParser.ts](https://github.com/happier-dev/happier/pull/197/files#diff-93cf66a1b326ffabcf55af518b6d9b77c20ca924d245b2c3eaadbbbdc092d170), which replaces a trailing `<options>...</options>` block with a numbered list while leaving all preceding text intact.
> - Updates [messageFormatterInk.ts](https://github.com/happier-dev/happier/pull/197/files#diff-fc628214847c29a31bc6ebc26c2572dd8697d2842d16d5b6e821490bdf154d00) to accumulate contiguous text blocks and format them together, ensuring options split across adjacent SDK blocks are handled correctly.
> - Updates [runGemini.ts](https://github.com/happier-dev/happier/pull/197/files#diff-fcb3c207954e4f1a7c0f6b43b185b56fdcd01788305c52ae0db84a521bf7cd2a) to use `segmentTrailingOptions` instead of the old `parseOptionsFromText`, so only trailing options blocks are parsed and removed from the displayed message.
> - Deletes the now-superseded [optionsParser.ts](https://github.com/happier-dev/happier/pull/197/files#diff-49a8e3a120b1738c804ad7f0b3bb4e3bc3a85ce0b988e5be960258e3b1fd7af6) from the Gemini backend in favour of the shared utility.
> - Behavioral Change: raw `<options>` XML is no longer shown in assistant or result messages; only trailing blocks are converted — mid-text or incomplete (still-streaming) blocks are left as-is.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9782746.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of end-of-message options, presenting them as clear numbered lists in terminal and app messages.
  * Preserved surrounding message text and formatting while removing options markup.
  * Added support for options streamed across multiple text segments.

* **Bug Fixes**
  * Prevented incomplete or embedded options blocks from being prematurely reformatted.
  * Empty trailing options blocks are now omitted cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->