### PR TITLE
fix(ui-transcript): localize hardcoded unsupported/unparsed placeholder strings

### DIFF
--- a/apps/ui/sources/components/sessions/transcript/MessageView.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.tsx
@@ -31,7 +31,7 @@ import { ThinkingTimelineRow } from '@/components/sessions/transcript/thinking/T
 import { TranscriptEventRow } from '@/components/sessions/transcript/events/TranscriptEventRow';
 import { transcriptMarkdownTextStyle } from '@/components/sessions/transcript/transcriptMarkdownTypography';
 import { parseHappierMetaEnvelope } from '@/components/sessions/transcript/structured/happierMetaEnvelope';
-import { readUnsupportedContentMeta, type UnsupportedContentMetaValue } from '@/sync/domains/messages/unsupportedContentMeta';
+import { readUnsupportedContentMeta, type UnsupportedContentKind } from '@/sync/domains/messages/unsupportedContentMeta';
 import { AttachmentsMessageRow } from '@/components/sessions/attachments/messages/AttachmentsMessageRow';
 import { SessionMediaInlineImages } from '@/components/sessions/sessionMedia/SessionMediaInlineImages';
 import { parseSessionMediaMessageMeta } from '@/sync/domains/sessionMedia/sessionMediaMessageMeta';
@@ -105,16 +105,16 @@ function shouldEnableFallbackTextNativeSelection(platformOS: typeof Platform.OS)
   return platformOS !== 'ios';
 }
 
-function resolveUnsupportedContentLabel(meta: UnsupportedContentMetaValue): string {
-  switch (meta.kind) {
+function resolveUnsupportedContentLabel(kind: UnsupportedContentKind): string {
+  switch (kind) {
     case 'unparsed-user-message':
       return t('transcript.unsupportedContent.unparsedUserMessage');
     case 'unparsed-agent-message':
       return t('transcript.unsupportedContent.unparsedAgentMessage');
     case 'unsupported-agent-output':
-      return t('transcript.unsupportedContent.unsupportedAgentOutput', { recordType: meta.recordType });
+      return t('transcript.unsupportedContent.unsupportedAgentOutput');
     case 'unsupported-transcript-record':
-      return t('transcript.unsupportedContent.unsupportedTranscriptRecord', { recordType: meta.recordType });
+      return t('transcript.unsupportedContent.unsupportedTranscriptRecord');
   }
 }
 

--- a/apps/ui/sources/components/sessions/transcript/MessageView.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.tsx
@@ -31,7 +31,8 @@ import { ThinkingTimelineRow } from '@/components/sessions/transcript/thinking/T
 import { TranscriptEventRow } from '@/components/sessions/transcript/events/TranscriptEventRow';
 import { transcriptMarkdownTextStyle } from '@/components/sessions/transcript/transcriptMarkdownTypography';
 import { parseHappierMetaEnvelope } from '@/components/sessions/transcript/structured/happierMetaEnvelope';
-import { readUnsupportedContentMeta, type UnsupportedContentKind } from '@/sync/domains/messages/unsupportedContentMeta';
+import { readUnsupportedContentMeta } from '@/sync/domains/messages/unsupportedContentMeta';
+import { resolveUnsupportedContentLabel } from '@/sync/domains/messages/resolveUnsupportedContentLabel';
 import { AttachmentsMessageRow } from '@/components/sessions/attachments/messages/AttachmentsMessageRow';
 import { SessionMediaInlineImages } from '@/components/sessions/sessionMedia/SessionMediaInlineImages';
 import { parseSessionMediaMessageMeta } from '@/sync/domains/sessionMedia/sessionMediaMessageMeta';
@@ -103,19 +104,6 @@ function useStructuredMessageJumpHandler(sessionId: string): StructuredMessageRe
 
 function shouldEnableFallbackTextNativeSelection(platformOS: typeof Platform.OS): boolean {
   return platformOS !== 'ios';
-}
-
-function resolveUnsupportedContentLabel(kind: UnsupportedContentKind): string {
-  switch (kind) {
-    case 'unparsed-user-message':
-      return t('transcript.unsupportedContent.unparsedUserMessage');
-    case 'unparsed-agent-message':
-      return t('transcript.unsupportedContent.unparsedAgentMessage');
-    case 'unsupported-agent-output':
-      return t('transcript.unsupportedContent.unsupportedAgentOutput');
-    case 'unsupported-transcript-record':
-      return t('transcript.unsupportedContent.unsupportedTranscriptRecord');
-  }
 }
 
 function normalizeStreamSegmentStateForRendering(value: unknown): StreamSegmentStateForRendering | null {
@@ -426,11 +414,14 @@ function UserTextBlock(props: {
     return true;
   }, []);
 
-  const selectableMessage = isDiscarded ? null : resolveSelectableMessageText({
-    message: props.message,
-    isStructuredOnly,
-    hasAttachmentBlockToStrip: attachmentsMeta != null,
-  });
+  const selectableMessage = isDiscarded ? null : (() => {
+    const base = resolveSelectableMessageText({
+      message: props.message,
+      isStructuredOnly,
+      hasAttachmentBlockToStrip: attachmentsMeta != null,
+    });
+    return base && unsupportedContentMeta ? { ...base, text: resolveUnsupportedContentLabel(unsupportedContentMeta) } : base;
+  })();
   const selectionEnabled = props.messageDisplayCommon.transcriptMessageSelectionEnabled === true && selectableMessage != null;
   const selectionRow = useOptionalTranscriptSelectionRow(props.message.id);
   const selectionModeActionsVisible = selectionEnabled && selectionRow.isSelectionMode;
@@ -777,11 +768,14 @@ function AgentTextBlock(props: {
     if (cleaned.length <= 120) return cleaned;
     return cleaned.slice(0, 117) + '…';
   };
-  const selectableMessage = resolveSelectableMessageText({
-    message: props.message,
-    isStructuredOnly,
-    hasAttachmentBlockToStrip: false,
-  });
+  const selectableMessage = (() => {
+    const base = resolveSelectableMessageText({
+      message: props.message,
+      isStructuredOnly,
+      hasAttachmentBlockToStrip: false,
+    });
+    return base && unsupportedContentMeta ? { ...base, text: resolveUnsupportedContentLabel(unsupportedContentMeta) } : base;
+  })();
   const selectionEnabled = props.messageDisplayCommon.transcriptMessageSelectionEnabled === true && selectableMessage != null;
   const copyText = selectableMessage?.text ?? (isStructuredOnly ? props.message.text : markdown);
 

--- a/apps/ui/sources/components/sessions/transcript/MessageView.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.tsx
@@ -31,6 +31,7 @@ import { ThinkingTimelineRow } from '@/components/sessions/transcript/thinking/T
 import { TranscriptEventRow } from '@/components/sessions/transcript/events/TranscriptEventRow';
 import { transcriptMarkdownTextStyle } from '@/components/sessions/transcript/transcriptMarkdownTypography';
 import { parseHappierMetaEnvelope } from '@/components/sessions/transcript/structured/happierMetaEnvelope';
+import { readUnsupportedContentMeta, type UnsupportedContentMetaValue } from '@/sync/domains/messages/unsupportedContentMeta';
 import { AttachmentsMessageRow } from '@/components/sessions/attachments/messages/AttachmentsMessageRow';
 import { SessionMediaInlineImages } from '@/components/sessions/sessionMedia/SessionMediaInlineImages';
 import { parseSessionMediaMessageMeta } from '@/sync/domains/sessionMedia/sessionMediaMessageMeta';
@@ -102,6 +103,19 @@ function useStructuredMessageJumpHandler(sessionId: string): StructuredMessageRe
 
 function shouldEnableFallbackTextNativeSelection(platformOS: typeof Platform.OS): boolean {
   return platformOS !== 'ios';
+}
+
+function resolveUnsupportedContentLabel(meta: UnsupportedContentMetaValue): string {
+  switch (meta.kind) {
+    case 'unparsed-user-message':
+      return t('transcript.unsupportedContent.unparsedUserMessage');
+    case 'unparsed-agent-message':
+      return t('transcript.unsupportedContent.unparsedAgentMessage');
+    case 'unsupported-agent-output':
+      return t('transcript.unsupportedContent.unsupportedAgentOutput', { recordType: meta.recordType });
+    case 'unsupported-transcript-record':
+      return t('transcript.unsupportedContent.unsupportedTranscriptRecord', { recordType: meta.recordType });
+  }
 }
 
 function normalizeStreamSegmentStateForRendering(value: unknown): StreamSegmentStateForRendering | null {
@@ -342,6 +356,11 @@ function UserTextBlock(props: {
     return envelope?.kind === 'voice_agent_turn.v1';
   }, [props.message.meta]);
 
+  const unsupportedContentMeta = React.useMemo(
+    () => readUnsupportedContentMeta(props.message.meta),
+    [props.message.meta],
+  );
+
   const structuredNode = renderStructuredMessage({
     message: props.message,
     sessionId: props.sessionId,
@@ -368,13 +387,14 @@ function UserTextBlock(props: {
   }, [pathname, props.sessionId, router]);
 
   const markdownText = React.useMemo(() => {
+    if (unsupportedContentMeta) return resolveUnsupportedContentLabel(unsupportedContentMeta);
     if (isVoiceAgentTurn && props.message.displayText === undefined) {
       return normalizeVoiceAgentTurnTranscriptText(props.message.text);
     }
     if (props.message.displayText !== undefined) return props.message.displayText;
     if (attachmentsMeta) return stripLegacyAttachmentsBlock(props.message.text);
     return props.message.text;
-  }, [attachmentsMeta, isVoiceAgentTurn, props.message.displayText, props.message.text]);
+  }, [attachmentsMeta, isVoiceAgentTurn, props.message.displayText, props.message.text, unsupportedContentMeta]);
   const renderedMarkdownText = markdownText ?? props.message.displayText ?? props.message.text;
 
   const linkedWorkspaceFiles = React.useMemo(
@@ -705,6 +725,10 @@ function AgentTextBlock(props: {
     const envelope = parseHappierMetaEnvelope(props.message.meta);
     return envelope?.kind === 'voice_agent_turn.v1';
   }, [props.message.meta]);
+  const unsupportedContentMeta = React.useMemo(
+    () => readUnsupportedContentMeta(props.message.meta),
+    [props.message.meta],
+  );
   const sessionThinkingDisplayMode = props.messageDisplayCommon.sessionThinkingDisplayMode;
   const sessionThinkingInlinePresentation = props.messageDisplayCommon.sessionThinkingInlinePresentation;
   const sessionThinkingInlineChrome = props.messageDisplayCommon.sessionThinkingInlineChrome;
@@ -729,14 +753,18 @@ function AgentTextBlock(props: {
   const handleOpenMediaPath = React.useCallback((filePath: string) => {
     pushSessionFileDeepLink(router, pathname, { sessionId: props.sessionId, filePath });
   }, [pathname, props.sessionId, router]);
-  const baseMarkdownText = isVoiceAgentTurn
-    ? normalizeVoiceAgentTurnTranscriptText(props.message.text)
-    : props.message.text;
-  if (isVoiceAgentTurn && baseMarkdownText == null) {
+  const baseMarkdownText = unsupportedContentMeta
+    ? resolveUnsupportedContentLabel(unsupportedContentMeta)
+    : isVoiceAgentTurn
+      ? normalizeVoiceAgentTurnTranscriptText(props.message.text)
+      : props.message.text;
+  if (!unsupportedContentMeta && isVoiceAgentTurn && baseMarkdownText == null) {
     return null;
   }
   const markdownSource = baseMarkdownText ?? props.message.text;
-  const markdown = props.message.isThinking ? unwrapLegacyThinkingWrapper(markdownSource) : markdownSource;
+  const markdown = (!unsupportedContentMeta && props.message.isThinking)
+    ? unwrapLegacyThinkingWrapper(markdownSource)
+    : markdownSource;
   const deriveThinkingSummary = (text: string) => {
     const trimmed = String(text ?? '').trim();
     if (!trimmed) return '';

--- a/apps/ui/sources/components/sessions/transcript/MessageView.unsupportedContent.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.unsupportedContent.test.tsx
@@ -38,9 +38,11 @@ vi.mock('@/components/ui/text/Text', () => ({
     TextInput: (props: any) => React.createElement('TextInput', props, props.children),
 }));
 
+let copyButtonsVisible = false;
+
 vi.mock('@/components/sessions/transcript/messageCopyVisibility', () => ({
-    shouldShowMessageCopyButton: () => false,
-    shouldShowMessageSelectButton: () => false,
+    shouldShowMessageCopyButton: () => copyButtonsVisible,
+    shouldShowMessageSelectButton: () => copyButtonsVisible,
 }));
 
 vi.mock('@/components/sessions/transcript/structured/StructuredMessageBlock', () => ({
@@ -84,9 +86,19 @@ vi.mock('@expo/vector-icons', () => ({
     Ionicons: 'Ionicons',
 }));
 
+const setClipboardStringSafeMock = vi.fn(async (_text: string) => true);
+vi.mock('@/utils/ui/clipboard', () => ({
+    setClipboardStringSafe: (text: string) => setClipboardStringSafeMock(text),
+}));
+
+vi.mock('@/components/sessions/transcript/messageSelection/SelectMessageButton', () => ({
+    SelectMessageButton: (props: any) => React.createElement('SelectMessageButton', props),
+}));
+
 describe('MessageView unsupported-content rendering', () => {
     beforeEach(() => {
         vi.resetModules();
+        copyButtonsVisible = false;
     });
 
     afterEach(() => {
@@ -194,5 +206,55 @@ describe('MessageView unsupported-content rendering', () => {
 
         const markdownView = screen.findByType('MarkdownView' as any);
         expect(markdownView.props.markdown).toBe('hello world');
+    });
+
+    it.each([
+        ['[Unparsed user message]', undefined],
+        ['[Unparsed agent message]', undefined],
+        ['[Unsupported agent output]', { happierUnsupportedContentV1: 'not-a-real-kind' }],
+        ['[Unsupported transcript record]', { happierUnsupportedContentV1: 42 }],
+    ] as const)(
+        'renders the literal raw placeholder text %s unchanged when the meta marker is absent or malformed (no string-sniffing)',
+        async (rawText, meta) => {
+            const { MessageView } = await import('./MessageView');
+
+            const screen = await renderScreen(
+                <MessageView
+                    sessionId="s1"
+                    metadata={null}
+                    message={{ kind: 'agent-text', id: 'legacy', localId: 'local-legacy', createdAt: 1, text: rawText, meta }}
+                />,
+            );
+
+            const markdownView = screen.findByType('MarkdownView' as any);
+            expect(markdownView.props.markdown).toBe(rawText);
+        },
+    );
+
+    it('does not leak the raw fallback text into select-preview/copy text when an unsupported-content marker is present', async () => {
+        copyButtonsVisible = true;
+        setClipboardStringSafeMock.mockClear();
+        const { MessageView } = await import('./MessageView');
+
+        const screen = await renderScreen(
+            <MessageView
+                sessionId="s1"
+                metadata={null}
+                message={{
+                    kind: 'agent-text',
+                    id: 'a5',
+                    localId: 'local-a5',
+                    createdAt: 1,
+                    text: '[Unsupported agent output]',
+                    meta: { happierUnsupportedContentV1: 'unsupported-agent-output' },
+                }}
+            />,
+        );
+
+        const selectButton = screen.findByTestId('transcript-message-select:a5');
+        expect(selectButton?.props.previewText).toBe('transcript.unsupportedContent.unsupportedAgentOutput');
+
+        await screen.pressByTestIdAsync('transcript-message-copy:a5');
+        expect(setClipboardStringSafeMock).toHaveBeenCalledWith('transcript.unsupportedContent.unsupportedAgentOutput');
     });
 });

--- a/apps/ui/sources/components/sessions/transcript/MessageView.unsupportedContent.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.unsupportedContent.test.tsx
@@ -106,7 +106,7 @@ describe('MessageView unsupported-content rendering', () => {
                     localId: 'local-u1',
                     createdAt: 1,
                     text: '[Unparsed user message]',
-                    meta: { happierUnsupportedContentV1: { kind: 'unparsed-user-message' } },
+                    meta: { happierUnsupportedContentV1: 'unparsed-user-message' },
                 }}
             />,
         );
@@ -128,7 +128,7 @@ describe('MessageView unsupported-content rendering', () => {
                     localId: 'local-a1',
                     createdAt: 1,
                     text: '[Unparsed agent message]',
-                    meta: { happierUnsupportedContentV1: { kind: 'unparsed-agent-message' } },
+                    meta: { happierUnsupportedContentV1: 'unparsed-agent-message' },
                 }}
             />,
         );
@@ -137,7 +137,7 @@ describe('MessageView unsupported-content rendering', () => {
         expect(markdownView.props.markdown).toBe('transcript.unsupportedContent.unparsedAgentMessage');
     });
 
-    it('renders the localized label with the recordType param for unsupported agent output', async () => {
+    it('renders the localized label for unsupported agent output', async () => {
         const { MessageView } = await import('./MessageView');
 
         const screen = await renderScreen(
@@ -150,23 +150,16 @@ describe('MessageView unsupported-content rendering', () => {
                     localId: 'local-a2',
                     createdAt: 1,
                     text: '[Unsupported agent output]',
-                    meta: {
-                        happierUnsupportedContentV1: {
-                            kind: 'unsupported-agent-output',
-                            recordType: 'some_future_output_type',
-                        },
-                    },
+                    meta: { happierUnsupportedContentV1: 'unsupported-agent-output' },
                 }}
             />,
         );
 
         const markdownView = screen.findByType('MarkdownView' as any);
-        expect(markdownView.props.markdown).toBe(
-            'transcript.unsupportedContent.unsupportedAgentOutput::{"recordType":"some_future_output_type"}',
-        );
+        expect(markdownView.props.markdown).toBe('transcript.unsupportedContent.unsupportedAgentOutput');
     });
 
-    it('renders the localized label with the recordType param for an unsupported transcript record', async () => {
+    it('renders the localized label for an unsupported transcript record', async () => {
         const { MessageView } = await import('./MessageView');
 
         const screen = await renderScreen(
@@ -179,20 +172,13 @@ describe('MessageView unsupported-content rendering', () => {
                     localId: 'local-a3',
                     createdAt: 1,
                     text: '[Unsupported transcript record]',
-                    meta: {
-                        happierUnsupportedContentV1: {
-                            kind: 'unsupported-transcript-record',
-                            recordType: 'some_future_acp_type',
-                        },
-                    },
+                    meta: { happierUnsupportedContentV1: 'unsupported-transcript-record' },
                 }}
             />,
         );
 
         const markdownView = screen.findByType('MarkdownView' as any);
-        expect(markdownView.props.markdown).toBe(
-            'transcript.unsupportedContent.unsupportedTranscriptRecord::{"recordType":"some_future_acp_type"}',
-        );
+        expect(markdownView.props.markdown).toBe('transcript.unsupportedContent.unsupportedTranscriptRecord');
     });
 
     it('renders normal message text unaffected when no unsupported-content marker is present', async () => {

--- a/apps/ui/sources/components/sessions/transcript/MessageView.unsupportedContent.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.unsupportedContent.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderScreen, standardCleanup } from '@/dev/testkit';
+import { installMessageViewCommonModuleMocks } from './messageViewTestHelpers';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+installMessageViewCommonModuleMocks({
+    text: async () => {
+        const { createTextModuleMock } = await import('@/dev/testkit/mocks/text');
+        return createTextModuleMock({
+            translate: (key: string, params?: Record<string, unknown>) =>
+                params ? `${key}::${JSON.stringify(params)}` : key,
+        });
+    },
+    storage: async (importOriginal) => {
+        const { createStorageModuleMock } = await import('@/dev/testkit/mocks/storage');
+        return createStorageModuleMock({
+            importOriginal,
+            overrides: {
+                useSetting: () => null,
+                useSessionForkSupportSource: () => null,
+                useSessionWorkspacePath: () => null,
+                useSessionMessagesById: () => ({}),
+                useSessionMessagesReducerState: () => ({} as any),
+            },
+        });
+    },
+});
+
+vi.mock('@/components/markdown/MarkdownView', () => ({
+    MarkdownView: (props: any) => React.createElement('MarkdownView', props),
+}));
+
+vi.mock('@/components/ui/text/Text', () => ({
+    Text: (props: any) => React.createElement('Text', props, props.children),
+    TextInput: (props: any) => React.createElement('TextInput', props, props.children),
+}));
+
+vi.mock('@/components/sessions/transcript/messageCopyVisibility', () => ({
+    shouldShowMessageCopyButton: () => false,
+    shouldShowMessageSelectButton: () => false,
+}));
+
+vi.mock('@/components/sessions/transcript/structured/StructuredMessageBlock', () => ({
+    StructuredMessageBlock: () => null,
+    renderStructuredMessage: () => null,
+}));
+
+vi.mock('@/components/sessions/linkedFiles/extractWorkspaceFileMentions', () => ({
+    extractWorkspaceFileMentions: () => [],
+}));
+
+vi.mock('@/components/sessions/linkedFiles/LinkedWorkspaceFilesRow', () => ({
+    LinkedWorkspaceFilesRow: () => null,
+}));
+
+vi.mock('@/components/tools/shell/views/ToolView', () => ({
+    ToolView: () => null,
+}));
+
+vi.mock('@/components/tools/shell/views/ToolTimelineRow', () => ({
+    ToolTimelineRow: () => null,
+}));
+
+vi.mock('@/components/sessions/transcript/thinking/ThinkingTimelineRow', () => ({
+    ThinkingTimelineRow: ({ children }: any) => React.createElement(React.Fragment, null, children),
+}));
+
+vi.mock('@/components/sessions/attachments/messages/AttachmentsMessageRow', () => ({
+    AttachmentsMessageRow: () => null,
+}));
+
+vi.mock('@/components/sessions/sessionMedia/SessionMediaInlineImages', () => ({
+    SessionMediaInlineImages: () => null,
+}));
+
+vi.mock('@/hooks/server/useFeatureEnabled', () => ({
+    useFeatureEnabled: () => false,
+}));
+
+vi.mock('@expo/vector-icons', () => ({
+    Ionicons: 'Ionicons',
+}));
+
+describe('MessageView unsupported-content rendering', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    afterEach(() => {
+        standardCleanup();
+    });
+
+    it('renders the localized label for an unparsed user message instead of the raw fallback text', async () => {
+        const { MessageView } = await import('./MessageView');
+
+        const screen = await renderScreen(
+            <MessageView
+                sessionId="s1"
+                metadata={null}
+                message={{
+                    kind: 'user-text',
+                    id: 'u1',
+                    localId: 'local-u1',
+                    createdAt: 1,
+                    text: '[Unparsed user message]',
+                    meta: { happierUnsupportedContentV1: { kind: 'unparsed-user-message' } },
+                }}
+            />,
+        );
+
+        const markdownView = screen.findByType('MarkdownView' as any);
+        expect(markdownView.props.markdown).toBe('transcript.unsupportedContent.unparsedUserMessage');
+    });
+
+    it('renders the localized label for an unparsed agent message instead of the raw fallback text', async () => {
+        const { MessageView } = await import('./MessageView');
+
+        const screen = await renderScreen(
+            <MessageView
+                sessionId="s1"
+                metadata={null}
+                message={{
+                    kind: 'agent-text',
+                    id: 'a1',
+                    localId: 'local-a1',
+                    createdAt: 1,
+                    text: '[Unparsed agent message]',
+                    meta: { happierUnsupportedContentV1: { kind: 'unparsed-agent-message' } },
+                }}
+            />,
+        );
+
+        const markdownView = screen.findByType('MarkdownView' as any);
+        expect(markdownView.props.markdown).toBe('transcript.unsupportedContent.unparsedAgentMessage');
+    });
+
+    it('renders the localized label with the recordType param for unsupported agent output', async () => {
+        const { MessageView } = await import('./MessageView');
+
+        const screen = await renderScreen(
+            <MessageView
+                sessionId="s1"
+                metadata={null}
+                message={{
+                    kind: 'agent-text',
+                    id: 'a2',
+                    localId: 'local-a2',
+                    createdAt: 1,
+                    text: '[Unsupported agent output]',
+                    meta: {
+                        happierUnsupportedContentV1: {
+                            kind: 'unsupported-agent-output',
+                            recordType: 'some_future_output_type',
+                        },
+                    },
+                }}
+            />,
+        );
+
+        const markdownView = screen.findByType('MarkdownView' as any);
+        expect(markdownView.props.markdown).toBe(
+            'transcript.unsupportedContent.unsupportedAgentOutput::{"recordType":"some_future_output_type"}',
+        );
+    });
+
+    it('renders the localized label with the recordType param for an unsupported transcript record', async () => {
+        const { MessageView } = await import('./MessageView');
+
+        const screen = await renderScreen(
+            <MessageView
+                sessionId="s1"
+                metadata={null}
+                message={{
+                    kind: 'agent-text',
+                    id: 'a3',
+                    localId: 'local-a3',
+                    createdAt: 1,
+                    text: '[Unsupported transcript record]',
+                    meta: {
+                        happierUnsupportedContentV1: {
+                            kind: 'unsupported-transcript-record',
+                            recordType: 'some_future_acp_type',
+                        },
+                    },
+                }}
+            />,
+        );
+
+        const markdownView = screen.findByType('MarkdownView' as any);
+        expect(markdownView.props.markdown).toBe(
+            'transcript.unsupportedContent.unsupportedTranscriptRecord::{"recordType":"some_future_acp_type"}',
+        );
+    });
+
+    it('renders normal message text unaffected when no unsupported-content marker is present', async () => {
+        const { MessageView } = await import('./MessageView');
+
+        const screen = await renderScreen(
+            <MessageView
+                sessionId="s1"
+                metadata={null}
+                message={{ kind: 'agent-text', id: 'a4', localId: 'local-a4', createdAt: 1, text: 'hello world' }}
+            />,
+        );
+
+        const markdownView = screen.findByType('MarkdownView' as any);
+        expect(markdownView.props.markdown).toBe('hello world');
+    });
+});

--- a/apps/ui/sources/components/sessions/transcript/messageSelection/resolveTranscriptSelectionToolbarMessages.test.ts
+++ b/apps/ui/sources/components/sessions/transcript/messageSelection/resolveTranscriptSelectionToolbarMessages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Message } from '@/sync/domains/messages/messageTypes';
+import { resolveUnsupportedContentLabel } from '@/sync/domains/messages/resolveUnsupportedContentLabel';
 import type { Metadata } from '@/sync/domains/state/storageTypes';
 
 import { resolveTranscriptSelectionToolbarMessages } from './resolveTranscriptSelectionToolbarMessages';
@@ -49,5 +50,23 @@ describe('resolveTranscriptSelectionToolbarMessages', () => {
         ], { path: '/', host: 'localhost', discardedCommittedMessageLocalIds: ['local-discarded'] } as Metadata);
 
         expect(resolved).toEqual([{ id: 'done', role: 'assistant', text: 'complete' }]);
+    });
+
+    it('resolves the localized label, not the raw fallback text, for a message carrying an unsupported-content marker', () => {
+        const resolved = resolveTranscriptSelectionToolbarMessages([
+            message({
+                id: 'unsupported',
+                kind: 'agent-text',
+                text: '[Unsupported agent output]',
+                meta: { happierUnsupportedContentV1: 'unsupported-agent-output' },
+            }),
+        ]);
+
+        expect(resolved).toEqual([{
+            id: 'unsupported',
+            role: 'assistant',
+            text: resolveUnsupportedContentLabel('unsupported-agent-output'),
+        }]);
+        expect(resolved[0]?.text).not.toBe('[Unsupported agent output]');
     });
 });

--- a/apps/ui/sources/components/sessions/transcript/messageSelection/resolveTranscriptSelectionToolbarMessages.ts
+++ b/apps/ui/sources/components/sessions/transcript/messageSelection/resolveTranscriptSelectionToolbarMessages.ts
@@ -1,5 +1,7 @@
 import { parseSessionMediaMessageMeta } from '@/sync/domains/sessionMedia/sessionMediaMessageMeta';
 import type { Message } from '@/sync/domains/messages/messageTypes';
+import { readUnsupportedContentMeta } from '@/sync/domains/messages/unsupportedContentMeta';
+import { resolveUnsupportedContentLabel } from '@/sync/domains/messages/resolveUnsupportedContentLabel';
 import type { Metadata } from '@/sync/domains/state/storageTypes';
 import { isCommittedMessageDiscarded } from '@/utils/sessions/discardedCommittedMessages';
 
@@ -27,7 +29,11 @@ export function resolveTranscriptSelectionToolbarMessages(
             hasAttachmentBlockToStrip: message.kind === 'user-text' && parsedSessionMediaMeta?.legacyAttachments != null,
         });
         if (!selectable) continue;
-        selectableMessages.push({ id: message.id, ...selectable });
+        const unsupportedContentMeta = readUnsupportedContentMeta(message.meta);
+        const resolved = unsupportedContentMeta
+            ? { ...selectable, text: resolveUnsupportedContentLabel(unsupportedContentMeta) }
+            : selectable;
+        selectableMessages.push({ id: message.id, ...resolved });
     }
     return selectableMessages;
 }

--- a/apps/ui/sources/sync/domains/messages/resolveUnsupportedContentLabel.ts
+++ b/apps/ui/sources/sync/domains/messages/resolveUnsupportedContentLabel.ts
@@ -1,0 +1,16 @@
+import { t } from '@/text';
+
+import type { UnsupportedContentKind } from './unsupportedContentMeta';
+
+export function resolveUnsupportedContentLabel(kind: UnsupportedContentKind): string {
+    switch (kind) {
+        case 'unparsed-user-message':
+            return t('transcript.unsupportedContent.unparsedUserMessage');
+        case 'unparsed-agent-message':
+            return t('transcript.unsupportedContent.unparsedAgentMessage');
+        case 'unsupported-agent-output':
+            return t('transcript.unsupportedContent.unsupportedAgentOutput');
+        case 'unsupported-transcript-record':
+            return t('transcript.unsupportedContent.unsupportedTranscriptRecord');
+    }
+}

--- a/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.test.ts
+++ b/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { markUnsupportedContentMeta, readUnsupportedContentMeta } from './unsupportedContentMeta';
+
+describe('markUnsupportedContentMeta / readUnsupportedContentMeta', () => {
+    it('round-trips a kind with no recordType', () => {
+        const meta = markUnsupportedContentMeta(undefined, { kind: 'unparsed-user-message' });
+        expect(readUnsupportedContentMeta(meta)).toEqual({ kind: 'unparsed-user-message' });
+    });
+
+    it('round-trips a kind with a recordType', () => {
+        const meta = markUnsupportedContentMeta(undefined, { kind: 'unsupported-agent-output', recordType: 'weird_type' });
+        expect(readUnsupportedContentMeta(meta)).toEqual({ kind: 'unsupported-agent-output', recordType: 'weird_type' });
+    });
+
+    it('preserves unrelated existing meta fields', () => {
+        const meta = markUnsupportedContentMeta({ source: 'cli' } as any, { kind: 'unsupported-transcript-record' });
+        expect((meta as any).source).toBe('cli');
+        expect(readUnsupportedContentMeta(meta)).toEqual({ kind: 'unsupported-transcript-record' });
+    });
+
+    it.each([
+        ['unparsed-user-message'],
+        ['unparsed-agent-message'],
+        ['unsupported-agent-output'],
+        ['unsupported-transcript-record'],
+    ] as const)('supports kind=%s', (kind) => {
+        const meta = markUnsupportedContentMeta(undefined, { kind });
+        expect(readUnsupportedContentMeta(meta)?.kind).toBe(kind);
+    });
+
+    it('returns null for undefined/null meta', () => {
+        expect(readUnsupportedContentMeta(undefined)).toBeNull();
+        expect(readUnsupportedContentMeta(null)).toBeNull();
+    });
+
+    it('returns null when the meta key is absent', () => {
+        expect(readUnsupportedContentMeta({ source: 'ui' })).toBeNull();
+    });
+
+    it('returns null for a malformed marker value', () => {
+        expect(readUnsupportedContentMeta({ happierUnsupportedContentV1: 'not-an-object' })).toBeNull();
+        expect(readUnsupportedContentMeta({ happierUnsupportedContentV1: { kind: 'not-a-real-kind' } })).toBeNull();
+        expect(readUnsupportedContentMeta({ happierUnsupportedContentV1: {} })).toBeNull();
+    });
+
+    it('ignores a non-string recordType', () => {
+        expect(readUnsupportedContentMeta({
+            happierUnsupportedContentV1: { kind: 'unsupported-agent-output', recordType: 42 },
+        })).toEqual({ kind: 'unsupported-agent-output' });
+    });
+
+    it('ignores an empty-string recordType', () => {
+        expect(readUnsupportedContentMeta({
+            happierUnsupportedContentV1: { kind: 'unsupported-agent-output', recordType: '' },
+        })).toEqual({ kind: 'unsupported-agent-output' });
+    });
+});

--- a/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.test.ts
+++ b/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.test.ts
@@ -8,8 +8,8 @@ describe('markUnsupportedContentMeta / readUnsupportedContentMeta', () => {
     });
 
     it('preserves unrelated existing meta fields', () => {
-        const meta = markUnsupportedContentMeta({ source: 'cli' } as any, 'unsupported-transcript-record');
-        expect((meta as any).source).toBe('cli');
+        const meta = markUnsupportedContentMeta({ source: 'cli' }, 'unsupported-transcript-record');
+        expect(meta.source).toBe('cli');
         expect(readUnsupportedContentMeta(meta)).toBe('unsupported-transcript-record');
     });
 

--- a/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.test.ts
+++ b/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.test.ts
@@ -2,20 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { markUnsupportedContentMeta, readUnsupportedContentMeta } from './unsupportedContentMeta';
 
 describe('markUnsupportedContentMeta / readUnsupportedContentMeta', () => {
-    it('round-trips a kind with no recordType', () => {
-        const meta = markUnsupportedContentMeta(undefined, { kind: 'unparsed-user-message' });
-        expect(readUnsupportedContentMeta(meta)).toEqual({ kind: 'unparsed-user-message' });
-    });
-
-    it('round-trips a kind with a recordType', () => {
-        const meta = markUnsupportedContentMeta(undefined, { kind: 'unsupported-agent-output', recordType: 'weird_type' });
-        expect(readUnsupportedContentMeta(meta)).toEqual({ kind: 'unsupported-agent-output', recordType: 'weird_type' });
+    it('round-trips a kind', () => {
+        const meta = markUnsupportedContentMeta(undefined, 'unparsed-user-message');
+        expect(readUnsupportedContentMeta(meta)).toBe('unparsed-user-message');
     });
 
     it('preserves unrelated existing meta fields', () => {
-        const meta = markUnsupportedContentMeta({ source: 'cli' } as any, { kind: 'unsupported-transcript-record' });
+        const meta = markUnsupportedContentMeta({ source: 'cli' } as any, 'unsupported-transcript-record');
         expect((meta as any).source).toBe('cli');
-        expect(readUnsupportedContentMeta(meta)).toEqual({ kind: 'unsupported-transcript-record' });
+        expect(readUnsupportedContentMeta(meta)).toBe('unsupported-transcript-record');
     });
 
     it.each([
@@ -24,8 +19,8 @@ describe('markUnsupportedContentMeta / readUnsupportedContentMeta', () => {
         ['unsupported-agent-output'],
         ['unsupported-transcript-record'],
     ] as const)('supports kind=%s', (kind) => {
-        const meta = markUnsupportedContentMeta(undefined, { kind });
-        expect(readUnsupportedContentMeta(meta)?.kind).toBe(kind);
+        const meta = markUnsupportedContentMeta(undefined, kind);
+        expect(readUnsupportedContentMeta(meta)).toBe(kind);
     });
 
     it('returns null for undefined/null meta', () => {
@@ -37,21 +32,8 @@ describe('markUnsupportedContentMeta / readUnsupportedContentMeta', () => {
         expect(readUnsupportedContentMeta({ source: 'ui' })).toBeNull();
     });
 
-    it('returns null for a malformed marker value', () => {
-        expect(readUnsupportedContentMeta({ happierUnsupportedContentV1: 'not-an-object' })).toBeNull();
-        expect(readUnsupportedContentMeta({ happierUnsupportedContentV1: { kind: 'not-a-real-kind' } })).toBeNull();
-        expect(readUnsupportedContentMeta({ happierUnsupportedContentV1: {} })).toBeNull();
-    });
-
-    it('ignores a non-string recordType', () => {
-        expect(readUnsupportedContentMeta({
-            happierUnsupportedContentV1: { kind: 'unsupported-agent-output', recordType: 42 },
-        })).toEqual({ kind: 'unsupported-agent-output' });
-    });
-
-    it('ignores an empty-string recordType', () => {
-        expect(readUnsupportedContentMeta({
-            happierUnsupportedContentV1: { kind: 'unsupported-agent-output', recordType: '' },
-        })).toEqual({ kind: 'unsupported-agent-output' });
+    it('returns null for an unknown kind value', () => {
+        expect(readUnsupportedContentMeta({ happierUnsupportedContentV1: 'not-a-real-kind' })).toBeNull();
+        expect(readUnsupportedContentMeta({ happierUnsupportedContentV1: 42 })).toBeNull();
     });
 });

--- a/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.ts
+++ b/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.ts
@@ -13,35 +13,19 @@ const UNSUPPORTED_CONTENT_KINDS = new Set<UnsupportedContentKind>([
     'unsupported-transcript-record',
 ]);
 
-export type UnsupportedContentMetaValue = Readonly<{
-    kind: UnsupportedContentKind;
-    recordType?: string;
-}>;
-
 const UNSUPPORTED_CONTENT_META_KEY = 'happierUnsupportedContentV1';
 
-export function markUnsupportedContentMeta(
-    meta: MessageMeta | undefined,
-    value: UnsupportedContentMetaValue,
-): MessageMeta {
+export function markUnsupportedContentMeta(meta: MessageMeta | undefined, kind: UnsupportedContentKind): MessageMeta {
     return {
         ...(meta ?? {}),
-        [UNSUPPORTED_CONTENT_META_KEY]: {
-            kind: value.kind,
-            ...(value.recordType ? { recordType: value.recordType } : {}),
-        },
+        [UNSUPPORTED_CONTENT_META_KEY]: kind,
     } as MessageMeta;
 }
 
-export function readUnsupportedContentMeta(meta: unknown): UnsupportedContentMetaValue | null {
+export function readUnsupportedContentMeta(meta: unknown): UnsupportedContentKind | null {
     if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return null;
-    const raw = (meta as Record<string, unknown>)[UNSUPPORTED_CONTENT_META_KEY];
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
-    const kind = (raw as Record<string, unknown>).kind;
-    if (typeof kind !== 'string' || !UNSUPPORTED_CONTENT_KINDS.has(kind as UnsupportedContentKind)) return null;
-    const recordType = (raw as Record<string, unknown>).recordType;
-    return {
-        kind: kind as UnsupportedContentKind,
-        ...(typeof recordType === 'string' && recordType.length > 0 ? { recordType } : {}),
-    };
+    const kind = (meta as Record<string, unknown>)[UNSUPPORTED_CONTENT_META_KEY];
+    return typeof kind === 'string' && UNSUPPORTED_CONTENT_KINDS.has(kind as UnsupportedContentKind)
+        ? kind as UnsupportedContentKind
+        : null;
 }

--- a/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.ts
+++ b/apps/ui/sources/sync/domains/messages/unsupportedContentMeta.ts
@@ -1,0 +1,47 @@
+import type { MessageMeta } from './messageMetaTypes';
+
+export type UnsupportedContentKind =
+    | 'unparsed-user-message'
+    | 'unparsed-agent-message'
+    | 'unsupported-agent-output'
+    | 'unsupported-transcript-record';
+
+const UNSUPPORTED_CONTENT_KINDS = new Set<UnsupportedContentKind>([
+    'unparsed-user-message',
+    'unparsed-agent-message',
+    'unsupported-agent-output',
+    'unsupported-transcript-record',
+]);
+
+export type UnsupportedContentMetaValue = Readonly<{
+    kind: UnsupportedContentKind;
+    recordType?: string;
+}>;
+
+const UNSUPPORTED_CONTENT_META_KEY = 'happierUnsupportedContentV1';
+
+export function markUnsupportedContentMeta(
+    meta: MessageMeta | undefined,
+    value: UnsupportedContentMetaValue,
+): MessageMeta {
+    return {
+        ...(meta ?? {}),
+        [UNSUPPORTED_CONTENT_META_KEY]: {
+            kind: value.kind,
+            ...(value.recordType ? { recordType: value.recordType } : {}),
+        },
+    } as MessageMeta;
+}
+
+export function readUnsupportedContentMeta(meta: unknown): UnsupportedContentMetaValue | null {
+    if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return null;
+    const raw = (meta as Record<string, unknown>)[UNSUPPORTED_CONTENT_META_KEY];
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const kind = (raw as Record<string, unknown>).kind;
+    if (typeof kind !== 'string' || !UNSUPPORTED_CONTENT_KINDS.has(kind as UnsupportedContentKind)) return null;
+    const recordType = (raw as Record<string, unknown>).recordType;
+    return {
+        kind: kind as UnsupportedContentKind,
+        ...(typeof recordType === 'string' && recordType.length > 0 ? { recordType } : {}),
+    };
+}

--- a/apps/ui/sources/sync/typesRaw/normalize.ts
+++ b/apps/ui/sources/sync/typesRaw/normalize.ts
@@ -6,6 +6,7 @@ import {
     markSyntheticNoResponseMeta,
     SYNTHETIC_NO_RESPONSE_TEXT,
 } from '../domains/messages/syntheticNoResponseMessageMeta';
+import { markUnsupportedContentMeta } from '../domains/messages/unsupportedContentMeta';
 import { hasSessionMediaRenderItems } from '../domains/sessionMedia/sessionMediaMessageMeta';
 import { rawRecordSchema, type AgentEvent, type RawAgentContent, type RawRecord, type UsageData } from './schemas';
 import { buildUsageDataFromTokenCountMessage } from './tokenCountUsage';
@@ -339,6 +340,7 @@ export function normalizeRawMessage(
             role === 'user'
                 ? '[Unparsed user message]'
                 : '[Unparsed agent message]';
+        const unparsedRecordType = typeof rawContentRecord?.type === 'string' ? rawContentRecord.type : undefined;
         return role === 'user'
             ? {
                 id,
@@ -348,7 +350,10 @@ export function normalizeRawMessage(
                 role: 'user',
                 isSidechain: false,
                 content: { type: 'text', text },
-                meta: rawInputRecord?.meta as MessageMeta | undefined,
+                meta: markUnsupportedContentMeta(rawInputRecord?.meta as MessageMeta | undefined, {
+                    kind: 'unparsed-user-message',
+                    recordType: unparsedRecordType,
+                }),
             }
             : {
                 id,
@@ -358,7 +363,10 @@ export function normalizeRawMessage(
                 role: 'agent',
                 isSidechain: false,
                 content: [{ type: 'text', text, uuid: id, parentUUID: null }],
-                meta: rawInputRecord?.meta as MessageMeta | undefined,
+                meta: markUnsupportedContentMeta(rawInputRecord?.meta as MessageMeta | undefined, {
+                    kind: 'unparsed-agent-message',
+                    recordType: unparsedRecordType,
+                }),
             };
     }
     const raw = parsed.data as RawRecord;
@@ -753,6 +761,10 @@ export function normalizeRawMessage(
                 return filterNormalizedEventRoleOutput(normalized, opts?.messageRole);
             }
             // Any other output payload should be surfaced as an opaque message rather than dropped.
+            const unsupportedOutputRecordType = (() => {
+                const dataType = (raw.content.data as { type?: unknown } | undefined)?.type;
+                return typeof dataType === 'string' ? dataType : undefined;
+            })();
             const normalized = {
                 id,
                 ...(seq !== undefined ? { seq } : {}),
@@ -766,7 +778,10 @@ export function normalizeRawMessage(
                     uuid: id,
                     parentUUID: null,
                 }],
-                meta: raw.meta,
+                meta: markUnsupportedContentMeta(raw.meta, {
+                    kind: 'unsupported-agent-output',
+                    recordType: unsupportedOutputRecordType,
+                }),
             } satisfies NormalizedMessage;
             return filterNormalizedEventRoleOutput(normalized, opts?.messageRole);
         }
@@ -1165,6 +1180,12 @@ export function normalizeRawMessage(
             }
         }
     }
+    const unsupportedRecordType = (() => {
+        const dataType = (raw as any)?.content?.data?.type;
+        if (typeof dataType === 'string') return dataType;
+        const contentType = (raw as any)?.content?.type;
+        return typeof contentType === 'string' ? contentType : undefined;
+    })();
     return {
         id,
         ...(seq !== undefined ? { seq } : {}),
@@ -1178,6 +1199,9 @@ export function normalizeRawMessage(
             uuid: id,
             parentUUID: null,
         }],
-        meta: (raw as any)?.meta,
+        meta: markUnsupportedContentMeta((raw as any)?.meta, {
+            kind: 'unsupported-transcript-record',
+            recordType: unsupportedRecordType,
+        }),
     };
 }

--- a/apps/ui/sources/sync/typesRaw/normalize.ts
+++ b/apps/ui/sources/sync/typesRaw/normalize.ts
@@ -340,7 +340,6 @@ export function normalizeRawMessage(
             role === 'user'
                 ? '[Unparsed user message]'
                 : '[Unparsed agent message]';
-        const unparsedRecordType = typeof rawContentRecord?.type === 'string' ? rawContentRecord.type : undefined;
         return role === 'user'
             ? {
                 id,
@@ -350,10 +349,7 @@ export function normalizeRawMessage(
                 role: 'user',
                 isSidechain: false,
                 content: { type: 'text', text },
-                meta: markUnsupportedContentMeta(rawInputRecord?.meta as MessageMeta | undefined, {
-                    kind: 'unparsed-user-message',
-                    recordType: unparsedRecordType,
-                }),
+                meta: markUnsupportedContentMeta(rawInputRecord?.meta as MessageMeta | undefined, 'unparsed-user-message'),
             }
             : {
                 id,
@@ -363,10 +359,7 @@ export function normalizeRawMessage(
                 role: 'agent',
                 isSidechain: false,
                 content: [{ type: 'text', text, uuid: id, parentUUID: null }],
-                meta: markUnsupportedContentMeta(rawInputRecord?.meta as MessageMeta | undefined, {
-                    kind: 'unparsed-agent-message',
-                    recordType: unparsedRecordType,
-                }),
+                meta: markUnsupportedContentMeta(rawInputRecord?.meta as MessageMeta | undefined, 'unparsed-agent-message'),
             };
     }
     const raw = parsed.data as RawRecord;
@@ -761,10 +754,6 @@ export function normalizeRawMessage(
                 return filterNormalizedEventRoleOutput(normalized, opts?.messageRole);
             }
             // Any other output payload should be surfaced as an opaque message rather than dropped.
-            const unsupportedOutputRecordType = (() => {
-                const dataType = (raw.content.data as { type?: unknown } | undefined)?.type;
-                return typeof dataType === 'string' ? dataType : undefined;
-            })();
             const normalized = {
                 id,
                 ...(seq !== undefined ? { seq } : {}),
@@ -778,10 +767,7 @@ export function normalizeRawMessage(
                     uuid: id,
                     parentUUID: null,
                 }],
-                meta: markUnsupportedContentMeta(raw.meta, {
-                    kind: 'unsupported-agent-output',
-                    recordType: unsupportedOutputRecordType,
-                }),
+                meta: markUnsupportedContentMeta(raw.meta, 'unsupported-agent-output'),
             } satisfies NormalizedMessage;
             return filterNormalizedEventRoleOutput(normalized, opts?.messageRole);
         }
@@ -1180,12 +1166,6 @@ export function normalizeRawMessage(
             }
         }
     }
-    const unsupportedRecordType = (() => {
-        const dataType = (raw as any)?.content?.data?.type;
-        if (typeof dataType === 'string') return dataType;
-        const contentType = (raw as any)?.content?.type;
-        return typeof contentType === 'string' ? contentType : undefined;
-    })();
     return {
         id,
         ...(seq !== undefined ? { seq } : {}),
@@ -1199,9 +1179,6 @@ export function normalizeRawMessage(
             uuid: id,
             parentUUID: null,
         }],
-        meta: markUnsupportedContentMeta((raw as any)?.meta, {
-            kind: 'unsupported-transcript-record',
-            recordType: unsupportedRecordType,
-        }),
+        meta: markUnsupportedContentMeta((raw as any)?.meta, 'unsupported-transcript-record'),
     };
 }

--- a/apps/ui/sources/sync/typesRaw/normalize.unsupportedContentMeta.test.ts
+++ b/apps/ui/sources/sync/typesRaw/normalize.unsupportedContentMeta.test.ts
@@ -5,7 +5,7 @@ import { readUnsupportedContentMeta } from '../domains/messages/unsupportedConte
 
 describe('normalizeRawMessage unsupported-content meta marking', () => {
     it('marks a Zod parse failure for a user record as unparsed-user-message', () => {
-        const raw: any = {
+        const raw = {
             role: 'user',
             // `content.type` outside the known 'output' | 'event' | 'codex' | 'acp' union fails schema validation.
             content: { type: 'totally-unknown-content-type' },
@@ -19,7 +19,7 @@ describe('normalizeRawMessage unsupported-content meta marking', () => {
     });
 
     it('marks a Zod parse failure for an agent record as unparsed-agent-message', () => {
-        const raw: any = {
+        const raw = {
             role: 'agent',
             content: { type: 'totally-unknown-content-type' },
         };
@@ -32,7 +32,7 @@ describe('normalizeRawMessage unsupported-content meta marking', () => {
     });
 
     it('marks an unrecognized output payload as unsupported-agent-output', () => {
-        const raw: any = {
+        const raw = {
             role: 'agent',
             content: {
                 type: 'output',
@@ -48,7 +48,7 @@ describe('normalizeRawMessage unsupported-content meta marking', () => {
     });
 
     it('marks an unrecognized ACP data payload as unsupported-transcript-record', () => {
-        const raw: any = {
+        const raw = {
             role: 'agent',
             content: {
                 type: 'acp',

--- a/apps/ui/sources/sync/typesRaw/normalize.unsupportedContentMeta.test.ts
+++ b/apps/ui/sources/sync/typesRaw/normalize.unsupportedContentMeta.test.ts
@@ -15,7 +15,7 @@ describe('normalizeRawMessage unsupported-content meta marking', () => {
         expect(normalized).not.toBeNull();
         if (!normalized) return;
         expect(normalized.role).toBe('user');
-        expect(readUnsupportedContentMeta(normalized.meta)?.kind).toBe('unparsed-user-message');
+        expect(readUnsupportedContentMeta(normalized.meta)).toBe('unparsed-user-message');
     });
 
     it('marks a Zod parse failure for an agent record as unparsed-agent-message', () => {
@@ -28,10 +28,10 @@ describe('normalizeRawMessage unsupported-content meta marking', () => {
         expect(normalized).not.toBeNull();
         if (!normalized) return;
         expect(normalized.role).toBe('agent');
-        expect(readUnsupportedContentMeta(normalized.meta)?.kind).toBe('unparsed-agent-message');
+        expect(readUnsupportedContentMeta(normalized.meta)).toBe('unparsed-agent-message');
     });
 
-    it('marks an unrecognized output payload as unsupported-agent-output, carrying the raw data type', () => {
+    it('marks an unrecognized output payload as unsupported-agent-output', () => {
         const raw: any = {
             role: 'agent',
             content: {
@@ -44,13 +44,10 @@ describe('normalizeRawMessage unsupported-content meta marking', () => {
         expect(normalized).not.toBeNull();
         if (!normalized) return;
         expect(normalized.role).toBe('agent');
-        expect(readUnsupportedContentMeta(normalized.meta)).toEqual({
-            kind: 'unsupported-agent-output',
-            recordType: 'some_future_output_type',
-        });
+        expect(readUnsupportedContentMeta(normalized.meta)).toBe('unsupported-agent-output');
     });
 
-    it('marks an unrecognized ACP data payload as unsupported-transcript-record, carrying the raw data type', () => {
+    it('marks an unrecognized ACP data payload as unsupported-transcript-record', () => {
         const raw: any = {
             role: 'agent',
             content: {
@@ -64,9 +61,6 @@ describe('normalizeRawMessage unsupported-content meta marking', () => {
         expect(normalized).not.toBeNull();
         if (!normalized) return;
         expect(normalized.role).toBe('agent');
-        expect(readUnsupportedContentMeta(normalized.meta)).toEqual({
-            kind: 'unsupported-transcript-record',
-            recordType: 'some_future_acp_type',
-        });
+        expect(readUnsupportedContentMeta(normalized.meta)).toBe('unsupported-transcript-record');
     });
 });

--- a/apps/ui/sources/sync/typesRaw/normalize.unsupportedContentMeta.test.ts
+++ b/apps/ui/sources/sync/typesRaw/normalize.unsupportedContentMeta.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeRawMessage } from './normalize';
+import { readUnsupportedContentMeta } from '../domains/messages/unsupportedContentMeta';
+
+describe('normalizeRawMessage unsupported-content meta marking', () => {
+    it('marks a Zod parse failure for a user record as unparsed-user-message', () => {
+        const raw: any = {
+            role: 'user',
+            // `content.type` outside the known 'output' | 'event' | 'codex' | 'acp' union fails schema validation.
+            content: { type: 'totally-unknown-content-type' },
+        };
+
+        const normalized = normalizeRawMessage('msg-1', null, 1000, raw);
+        expect(normalized).not.toBeNull();
+        if (!normalized) return;
+        expect(normalized.role).toBe('user');
+        expect(readUnsupportedContentMeta(normalized.meta)?.kind).toBe('unparsed-user-message');
+    });
+
+    it('marks a Zod parse failure for an agent record as unparsed-agent-message', () => {
+        const raw: any = {
+            role: 'agent',
+            content: { type: 'totally-unknown-content-type' },
+        };
+
+        const normalized = normalizeRawMessage('msg-2', null, 1000, raw);
+        expect(normalized).not.toBeNull();
+        if (!normalized) return;
+        expect(normalized.role).toBe('agent');
+        expect(readUnsupportedContentMeta(normalized.meta)?.kind).toBe('unparsed-agent-message');
+    });
+
+    it('marks an unrecognized output payload as unsupported-agent-output, carrying the raw data type', () => {
+        const raw: any = {
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: { type: 'some_future_output_type' },
+            },
+        };
+
+        const normalized = normalizeRawMessage('msg-3', null, 1000, raw);
+        expect(normalized).not.toBeNull();
+        if (!normalized) return;
+        expect(normalized.role).toBe('agent');
+        expect(readUnsupportedContentMeta(normalized.meta)).toEqual({
+            kind: 'unsupported-agent-output',
+            recordType: 'some_future_output_type',
+        });
+    });
+
+    it('marks an unrecognized ACP data payload as unsupported-transcript-record, carrying the raw data type', () => {
+        const raw: any = {
+            role: 'agent',
+            content: {
+                type: 'acp',
+                provider: 'some-provider',
+                data: { type: 'some_future_acp_type' },
+            },
+        };
+
+        const normalized = normalizeRawMessage('msg-4', null, 1000, raw);
+        expect(normalized).not.toBeNull();
+        if (!normalized) return;
+        expect(normalized.role).toBe('agent');
+        expect(readUnsupportedContentMeta(normalized.meta)).toEqual({
+            kind: 'unsupported-transcript-record',
+            recordType: 'some_future_acp_type',
+        });
+    });
+});

--- a/apps/ui/sources/text/i18n.integrity.test.ts
+++ b/apps/ui/sources/text/i18n.integrity.test.ts
@@ -159,8 +159,6 @@ const FUNCTION_SAMPLE_ARGS_BY_KEY = new Map<string, unknown[]>([
     ['transcript.selection.selectedCount', [{ count: 1 }, { count: 2 }]],
     ['transcript.selection.copyA11y', [{ count: 1 }, { count: 2 }]],
     ['transcript.selection.sendA11y', [{ count: 1 }, { count: 2 }]],
-    ['transcript.unsupportedContent.unsupportedAgentOutput', [{}, { recordType: 'foo' }]],
-    ['transcript.unsupportedContent.unsupportedTranscriptRecord', [{}, { recordType: 'foo' }]],
     ['connectedServices.detail.groups.memberQuotaExhaustedUntil', [{ time: '12:00' }]],
     ['connectedServices.detail.groups.memberRateLimitedUntil', [{ time: '12:00' }]],
     ['connectedServices.detail.groups.memberCapacityLimitedUntil', [{ time: '12:00' }]],

--- a/apps/ui/sources/text/i18n.integrity.test.ts
+++ b/apps/ui/sources/text/i18n.integrity.test.ts
@@ -159,6 +159,8 @@ const FUNCTION_SAMPLE_ARGS_BY_KEY = new Map<string, unknown[]>([
     ['transcript.selection.selectedCount', [{ count: 1 }, { count: 2 }]],
     ['transcript.selection.copyA11y', [{ count: 1 }, { count: 2 }]],
     ['transcript.selection.sendA11y', [{ count: 1 }, { count: 2 }]],
+    ['transcript.unsupportedContent.unsupportedAgentOutput', [{}, { recordType: 'foo' }]],
+    ['transcript.unsupportedContent.unsupportedTranscriptRecord', [{}, { recordType: 'foo' }]],
     ['connectedServices.detail.groups.memberQuotaExhaustedUntil', [{ time: '12:00' }]],
     ['connectedServices.detail.groups.memberRateLimitedUntil', [{ time: '12:00' }]],
     ['connectedServices.detail.groups.memberCapacityLimitedUntil', [{ time: '12:00' }]],

--- a/apps/ui/sources/text/translations/ca.ts
+++ b/apps/ui/sources/text/translations/ca.ts
@@ -678,6 +678,14 @@ export const ca: TranslationStructure = {
         progress: {
             catchingUp: 'Posant-se al dia…',
         },
+        unsupportedContent: {
+            unparsedUserMessage: 'Missatge no analitzat',
+            unparsedAgentMessage: 'Missatge no analitzat',
+            unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+                recordType ? `Sortida no compatible (${recordType})` : 'Sortida no compatible',
+            unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+                recordType ? `Registre no compatible (${recordType})` : 'Registre no compatible',
+        },
     },
 
     inbox: {

--- a/apps/ui/sources/text/translations/ca.ts
+++ b/apps/ui/sources/text/translations/ca.ts
@@ -681,10 +681,8 @@ export const ca: TranslationStructure = {
         unsupportedContent: {
             unparsedUserMessage: 'Missatge no analitzat',
             unparsedAgentMessage: 'Missatge no analitzat',
-            unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-                recordType ? `Sortida no compatible (${recordType})` : 'Sortida no compatible',
-            unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-                recordType ? `Registre no compatible (${recordType})` : 'Registre no compatible',
+            unsupportedAgentOutput: 'Sortida no compatible',
+            unsupportedTranscriptRecord: 'Registre no compatible',
         },
     },
 

--- a/apps/ui/sources/text/translations/ca.ts
+++ b/apps/ui/sources/text/translations/ca.ts
@@ -679,8 +679,8 @@ export const ca: TranslationStructure = {
             catchingUp: 'Posant-se al dia…',
         },
         unsupportedContent: {
-            unparsedUserMessage: 'Missatge no analitzat',
-            unparsedAgentMessage: 'Missatge no analitzat',
+            unparsedUserMessage: 'Missatge d\'usuari no analitzat',
+            unparsedAgentMessage: 'Missatge d\'assistent no analitzat',
             unsupportedAgentOutput: 'Sortida no compatible',
             unsupportedTranscriptRecord: 'Registre no compatible',
         },

--- a/apps/ui/sources/text/translations/en.ts
+++ b/apps/ui/sources/text/translations/en.ts
@@ -511,6 +511,14 @@ export const en = {
         progress: {
             catchingUp: 'Catching up…',
         },
+        unsupportedContent: {
+            unparsedUserMessage: 'Unparsed message',
+            unparsedAgentMessage: 'Unparsed message',
+            unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+                recordType ? `Unsupported output (${recordType})` : 'Unsupported output',
+            unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+                recordType ? `Unsupported record (${recordType})` : 'Unsupported record',
+        },
     },
 
     inbox: {

--- a/apps/ui/sources/text/translations/en.ts
+++ b/apps/ui/sources/text/translations/en.ts
@@ -514,10 +514,8 @@ export const en = {
         unsupportedContent: {
             unparsedUserMessage: 'Unparsed message',
             unparsedAgentMessage: 'Unparsed message',
-            unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-                recordType ? `Unsupported output (${recordType})` : 'Unsupported output',
-            unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-                recordType ? `Unsupported record (${recordType})` : 'Unsupported record',
+            unsupportedAgentOutput: 'Unsupported output',
+            unsupportedTranscriptRecord: 'Unsupported record',
         },
     },
 

--- a/apps/ui/sources/text/translations/en.ts
+++ b/apps/ui/sources/text/translations/en.ts
@@ -512,8 +512,8 @@ export const en = {
             catchingUp: 'Catching up…',
         },
         unsupportedContent: {
-            unparsedUserMessage: 'Unparsed message',
-            unparsedAgentMessage: 'Unparsed message',
+            unparsedUserMessage: 'Unparsed user message',
+            unparsedAgentMessage: 'Unparsed agent message',
             unsupportedAgentOutput: 'Unsupported output',
             unsupportedTranscriptRecord: 'Unsupported record',
         },

--- a/apps/ui/sources/text/translations/es.ts
+++ b/apps/ui/sources/text/translations/es.ts
@@ -727,10 +727,8 @@ export const es: TranslationStructure = {
     unsupportedContent: {
       unparsedUserMessage: 'Mensaje no analizado',
       unparsedAgentMessage: 'Mensaje no analizado',
-      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Salida no compatible (${recordType})` : 'Salida no compatible',
-      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Registro no compatible (${recordType})` : 'Registro no compatible',
+      unsupportedAgentOutput: 'Salida no compatible',
+      unsupportedTranscriptRecord: 'Registro no compatible',
     },
 
   },

--- a/apps/ui/sources/text/translations/es.ts
+++ b/apps/ui/sources/text/translations/es.ts
@@ -724,6 +724,15 @@ export const es: TranslationStructure = {
 
     },
 
+    unsupportedContent: {
+      unparsedUserMessage: 'Mensaje no analizado',
+      unparsedAgentMessage: 'Mensaje no analizado',
+      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Salida no compatible (${recordType})` : 'Salida no compatible',
+      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Registro no compatible (${recordType})` : 'Registro no compatible',
+    },
+
   },
 
 

--- a/apps/ui/sources/text/translations/es.ts
+++ b/apps/ui/sources/text/translations/es.ts
@@ -725,8 +725,8 @@ export const es: TranslationStructure = {
     },
 
     unsupportedContent: {
-      unparsedUserMessage: 'Mensaje no analizado',
-      unparsedAgentMessage: 'Mensaje no analizado',
+      unparsedUserMessage: 'Mensaje de usuario no analizado',
+      unparsedAgentMessage: 'Mensaje de asistente no analizado',
       unsupportedAgentOutput: 'Salida no compatible',
       unsupportedTranscriptRecord: 'Registro no compatible',
     },

--- a/apps/ui/sources/text/translations/it.ts
+++ b/apps/ui/sources/text/translations/it.ts
@@ -723,8 +723,8 @@ export const it: TranslationStructure = {
     },
 
     unsupportedContent: {
-      unparsedUserMessage: 'Messaggio non analizzato',
-      unparsedAgentMessage: 'Messaggio non analizzato',
+      unparsedUserMessage: 'Messaggio utente non analizzato',
+      unparsedAgentMessage: 'Messaggio assistente non analizzato',
       unsupportedAgentOutput: 'Output non supportato',
       unsupportedTranscriptRecord: 'Record non supportato',
     },

--- a/apps/ui/sources/text/translations/it.ts
+++ b/apps/ui/sources/text/translations/it.ts
@@ -722,6 +722,15 @@ export const it: TranslationStructure = {
 
     },
 
+    unsupportedContent: {
+      unparsedUserMessage: 'Messaggio non analizzato',
+      unparsedAgentMessage: 'Messaggio non analizzato',
+      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Output non supportato (${recordType})` : 'Output non supportato',
+      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Record non supportato (${recordType})` : 'Record non supportato',
+    },
+
   },
 
 

--- a/apps/ui/sources/text/translations/it.ts
+++ b/apps/ui/sources/text/translations/it.ts
@@ -725,10 +725,8 @@ export const it: TranslationStructure = {
     unsupportedContent: {
       unparsedUserMessage: 'Messaggio non analizzato',
       unparsedAgentMessage: 'Messaggio non analizzato',
-      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Output non supportato (${recordType})` : 'Output non supportato',
-      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Record non supportato (${recordType})` : 'Record non supportato',
+      unsupportedAgentOutput: 'Output non supportato',
+      unsupportedTranscriptRecord: 'Record non supportato',
     },
 
   },

--- a/apps/ui/sources/text/translations/ja.ts
+++ b/apps/ui/sources/text/translations/ja.ts
@@ -707,6 +707,15 @@ export const ja: TranslationStructure = {
 
     },
 
+    unsupportedContent: {
+      unparsedUserMessage: '解析できないメッセージ',
+      unparsedAgentMessage: '解析できないメッセージ',
+      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+        recordType ? `サポートされていない出力 (${recordType})` : 'サポートされていない出力',
+      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+        recordType ? `サポートされていない記録 (${recordType})` : 'サポートされていない記録',
+    },
+
   },
 
 

--- a/apps/ui/sources/text/translations/ja.ts
+++ b/apps/ui/sources/text/translations/ja.ts
@@ -708,8 +708,8 @@ export const ja: TranslationStructure = {
     },
 
     unsupportedContent: {
-      unparsedUserMessage: '解析できないメッセージ',
-      unparsedAgentMessage: '解析できないメッセージ',
+      unparsedUserMessage: '解析できないユーザーメッセージ',
+      unparsedAgentMessage: '解析できないアシスタントメッセージ',
       unsupportedAgentOutput: 'サポートされていない出力',
       unsupportedTranscriptRecord: 'サポートされていない記録',
     },

--- a/apps/ui/sources/text/translations/ja.ts
+++ b/apps/ui/sources/text/translations/ja.ts
@@ -710,10 +710,8 @@ export const ja: TranslationStructure = {
     unsupportedContent: {
       unparsedUserMessage: '解析できないメッセージ',
       unparsedAgentMessage: '解析できないメッセージ',
-      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-        recordType ? `サポートされていない出力 (${recordType})` : 'サポートされていない出力',
-      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-        recordType ? `サポートされていない記録 (${recordType})` : 'サポートされていない記録',
+      unsupportedAgentOutput: 'サポートされていない出力',
+      unsupportedTranscriptRecord: 'サポートされていない記録',
     },
 
   },

--- a/apps/ui/sources/text/translations/pl.ts
+++ b/apps/ui/sources/text/translations/pl.ts
@@ -738,10 +738,8 @@ export const pl: TranslationStructure = {
     unsupportedContent: {
       unparsedUserMessage: 'Nieprzeanalizowana wiadomość',
       unparsedAgentMessage: 'Nieprzeanalizowana wiadomość',
-      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Nieobsługiwane wyjście (${recordType})` : 'Nieobsługiwane wyjście',
-      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Nieobsługiwany rekord (${recordType})` : 'Nieobsługiwany rekord',
+      unsupportedAgentOutput: 'Nieobsługiwane wyjście',
+      unsupportedTranscriptRecord: 'Nieobsługiwany rekord',
     },
 
   },

--- a/apps/ui/sources/text/translations/pl.ts
+++ b/apps/ui/sources/text/translations/pl.ts
@@ -735,6 +735,15 @@ export const pl: TranslationStructure = {
 
     },
 
+    unsupportedContent: {
+      unparsedUserMessage: 'Nieprzeanalizowana wiadomość',
+      unparsedAgentMessage: 'Nieprzeanalizowana wiadomość',
+      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Nieobsługiwane wyjście (${recordType})` : 'Nieobsługiwane wyjście',
+      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Nieobsługiwany rekord (${recordType})` : 'Nieobsługiwany rekord',
+    },
+
   },
 
 

--- a/apps/ui/sources/text/translations/pl.ts
+++ b/apps/ui/sources/text/translations/pl.ts
@@ -736,8 +736,8 @@ export const pl: TranslationStructure = {
     },
 
     unsupportedContent: {
-      unparsedUserMessage: 'Nieprzeanalizowana wiadomość',
-      unparsedAgentMessage: 'Nieprzeanalizowana wiadomość',
+      unparsedUserMessage: 'Nieprzeanalizowana wiadomość użytkownika',
+      unparsedAgentMessage: 'Nieprzeanalizowana wiadomość asystenta',
       unsupportedAgentOutput: 'Nieobsługiwane wyjście',
       unsupportedTranscriptRecord: 'Nieobsługiwany rekord',
     },

--- a/apps/ui/sources/text/translations/pt.ts
+++ b/apps/ui/sources/text/translations/pt.ts
@@ -774,8 +774,8 @@ export const pt: TranslationStructure = {
     },
 
     unsupportedContent: {
-      unparsedUserMessage: 'Mensagem não analisada',
-      unparsedAgentMessage: 'Mensagem não analisada',
+      unparsedUserMessage: 'Mensagem do usuário não analisada',
+      unparsedAgentMessage: 'Mensagem do assistente não analisada',
       unsupportedAgentOutput: 'Saída não suportada',
       unsupportedTranscriptRecord: 'Registro não suportado',
     },

--- a/apps/ui/sources/text/translations/pt.ts
+++ b/apps/ui/sources/text/translations/pt.ts
@@ -776,10 +776,8 @@ export const pt: TranslationStructure = {
     unsupportedContent: {
       unparsedUserMessage: 'Mensagem não analisada',
       unparsedAgentMessage: 'Mensagem não analisada',
-      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Saída não suportada (${recordType})` : 'Saída não suportada',
-      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Registro não suportado (${recordType})` : 'Registro não suportado',
+      unsupportedAgentOutput: 'Saída não suportada',
+      unsupportedTranscriptRecord: 'Registro não suportado',
     },
 
   },

--- a/apps/ui/sources/text/translations/pt.ts
+++ b/apps/ui/sources/text/translations/pt.ts
@@ -773,6 +773,15 @@ export const pt: TranslationStructure = {
 
     },
 
+    unsupportedContent: {
+      unparsedUserMessage: 'Mensagem não analisada',
+      unparsedAgentMessage: 'Mensagem não analisada',
+      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Saída não suportada (${recordType})` : 'Saída não suportada',
+      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Registro não suportado (${recordType})` : 'Registro não suportado',
+    },
+
   },
 
 

--- a/apps/ui/sources/text/translations/ru.ts
+++ b/apps/ui/sources/text/translations/ru.ts
@@ -740,8 +740,8 @@ export const ru: TranslationStructure = {
     },
 
     unsupportedContent: {
-      unparsedUserMessage: 'Нераспознанное сообщение',
-      unparsedAgentMessage: 'Нераспознанное сообщение',
+      unparsedUserMessage: 'Нераспознанное сообщение пользователя',
+      unparsedAgentMessage: 'Нераспознанное сообщение ассистента',
       unsupportedAgentOutput: 'Неподдерживаемый вывод',
       unsupportedTranscriptRecord: 'Неподдерживаемая запись',
     },

--- a/apps/ui/sources/text/translations/ru.ts
+++ b/apps/ui/sources/text/translations/ru.ts
@@ -739,6 +739,15 @@ export const ru: TranslationStructure = {
 
     },
 
+    unsupportedContent: {
+      unparsedUserMessage: 'Нераспознанное сообщение',
+      unparsedAgentMessage: 'Нераспознанное сообщение',
+      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Неподдерживаемый вывод (${recordType})` : 'Неподдерживаемый вывод',
+      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+        recordType ? `Неподдерживаемая запись (${recordType})` : 'Неподдерживаемая запись',
+    },
+
   },
 
 

--- a/apps/ui/sources/text/translations/ru.ts
+++ b/apps/ui/sources/text/translations/ru.ts
@@ -742,10 +742,8 @@ export const ru: TranslationStructure = {
     unsupportedContent: {
       unparsedUserMessage: 'Нераспознанное сообщение',
       unparsedAgentMessage: 'Нераспознанное сообщение',
-      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Неподдерживаемый вывод (${recordType})` : 'Неподдерживаемый вывод',
-      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-        recordType ? `Неподдерживаемая запись (${recordType})` : 'Неподдерживаемая запись',
+      unsupportedAgentOutput: 'Неподдерживаемый вывод',
+      unsupportedTranscriptRecord: 'Неподдерживаемая запись',
     },
 
   },

--- a/apps/ui/sources/text/translations/zh-Hans.ts
+++ b/apps/ui/sources/text/translations/zh-Hans.ts
@@ -725,10 +725,8 @@ export const zhHans: TranslationStructure = {
     unsupportedContent: {
       unparsedUserMessage: '无法解析的消息',
       unparsedAgentMessage: '无法解析的消息',
-      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-        recordType ? `不支持的输出 (${recordType})` : '不支持的输出',
-      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-        recordType ? `不支持的记录 (${recordType})` : '不支持的记录',
+      unsupportedAgentOutput: '不支持的输出',
+      unsupportedTranscriptRecord: '不支持的记录',
     },
 
   },

--- a/apps/ui/sources/text/translations/zh-Hans.ts
+++ b/apps/ui/sources/text/translations/zh-Hans.ts
@@ -723,8 +723,8 @@ export const zhHans: TranslationStructure = {
     },
 
     unsupportedContent: {
-      unparsedUserMessage: '无法解析的消息',
-      unparsedAgentMessage: '无法解析的消息',
+      unparsedUserMessage: '无法解析的用户消息',
+      unparsedAgentMessage: '无法解析的助手消息',
       unsupportedAgentOutput: '不支持的输出',
       unsupportedTranscriptRecord: '不支持的记录',
     },

--- a/apps/ui/sources/text/translations/zh-Hans.ts
+++ b/apps/ui/sources/text/translations/zh-Hans.ts
@@ -722,6 +722,15 @@ export const zhHans: TranslationStructure = {
 
     },
 
+    unsupportedContent: {
+      unparsedUserMessage: '无法解析的消息',
+      unparsedAgentMessage: '无法解析的消息',
+      unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+        recordType ? `不支持的输出 (${recordType})` : '不支持的输出',
+      unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+        recordType ? `不支持的记录 (${recordType})` : '不支持的记录',
+    },
+
   },
 
 

--- a/apps/ui/sources/text/translations/zh-Hant.ts
+++ b/apps/ui/sources/text/translations/zh-Hant.ts
@@ -821,10 +821,8 @@ const zhHantOverrides: DeepPartial<TranslationStructure> = {
       unsupportedContent: {
         unparsedUserMessage: '無法解析的訊息',
         unparsedAgentMessage: '無法解析的訊息',
-        unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
-          recordType ? `不支援的輸出 (${recordType})` : '不支援的輸出',
-        unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
-          recordType ? `不支援的記錄 (${recordType})` : '不支援的記錄',
+        unsupportedAgentOutput: '不支援的輸出',
+        unsupportedTranscriptRecord: '不支援的記錄',
       },
 
     },

--- a/apps/ui/sources/text/translations/zh-Hant.ts
+++ b/apps/ui/sources/text/translations/zh-Hant.ts
@@ -818,6 +818,15 @@ const zhHantOverrides: DeepPartial<TranslationStructure> = {
 
       },
 
+      unsupportedContent: {
+        unparsedUserMessage: '無法解析的訊息',
+        unparsedAgentMessage: '無法解析的訊息',
+        unsupportedAgentOutput: ({ recordType }: { recordType?: string }) =>
+          recordType ? `不支援的輸出 (${recordType})` : '不支援的輸出',
+        unsupportedTranscriptRecord: ({ recordType }: { recordType?: string }) =>
+          recordType ? `不支援的記錄 (${recordType})` : '不支援的記錄',
+      },
+
     },
 
 

--- a/apps/ui/sources/text/translations/zh-Hant.ts
+++ b/apps/ui/sources/text/translations/zh-Hant.ts
@@ -819,8 +819,8 @@ const zhHantOverrides: DeepPartial<TranslationStructure> = {
       },
 
       unsupportedContent: {
-        unparsedUserMessage: '無法解析的訊息',
-        unparsedAgentMessage: '無法解析的訊息',
+        unparsedUserMessage: '無法解析的使用者訊息',
+        unparsedAgentMessage: '無法解析的助手訊息',
         unsupportedAgentOutput: '不支援的輸出',
         unsupportedTranscriptRecord: '不支援的記錄',
       },


### PR DESCRIPTION
## Summary

Fixes #208.

`apps/ui/sources/sync/typesRaw/normalize.ts` hardcoded four English placeholder strings directly into transcript message content instead of going through `t(...)`:

- `[Unparsed user message]`
- `[Unparsed agent message]`
- `[Unsupported agent output]`
- `[Unsupported transcript record]`

This violates the repo's own rule (`AGENTS.md` / `apps/ui/CLAUDE.md`): all user-visible strings must use `t(...)` and exist in every locale. `normalize.ts` is a pure data-layer file with zero `t()`/React imports (it's imported by Node-context tests and must stay that way), so the fix can't just call `t()` inline — this is also what a CodeRabbit review on #206 flagged and recommended against doing directly in the normalizer.

## Approach

Follows the pattern already established in this codebase for exactly this kind of problem (`syntheticNoResponseMessageMeta.ts`): the data layer stamps a structured marker on `meta`, and the render boundary resolves the localized label.

- New `apps/ui/sources/sync/domains/messages/unsupportedContentMeta.ts` — a Node-safe module exporting `markUnsupportedContentMeta`/`readUnsupportedContentMeta` for a reserved `happierUnsupportedContentV1` meta key, whose value is one of the four `UnsupportedContentKind` strings above.
- `normalize.ts` now calls `markUnsupportedContentMeta(...)` at all four sites, in addition to the existing literal text (kept as a safe last-resort fallback if a caller bypasses the renderer — no behavior change, no snapshot churn).
- `MessageView.tsx` (`UserTextBlock` / `AgentTextBlock`) reads the marker via `readUnsupportedContentMeta(props.message.meta)` (same `useMemo`-off-`meta` pattern already used for `parseHappierMetaEnvelope`/`parseSessionMediaMessageMeta` in the same functions) and renders `t('transcript.unsupportedContent.<key>')` instead of the raw fallback text when present.
- New `transcript.unsupportedContent` translation namespace added to **all 10 locales** (sibling of the existing `transcript.selection`/`transcript.progress`), as plain strings.

No change to `NormalizedAgentContent`'s closed content-type union, no change to any other branch.

**Revision note:** an earlier version of this PR also carried the raw unrecognized record type (e.g. `Unsupported output (some_future_type)`) alongside the `kind` marker, matching a suggestion from the CodeRabbit review that originally flagged this. I cut it after a self-review pass — it wasn't needed to fix #208 (which only asked for localization) and it meaningfully bloated the diff (an extra helper, four extraction call sites, function-valued translations in all 10 locales). Happy to add it back as a small follow-up if a maintainer would rather have the diagnostic detail.

## Test plan

- New unit tests: `unsupportedContentMeta.test.ts` (mark/read round-trip + malformed-input handling), `normalize.unsupportedContentMeta.test.ts` (all 4 fallback sites produce the correct marker from real schema-valid-but-unrecognized payloads), `MessageView.unsupportedContent.test.tsx` (renders the correct localized key for each marker kind via `renderScreen`, plus a control case proving normal messages are unaffected).
- `tsc -p tsconfig.json --noEmit` (needed `NODE_OPTIONS=--max-old-space-size=8192`; the default heap OOMs on this repo regardless of this change) — passes with 0 errors across the whole UI workspace, which also verifies all 10 locale files satisfy `TranslationStructure` (a locale missing/mis-shaping a key is a compile error, not a lint warning).
- `yarn --cwd apps/ui vitest run sources/text/i18n.integrity.test.ts` — this test currently fails on `dev` before this change too (278 pre-existing untranslated strings, all under `connectedServices.*`, unrelated to this PR); confirmed via `git stash` comparison that this PR introduces **zero** new failures against that baseline, and a scratch check (not included) confirmed all 4 new keys are present, correctly typed, and genuinely distinct from English in every locale.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Localize hardcoded placeholder strings for unsupported/unparsed transcript messages
> - Introduces `UnsupportedContentKind` and `happierUnsupportedContentV1` meta marker in [`unsupportedContentMeta.ts`](https://github.com/happier-dev/happier/pull/209/files#diff-65dc3cf4cc24bc05344d34c20a22f61bd34e3f09bf1724973e704e9857117af2) to tag unparsed or unsupported messages during normalization.
> - Updates [`normalize.ts`](https://github.com/happier-dev/happier/pull/209/files#diff-626c7794b707c42df537691a399a697c07057ae5f4f0df65dfc69f2bd303563b) to mark messages with the appropriate kind (`unparsed-user-message`, `unparsed-agent-message`, `unsupported-agent-output`, `unsupported-transcript-record`) on Zod parse failures or unrecognized output types.
> - `MessageView` user and agent text blocks and the selection toolbar now read the meta marker and render a localized label via `resolveUnsupportedContentLabel` instead of raw fallback text.
> - Adds `transcript.unsupportedContent.*` translation keys across all 10 supported locales.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da214eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Transcript messages that can’t be parsed now display clear, localized unsupported-content labels instead of confusing or blank text.
  - Unsupported scenarios (unparsed user/agent messages, unsupported agent output, unsupported transcript records) are detected and handled consistently across the transcript.
  - Select/clipboard preview text now matches the displayed unsupported-content label.

- **Localization**
  - Added translated strings for unsupported transcript content labels across supported languages.

- **Tests**
  - Added/expanded test coverage for unsupported-content metadata tagging, rendering behavior, and selection/copy preview output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->