### PR TITLE
fix(sherpa-native): add missing includes

### DIFF
--- a/packages/sherpa-native/android/src/main/cpp/HappierSherpaNativeJni.cpp
+++ b/packages/sherpa-native/android/src/main/cpp/HappierSherpaNativeJni.cpp
@@ -1,10 +1,12 @@
 #include <jni.h>
 
 #include <atomic>
+#include <cstdint>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <memory>
+#include <vector>
 
 #include <android/log.h>
 


### PR DESCRIPTION
Fixes #201
<!-- What does this PR change? 1–3 sentences. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787079691&installation_id=129174028&pr_number=204&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F204&signature=2640ca56483571c7c4e025bcac743a4046640fa77ba7d4e4f708415ee5859233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add missing `cstdint` and `vector` includes to `HappierSherpaNativeJni.cpp`
> Adds the missing `<cstdint>` and `<vector>` headers to [HappierSherpaNativeJni.cpp](https://github.com/happier-dev/happier/pull/204/files#diff-75dc720304e4e7dc0a704086acce71fec82d376ba6ceb2bc35d8ae6e5c097d3b) and moves `<memory>` earlier in the include order to fix compilation issues.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f958658.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal native components to ensure required standard utilities are available.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->