### PR TITLE
fix(claude-transcript): skip internal Claude record types in transcripts

### DIFF
--- a/apps/cli/src/backends/claude/utils/internalClaudeEventTypes.ts
+++ b/apps/cli/src/backends/claude/utils/internalClaudeEventTypes.ts
@@ -3,11 +3,18 @@
  *
  * These records are telemetry or internal state transitions, not conversation messages.
  * Keeping them out of Happier transcripts avoids confusing "[Unsupported agent output]" rows.
+ *
+ * `attachment` records carry context injections (hook output, reminders, tool/skill listings,
+ * file snapshots) rather than conversation content, so they belong here too.
  */
 export const INTERNAL_CLAUDE_EVENT_TYPES = new Set<string>([
   'file-history-snapshot',
   'change',
   'queue-operation',
   'rate_limit_event',
+  'attachment',
+  'last-prompt',
+  'mode',
+  'pr-link',
 ]);
 

--- a/apps/cli/src/backends/claude/utils/readClaudeSessionJsonlMessages.test.ts
+++ b/apps/cli/src/backends/claude/utils/readClaudeSessionJsonlMessages.test.ts
@@ -73,4 +73,29 @@ describe('readClaudeSessionJsonlMessages', () => {
     expect(messages.map((m) => m.uuid)).toEqual(['u2', 'u3']);
     expect((logger.debug as any).mock.calls.some((call: unknown[]) => String(call[0]).includes('Error processing message'))).toBe(false);
   });
+
+  it('drops Claude-internal state records that are not conversation content', async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), 'happier-claude-jsonl-'));
+    const sessionFilePath = join(tmpRoot, 'sess.jsonl');
+
+    const lines = [
+      JSON.stringify({ type: 'last-prompt', lastPrompt: 'hi', leafUuid: 'leaf-1', sessionId: 's1' }),
+      JSON.stringify({ type: 'mode', mode: 'default', sessionId: 's1' }),
+      JSON.stringify({ type: 'pr-link', url: 'https://example.test/pr/1', sessionId: 's1' }),
+      JSON.stringify({
+        type: 'attachment',
+        uuid: 'a1',
+        sessionId: 's1',
+        attachment: { type: 'hook_success', hookEvent: 'SessionStart' },
+      }),
+      JSON.stringify({ type: 'assistant', uuid: 'u1', message: {} }),
+    ];
+
+    await writeFile(sessionFilePath, `${lines.join('\n')}\n`, 'utf8');
+
+    const { readClaudeSessionJsonlMessages } = await import('./readClaudeSessionJsonlMessages');
+    const messages = await readClaudeSessionJsonlMessages({ sessionFilePath, logLabel: 'TEST' });
+
+    expect(messages.map((m) => m.type)).toEqual(['assistant']);
+  });
 });

--- a/apps/cli/src/backends/claude/utils/sdkToLogConverter.core.test.ts
+++ b/apps/cli/src/backends/claude/utils/sdkToLogConverter.core.test.ts
@@ -389,5 +389,24 @@ describe('SDKToLogConverter core conversion', () => {
 
       expect(logMessage).toBeNull();
     });
+
+    it.each([
+      ['last-prompt', { type: 'last-prompt', lastPrompt: 'hi', leafUuid: 'leaf-1' }],
+      ['mode', { type: 'mode', mode: 'default' }],
+      ['pr-link', { type: 'pr-link', url: 'https://example.test/pr/1' }],
+    ])('does not convert %s records (internal session state, not transcript content)', (_label, sdkMessage) => {
+      // Boundary cast: these are raw internal SDK records outside the SDKMessage union by design.
+      expect(converter.convert(sdkMessage as any)).toBeNull();
+    });
+
+    it('does not convert attachment records (context injection, not transcript content)', () => {
+      // Boundary cast: raw attachment record shape is outside the typed SDKMessage union.
+      const logMessage = converter.convert({
+        type: 'attachment',
+        attachment: { type: 'hook_success', hookEvent: 'SessionStart', stdout: '{}' },
+      } as any);
+
+      expect(logMessage).toBeNull();
+    });
   });
 });

--- a/apps/ui/sources/sync/typesRaw/normalize.outputInvalidKnownTypeFallback.test.ts
+++ b/apps/ui/sources/sync/typesRaw/normalize.outputInvalidKnownTypeFallback.test.ts
@@ -63,4 +63,29 @@ describe('typesRaw output schema (fail-soft)', () => {
             }),
         );
     });
+
+    it('names the unrecognized payload type in the fallback placeholder', () => {
+        // Without the type name the placeholder is undiagnosable: new Claude Code record types
+        // render as an opaque row with nothing to grep for.
+        const raw: any = {
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    type: 'some-future-record',
+                    uuid: 'future-1',
+                },
+            },
+        };
+
+        const normalized = normalizeRawMessage('msg-future-1', null, 1000, raw);
+        expect(normalized).not.toBeNull();
+        if (!normalized) return;
+        expect(normalized.role).toBe('agent');
+        if (normalized.role !== 'agent') return;
+
+        const block = normalized.content[0];
+        expect(block?.type).toBe('text');
+        expect(block?.type === 'text' && block.text).toContain('some-future-record');
+    });
 });

--- a/apps/ui/sources/sync/typesRaw/normalize.ts
+++ b/apps/ui/sources/sync/typesRaw/normalize.ts
@@ -753,6 +753,12 @@ export function normalizeRawMessage(
                 return filterNormalizedEventRoleOutput(normalized, opts?.messageRole);
             }
             // Any other output payload should be surfaced as an opaque message rather than dropped.
+            // Name the payload type: agent CLIs keep adding record types, and an unnamed placeholder
+            // leaves nothing to grep for when one starts leaking into transcripts.
+            const unsupportedType = (raw.content.data as { type?: unknown }).type;
+            const unsupportedLabel = typeof unsupportedType === 'string' && unsupportedType.length > 0
+                ? `[Unsupported agent output: ${unsupportedType}]`
+                : '[Unsupported agent output]';
             const normalized = {
                 id,
                 ...(seq !== undefined ? { seq } : {}),
@@ -762,7 +768,7 @@ export function normalizeRawMessage(
                 isSidechain: false,
                 content: [{
                     type: 'text',
-                    text: '[Unsupported agent output]',
+                    text: unsupportedLabel,
                     uuid: id,
                     parentUUID: null,
                 }],


### PR DESCRIPTION
## Problem

Sessions were showing `[Unsupported agent output]` rows in the transcript (see below — two in a row mid tool-run).

Root cause: Claude Code began emitting new JSONL record types around **2026-06-19** — `attachment`, `last-prompt`, `mode`, `pr-link`. None are conversation content, but they were missing from `INTERNAL_CLAUDE_EVENT_TYPES`, so the SDK-to-log converter forwarded them and the UI normalizer rendered each unrecognized `output` payload as an `[Unsupported agent output]` placeholder (`apps/ui/sources/sync/typesRaw/normalize.ts`).

Evidence, counts across one daemon host's `~/.claude/projects/**`:

| type | count | earliest | in skip-list before |
|---|---|---|---|
| `attachment` | 9897 | 2026-06-19 | ❌ |
| `last-prompt` | 5486 | — | ❌ |
| `mode` | 2627 | — | ❌ |
| `pr-link` | 1811 | 2026-06-20 | ❌ |

`attachment` subtypes are all context injections (hook output, task reminders, tool/skill listings, file snapshots, queued commands) — no transcript content.

## Fix

1. Add `attachment`, `last-prompt`, `mode`, `pr-link` to `INTERNAL_CLAUDE_EVENT_TYPES`. Dropped at read time, feeding the three existing call sites (converter, session scanner, jsonl reader); no new plumbing.
2. Name the payload type in the UI fallback: `[Unsupported agent output: <type>]`. The old placeholder discarded `data.type`, which is why this went unnoticed for a month — nothing to grep for. The next new record type will name itself.

## Tests (TDD, RED→GREEN)

- `readClaudeSessionJsonlMessages.test.ts` — internal state records dropped, ordinary content kept.
- `sdkToLogConverter.core.test.ts` — converter returns null for the four types.
- `normalize.outputInvalidKnownTypeFallback.test.ts` — fallback names the unknown type.

## Verification

- `@happier-dev/cli` typecheck: pass. `@happier-dev/app` typecheck: pass.
- CLI `src/backends/claude/`: 219 files, 1796 tests pass.
- UI `sources/sync/typesRaw/`: 34 tests pass.
- Full UI `sources/sync/` lane: 5 failures in `syncSessions.*SocketUpdate.test.ts` — confirmed **pre-existing on `dev`** (identical failure set on a clean-tree run), unrelated to this change.

## Out of scope (follow-up)

`acceptedPromptTranscriptDiscovery.ts` has dead `queue-operation`/`attachment` branches — those rows never survive `RawJSONLinesSchema` (a closed union), so queued-command prompt discovery silently no-ops. Separate bug; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787295544&installation_model_id=20481&pr_number=206&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F206&signature=0708ffc66bc9823d31d88d30eccdba93db208db21a3c6cb06b58a51f5ef8f2a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip internal Claude record types (`attachment`, `last-prompt`, `mode`, `pr-link`) in transcripts
> - Adds `attachment`, `last-prompt`, `mode`, and `pr-link` to the `INTERNAL_CLAUDE_EVENT_TYPES` set in [internalClaudeEventTypes.ts](https://github.com/happier-dev/happier/pull/206/files#diff-4ea6bb747c01b844916a1397fc4b6380df1239b3df8e774bbb838d907e835809) so these records are filtered out of transcripts and treated as non-conversation content.
> - Updates the unsupported output placeholder in [normalize.ts](https://github.com/happier-dev/happier/pull/206/files#diff-626c7794b707c42df537691a399a697c07057ae5f4f0df65dfc69f2bd303563b) to include the payload's `type` field in the label, changing `[Unsupported agent output]` to `[Unsupported agent output: <type>]` when available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e36bf2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude transcript handling by excluding additional internal session events and context-injection records from conversation history.
  * Unsupported agent output types now display a clearer placeholder that identifies the unrecognized type.
  * Preserved graceful fallback behavior for unrecognized payloads when the type is missing or empty.
* **Tests**
  * Added coverage to ensure internal Claude records and context-injection events are filtered from transcript output.
  * Added coverage for unsupported raw output normalization fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->