### PR TITLE
fix(cli-claude): stop rewriting Bash commands in PreToolUse auth-scrub hook

### DIFF
--- a/apps/cli/src/backends/claude/remote/agentSdk/buildClaudeAgentSdkHooks.ts
+++ b/apps/cli/src/backends/claude/remote/agentSdk/buildClaudeAgentSdkHooks.ts
@@ -1,7 +1,6 @@
 import { join } from 'node:path';
 
 import { getProjectPath } from '@/backends/claude/utils/path';
-import { CLAUDE_AUTH_ENV_KEYS } from '@/backends/claude/auth/claudeAuthEnvKeys';
 import type { EnhancedMode } from '@/backends/claude/loop';
 import type { PermissionResult } from '@/backends/claude/sdk/types';
 
@@ -66,47 +65,6 @@ export function buildClaudeAgentSdkHooks(params: Readonly<{
               params.onSessionFound(sessionId, { transcript_path: transcriptPathFallback, transcriptPath: transcriptPathFallback });
             }
             return { continue: true };
-          },
-        ],
-      },
-    ],
-    PreToolUse: [
-      {
-        hooks: [
-          async (input: any) => {
-            if (!input || typeof input !== 'object') {
-              return { continue: true, suppressOutput: true };
-            }
-
-            const toolName = typeof input.tool_name === 'string' ? input.tool_name : '';
-            if (toolName !== 'Bash') {
-              return { continue: true, suppressOutput: true };
-            }
-
-            const toolInput = (input as any).tool_input;
-            if (!toolInput || typeof toolInput !== 'object' || Array.isArray(toolInput)) {
-              return { continue: true, suppressOutput: true };
-            }
-
-            const command = typeof (toolInput as any).command === 'string' ? (toolInput as any).command : '';
-            if (!command.trim()) {
-              return { continue: true, suppressOutput: true };
-            }
-
-            const prefix = `unset ${CLAUDE_AUTH_ENV_KEYS.join(' ')}; `;
-            const nextCommand = command.startsWith(prefix) ? command : prefix + command;
-
-            return {
-              continue: true,
-              suppressOutput: true,
-              hookSpecificOutput: {
-                hookEventName: 'PreToolUse',
-                updatedInput: {
-                  ...(toolInput as Record<string, unknown>),
-                  command: nextCommand,
-                },
-              },
-            };
           },
         ],
       },

--- a/apps/cli/src/backends/claude/remote/claudeRemoteAgentSdk.optionsAndHooks.test.ts
+++ b/apps/cli/src/backends/claude/remote/claudeRemoteAgentSdk.optionsAndHooks.test.ts
@@ -1558,19 +1558,10 @@ describe('claudeRemoteAgentSdk options and hooks', () => {
             expect(capturedOptions.env.CLAUDE_CODE_OAUTH_SCOPES).toBeUndefined();
             expect(capturedOptions.env.HAPPIER_CLAUDE_EXPLICIT_ENV_ALLOWED_TEST).toBe('allowed-explicit-value');
 
-            const output = await capturedOptions.hooks.PreToolUse[0].hooks[0]({
-                hook_event_name: 'PreToolUse',
-                session_id: 'sess_1',
-                transcript_path: '/tmp/sess_1.jsonl',
-                cwd: '/tmp',
-                tool_name: 'Bash',
-                tool_input: { command: 'echo hi' },
-                tool_use_id: 'toolu_123',
-            });
-
-            expect(output.hookSpecificOutput.updatedInput.command).toContain('CLAUDE_CODE_OAUTH_REFRESH_TOKEN');
-            expect(output.hookSpecificOutput.updatedInput.command).toContain('CLAUDE_CODE_OAUTH_SCOPES');
-            expect(output.hookSpecificOutput.updatedInput.command).toContain('echo hi');
+            // Bash commands must reach Claude Code's permission layer unmodified: a PreToolUse
+            // rewrite (e.g. an `unset ...;` prelude) breaks Bash prefix allow rules and trips
+            // auto-mode classifiers. Auth isolation happens via the subprocess env instead.
+            expect(capturedOptions.hooks.PreToolUse).toBeUndefined();
         } finally {
             if (originals.refreshToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_REFRESH_TOKEN;
             else process.env.CLAUDE_CODE_OAUTH_REFRESH_TOKEN = originals.refreshToken;
@@ -2990,7 +2981,7 @@ describe('claudeRemoteAgentSdk options and hooks', () => {
         );
     });
 
-    it('registers PreToolUse hook that scrubs sensitive env vars for Bash commands', async () => {
+    it('does not register a PreToolUse hook that rewrites Bash commands', async () => {
         let capturedHooks: any = null;
         const createQuery = vi.fn((_params: any) => {
             capturedHooks = _params.options?.hooks;
@@ -3029,35 +3020,12 @@ describe('claudeRemoteAgentSdk options and hooks', () => {
             createQuery,
         } as any);
 
-        expect(capturedHooks?.PreToolUse?.[0]?.hooks?.length).toBe(1);
-
-        const output = await capturedHooks.PreToolUse[0].hooks[0]({
-            hook_event_name: 'PreToolUse',
-            session_id: 'sess_1',
-            transcript_path: '/tmp/sess_1.jsonl',
-            cwd: '/tmp',
-            tool_name: 'Bash',
-            tool_input: { command: 'echo hi' },
-            tool_use_id: 'toolu_123',
-        });
-
-        expect(output).toEqual(
-            expect.objectContaining({
-                continue: true,
-                suppressOutput: true,
-                hookSpecificOutput: expect.objectContaining({
-                    hookEventName: 'PreToolUse',
-                    updatedInput: expect.objectContaining({
-                        command: expect.stringContaining('unset '),
-                    }),
-                }),
-            }),
-        );
-        expect(output.hookSpecificOutput.updatedInput.command).toContain('CLAUDE_CODE_OAUTH_TOKEN');
-        expect(output.hookSpecificOutput.updatedInput.command).toContain('CLAUDE_CODE_OAUTH_REFRESH_TOKEN');
-        expect(output.hookSpecificOutput.updatedInput.command).toContain('CLAUDE_CODE_OAUTH_SCOPES');
-        expect(output.hookSpecificOutput.updatedInput.command).toContain('ANTHROPIC_AUTH_TOKEN');
-        expect(output.hookSpecificOutput.updatedInput.command).toContain('echo hi');
+        // Bash `tool_input.command` must stay byte-identical to what the model produced:
+        // Claude Code's permission rules (`Bash(gh:*)`) and auto-mode classifier evaluate
+        // the post-hook command, so any rewrite (like an `unset ...;` auth prelude) breaks
+        // prefix allow rules and triggers "unsetting auth tokens" denials. Auth-token
+        // isolation is enforced through the scrubbed subprocess env instead.
+        expect(capturedHooks?.PreToolUse).toBeUndefined();
     });
 
 });


### PR DESCRIPTION
## Summary

Removes the Bash command rewrite from the Claude Agent SDK PreToolUse auth-scrub hook. Auth-token isolation stays enforced via subprocess env scrubbing; the hook no longer mutates commands before Claude Code's permission layer sees them.

## Why

The hook prepended an `unset ANTHROPIC_API_KEY ...;` prelude to every Bash command, which:

- broke Bash prefix allow rules (e.g. `Bash(gh:*)`), since the rewritten command no longer started with the allowed prefix
- triggered auto-mode "unsetting auth tokens" denials for benign commands
- spammed mobile permission prompts showing the preamble instead of the real command

The rewrite added no protection beyond the existing env scrub: subprocess env is already sanitized by `isolateClaudeRuntimeAuthEnv` / `buildClaudeSubprocessEnv`, and shell snapshots capture only `PATH`.

## How to test

1. `cd apps/cli && yarn vitest run src/backends/claude/remote/claudeRemoteAgentSdk.optionsAndHooks.test.ts` — hook tests assert Bash commands pass through unmodified and env scrubbing still applies.
2. `cd apps/cli && yarn typecheck`
3. Manual: start a Claude session through the Happier daemon with a `Bash(gh:*)` allow rule in `.claude/settings.json`; run a `gh` command and confirm it is auto-allowed without a permission prompt (previously denied/prompted because the command was rewritten).
4. Manual: verify `ANTHROPIC_API_KEY` set in the daemon environment is still absent from the spawned Claude subprocess env.

## Screenshots / recording (UI changes)

N/A — CLI-only change.

## Notes (optional)

Security: no weakening of auth isolation. The command mutation was a redundant second layer on top of subprocess env scrubbing, and it broke permission-rule matching as a side effect. Changed files:

- `apps/cli/src/backends/claude/remote/agentSdk/buildClaudeAgentSdkHooks.ts` — remove Bash command mutation
- `apps/cli/src/backends/claude/remote/claudeRemoteAgentSdk.optionsAndHooks.test.ts` — update hook tests to assert pass-through

## Checklist

- [x] PR targets `dev` (not `main`)
- [ ] I linked an issue/discussion (recommended for non-trivial changes)
- [x] I added/updated tests where feasible (or explained why not)
- [x] I updated docs if behavior changed (no doc surface documents the hook prelude)
- [x] If AI-assisted, I disclosed it and listed what I personally verified

AI-assisted (Claude Code). Verified by running the updated hook test file and CLI typecheck locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
