### PR TITLE
feat: per-profile coding prompt behavior override

### DIFF
--- a/apps/cli/src/agent/prompting/coding/resolveEffectiveCodingPrompt.test.ts
+++ b/apps/cli/src/agent/prompting/coding/resolveEffectiveCodingPrompt.test.ts
@@ -262,4 +262,94 @@ describe('resolveEffectiveCodingPromptText', () => {
     expect(out).not.toContain('# Plan mode with options');
     expect(out).not.toContain('<options>');
   });
+
+  it('applies a profile codingPromptBehaviorV1 override that disables responseOptions', async () => {
+    const credentials = createCredentials();
+
+    const settings = {
+      profiles: [
+        {
+          id: 'profile-no-options',
+          name: 'Profile (no options)',
+          codingPromptBehaviorV1: {
+            v: 1,
+            responseOptions: 'disabled',
+          },
+        },
+      ],
+    };
+
+    const out = await resolveEffectiveCodingPromptText({
+      credentials,
+      settings,
+      profileId: 'profile-no-options',
+      executionRunsFeatureEnabled: false,
+      providerId: 'claude',
+      fetchPromptArtifactRecord: async () => null,
+    });
+
+    // Override wins: responseOptions disabled => options block omitted.
+    expect(out).not.toContain('# Options');
+    expect(out).not.toContain('<options>');
+    // The other knob still inherits the global default (ongoing title updates).
+    expect(out).toContain('# Session title');
+  });
+
+  it('inherits the global default when the selected profile has no codingPromptBehaviorV1 override', async () => {
+    const credentials = createCredentials();
+
+    const settings = {
+      profiles: [
+        {
+          id: 'profile-default',
+          name: 'Profile (default)',
+          // No codingPromptBehaviorV1 field => inherit global default.
+        },
+      ],
+    };
+
+    const out = await resolveEffectiveCodingPromptText({
+      credentials,
+      settings,
+      profileId: 'profile-default',
+      executionRunsFeatureEnabled: false,
+      providerId: 'claude',
+      fetchPromptArtifactRecord: async () => null,
+    });
+
+    // Global default responseOptions is 'agent' => options block present.
+    expect(out).toContain('# Options');
+    expect(out).toContain('<options>');
+  });
+
+  it('applies a profile override that disables session title updates while leaving options at the global default', async () => {
+    const credentials = createCredentials();
+
+    const settings = {
+      profiles: [
+        {
+          id: 'profile-no-title',
+          name: 'Profile (no title)',
+          codingPromptBehaviorV1: {
+            v: 1,
+            sessionTitleUpdates: 'disabled',
+          },
+        },
+      ],
+    };
+
+    const out = await resolveEffectiveCodingPromptText({
+      credentials,
+      settings,
+      profileId: 'profile-no-title',
+      executionRunsFeatureEnabled: false,
+      providerId: 'claude',
+      fetchPromptArtifactRecord: async () => null,
+    });
+
+    // Override wins only for title; options inherit the global default.
+    expect(out).not.toContain('# Session title');
+    expect(out).toContain('# Options');
+    expect(out).toContain('<options>');
+  });
 });

--- a/apps/cli/src/agent/prompting/coding/resolveEffectiveCodingPrompt.ts
+++ b/apps/cli/src/agent/prompting/coding/resolveEffectiveCodingPrompt.ts
@@ -1,4 +1,5 @@
 import {
+  applyCodingPromptBehaviorOverrideToSettings,
   buildCodingSessionPromptPlanBaseV1,
   buildPromptPlanDiagnosticsV1,
   buildPromptPlanV1,
@@ -13,6 +14,7 @@ import {
   resolveCliPromptStackSystemAppendBlocks,
   type PromptArtifactRecord,
 } from '@/agent/promptLibrary/resolveCliPromptStackSystemAppendBlocks';
+import { readProfilesFromAccountSettings } from '@/settings/profiles/readProfilesFromAccountSettings';
 import { resolveCodingProviderBehaviorBlocks } from './providerPromptBehaviorRegistry';
 import { resolveCodingToolDeliveryBlocks } from './toolDeliveryPromptRegistry';
 
@@ -59,8 +61,22 @@ export async function resolveEffectiveCodingPromptPlan(
       ? args.memoryRecallGuidanceEnabled
       : await resolveCliMemoryRecallGuidanceEnabled();
 
-  const basePlan = buildCodingSessionPromptPlanBaseV1({
+  // Resolve the selected profile's per-profile coding prompt behavior override (if any)
+  // and merge it over the global account settings for base-prompt rendering only.
+  // The override is agent-agnostic; resolution is by profile id and non-throwing, so an
+  // unknown / incompatible / built-in profile simply falls back to the global default.
+  const selectedProfileId = typeof args.profileId === 'string' ? args.profileId.trim() : '';
+  const selectedProfileOverride = selectedProfileId
+    ? readProfilesFromAccountSettings(settings).customProfiles
+        .find((profile) => profile.id === selectedProfileId)?.codingPromptBehaviorV1 ?? null
+    : null;
+  const basePromptSettings = applyCodingPromptBehaviorOverrideToSettings({
     settings,
+    override: selectedProfileOverride,
+  });
+
+  const basePlan = buildCodingSessionPromptPlanBaseV1({
+    settings: basePromptSettings,
     base: args.baseOverride === null ? '' : args.baseOverride,
     executionRunsFeatureEnabled: args.executionRunsFeatureEnabled === true,
     memoryRecallGuidanceEnabled,

--- a/apps/ui/sources/components/profiles/edit/ProfileEditForm.codingPromptBehavior.icons.test.tsx
+++ b/apps/ui/sources/components/profiles/edit/ProfileEditForm.codingPromptBehavior.icons.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+
+import { installProfileEditFormModuleMocks } from './profileEditFormTestHelpers';
+import { renderScreen } from '@/dev/testkit';
+
+installProfileEditFormModuleMocks({
+    storageModule: () => ({
+        useSetting: (key: string) => {
+            if (key === 'newSessionDefaultPersistenceModeV1') return 'persisted';
+            if (key === 'newSessionDefaultPersistenceModeByTargetKeyV1') return {};
+            return {};
+        },
+        useAllMachines: () => [],
+        useMachine: () => null,
+        useSettings: () => ({ opencodeBackendMode: 'server' }),
+        useSettingMutable: (key: string) => {
+            if (key === 'favoriteMachines') return [[], vi.fn()] as const;
+            if (key === 'secrets') return [[], vi.fn()] as const;
+            if (key === 'secretBindingsByProfileId') return [{}, vi.fn()] as const;
+            return [[], vi.fn()] as const;
+        },
+    }),
+});
+
+// The shared form helpers stub DropdownMenu as `() => null`, which never invokes the trigger
+// render prop — exactly how the coding-prompt triggers' icons escaped test coverage. This file
+// mounts the real trigger content instead. vi.doMock (not hoisted) so it registers AFTER the
+// shared helpers' own DropdownMenu stub and wins.
+vi.doMock('@/components/ui/forms/dropdown/DropdownMenu', () => {
+    return {
+        DropdownMenu: (props: {
+            trigger: (state: { open: boolean; toggle: () => void }) => React.ReactElement;
+        }) => React.createElement(
+            'dropdown-menu-stub',
+            null,
+            props.trigger({ open: false, toggle: () => undefined }),
+        ),
+    };
+});
+// The helper's ItemGroup stub omits the selection context the real Item consumes; the stub in
+// profileEditFormTestHelpers now exposes ItemGroupSelectionContext for exactly this case.
+
+vi.mock('@/hooks/server/useFeatureEnabled', () => ({
+    useFeatureEnabled: (featureId: string) => featureId === 'sessions.direct',
+}));
+
+vi.mock('@/hooks/auth/useCLIDetection', () => ({
+    useCLIDetection: () => ({ status: 'unknown' }),
+}));
+
+vi.mock('@/agents/hooks/useEnabledAgentIds', () => ({
+    useEnabledAgentIds: () => ['codex'],
+}));
+
+vi.mock('@/agents/catalog/catalog', () => ({
+    AGENT_IDS: ['codex'],
+    DEFAULT_AGENT_ID: 'codex',
+    getAgentCore: () => ({
+        sessionStorage: { direct: true, persisted: true },
+        permissions: { modeGroup: 'codexLike' },
+        cli: { machineLoginKey: 'codex' },
+        ui: { agentPickerIconName: 'terminal-outline' },
+        displayNameKey: 'agent.codex',
+    }),
+    getAgentBehavior: () => ({
+        resolveInitialPermissionMode: () => 'default',
+        resolveDefaultPersistenceMode: () => 'persisted',
+        formatProfileBackendEntryKey: () => 'codex',
+    }),
+    isProfileCompatibleWithBackendTarget: () => true,
+}));
+
+vi.mock('@/sync/domains/profiles/profileCompatibility', async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
+    isProfileCompatibleWithBackendTarget: () => true,
+}));
+
+const { ProfileEditForm } = await import('./ProfileEditForm');
+
+function buildProfile() {
+    return {
+        id: 'p1',
+        name: 'P',
+        target: 'codex',
+        env: {},
+        envVarRequirements: [],
+        isBuiltIn: false,
+        createdAt: 0,
+        updatedAt: 0,
+        version: '1.0.0',
+    } as never;
+}
+
+describe('ProfileEditForm coding prompt behavior icons render', () => {
+    it('renders the coding-prompt dropdown triggers through the canonical Icon component without a bare Ionicons reference', async () => {
+        // Regression guard: the section shipped referencing an unimported `Ionicons`, which
+        // crashed the profile form at render time on every platform while tests stayed green
+        // (their DropdownMenu stub never invoked the trigger). Rendering must not throw, and
+        // both trigger rows must mount.
+        const screen = await renderScreen(React.createElement(ProfileEditForm, {
+            profile: buildProfile(),
+            machineId: null,
+            onSave: vi.fn(() => true),
+            onCancel: vi.fn(),
+            saveRef: { current: null },
+        }));
+
+        expect(screen).toBeDefined();
+        const rendered = JSON.stringify(screen.tree.toJSON());
+        expect(rendered).toContain('profiles.codingPromptBehavior.sessionTitleUpdates.label');
+        expect(rendered).toContain('profiles.codingPromptBehavior.responseOptions.label');
+    });
+});

--- a/apps/ui/sources/components/profiles/edit/ProfileEditForm.codingPromptBehavior.test.tsx
+++ b/apps/ui/sources/components/profiles/edit/ProfileEditForm.codingPromptBehavior.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    AIBackendProfileSchema,
+    getProfileCodingPromptBehaviorOverride,
+    type AIBackendProfile,
+} from '@/sync/domains/profiles/profileCompatibility';
+
+function parseProfile(overrides: Partial<AIBackendProfile> = {}): AIBackendProfile {
+    return AIBackendProfileSchema.parse({
+        id: 'p1',
+        name: 'P',
+        ...overrides,
+    });
+}
+
+describe('getProfileCodingPromptBehaviorOverride', () => {
+    it('returns null when the profile has no codingPromptBehaviorV1 field', () => {
+        expect(getProfileCodingPromptBehaviorOverride(parseProfile())).toBeNull();
+    });
+
+    it('returns the full override when both knobs are set', () => {
+        const profile = parseProfile({
+            codingPromptBehaviorV1: { v: 1, sessionTitleUpdates: 'initial', responseOptions: 'disabled' },
+        });
+        expect(getProfileCodingPromptBehaviorOverride(profile)).toEqual({
+            v: 1,
+            sessionTitleUpdates: 'initial',
+            responseOptions: 'disabled',
+        });
+    });
+
+    it('preserves partial overrides (omit-means-inherit semantics survive parsing)', () => {
+        const profile = parseProfile({
+            codingPromptBehaviorV1: { v: 1, responseOptions: 'disabled' },
+        });
+        expect(getProfileCodingPromptBehaviorOverride(profile)).toEqual({
+            v: 1,
+            responseOptions: 'disabled',
+        });
+    });
+
+    it('drops a malformed override to a minimal object while keeping the profile valid', () => {
+        const profile = parseProfile({
+            codingPromptBehaviorV1: { sessionTitleUpdates: 'bogus' } as unknown as AIBackendProfile['codingPromptBehaviorV1'],
+        });
+        // Malformed override is reduced to { v: 1 } (no knobs set => inherit global for both).
+        expect(getProfileCodingPromptBehaviorOverride(profile)).toEqual({ v: 1 });
+    });
+});

--- a/apps/ui/sources/components/profiles/edit/ProfileEditForm.codingPromptBehavior.test.tsx
+++ b/apps/ui/sources/components/profiles/edit/ProfileEditForm.codingPromptBehavior.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
     AIBackendProfileSchema,
+    buildCodingPromptBehaviorOverrideV1,
     getProfileCodingPromptBehaviorOverride,
     type AIBackendProfile,
 } from '@/sync/domains/profiles/profileCompatibility';
@@ -46,5 +47,41 @@ describe('getProfileCodingPromptBehaviorOverride', () => {
         });
         // Malformed override is reduced to { v: 1 } (no knobs set => inherit global for both).
         expect(getProfileCodingPromptBehaviorOverride(profile)).toEqual({ v: 1 });
+    });
+});
+
+describe('buildCodingPromptBehaviorOverrideV1', () => {
+    it('returns undefined when no knob is set (omit-means-inherit on save)', () => {
+        expect(buildCodingPromptBehaviorOverrideV1({})).toBeUndefined();
+        expect(buildCodingPromptBehaviorOverrideV1({ sessionTitleUpdates: null, responseOptions: null })).toBeUndefined();
+    });
+
+    it('builds a partial override when only sessionTitleUpdates is set', () => {
+        expect(buildCodingPromptBehaviorOverrideV1({ sessionTitleUpdates: 'initial' })).toEqual({
+            v: 1,
+            sessionTitleUpdates: 'initial',
+        });
+    });
+
+    it('builds a partial override when only responseOptions is set', () => {
+        expect(buildCodingPromptBehaviorOverrideV1({ responseOptions: 'disabled' })).toEqual({
+            v: 1,
+            responseOptions: 'disabled',
+        });
+    });
+
+    it('builds a full override when both knobs are set', () => {
+        expect(buildCodingPromptBehaviorOverrideV1({ sessionTitleUpdates: 'ongoing', responseOptions: 'agent' })).toEqual({
+            v: 1,
+            sessionTitleUpdates: 'ongoing',
+            responseOptions: 'agent',
+        });
+    });
+
+    it('treats null like omitted for each knob independently', () => {
+        expect(buildCodingPromptBehaviorOverrideV1({ sessionTitleUpdates: null, responseOptions: 'disabled' })).toEqual({
+            v: 1,
+            responseOptions: 'disabled',
+        });
     });
 });

--- a/apps/ui/sources/components/profiles/edit/ProfileEditForm.tsx
+++ b/apps/ui/sources/components/profiles/edit/ProfileEditForm.tsx
@@ -4,7 +4,7 @@ import { StyleSheet } from 'react-native-unistyles';
 import { useUnistyles } from 'react-native-unistyles';
 import { Typography } from '@/constants/Typography';
 import { t } from '@/text';
-import { type AIBackendProfile } from '@/sync/domains/profiles/profileCompatibility';
+import { buildCodingPromptBehaviorOverrideV1, type AIBackendProfile } from '@/sync/domains/profiles/profileCompatibility';
 import { type SavedSecret } from '@/sync/domains/settings/savedSecretTypes';
 import { normalizeProfileDefaultPermissionMode, type PermissionMode } from '@/sync/domains/permissions/permissionTypes';
 import { getPermissionModeLabelForAgentType, getPermissionModeOptionsForAgentType, normalizePermissionModeForAgentType } from '@/sync/domains/permissions/permissionModeOptions';
@@ -29,7 +29,12 @@ import { DEFAULT_AGENT_ID, getAgentCore, type AgentId } from '@/agents/catalog/c
 import { AgentIcon } from '@/agents/registry/AgentIcon';
 import { getResolvedBackendCatalogEntries, type ResolvedBackendCatalogEntry } from '@/agents/backendCatalog/getResolvedBackendCatalogEntries';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { buildBackendTargetKey } from '@happier-dev/protocol';
+import {
+    buildBackendTargetKey,
+    resolveCodingPromptBehaviorV1,
+    type CodingPromptBehaviorModeV1,
+    type CodingPromptSessionTitleUpdatesModeV1,
+} from '@happier-dev/protocol';
 import { supportsDirectTranscriptStorageForNewSession } from '@/components/sessions/new/modules/newSessionTranscriptStorage';
 import { readAccountTranscriptStorageDefaults, type SessionTranscriptStorageMode } from '@/sync/domains/session/transcriptStorageDefaults';
 import { MachinePreviewModal } from './MachinePreviewModal';
@@ -182,6 +187,11 @@ export function ProfileEditForm({
     const sessionDefaultPermissionModeByTargetKey = useSetting('sessionDefaultPermissionModeByTargetKey');
     const newSessionDefaultPersistenceModeV1 = useSetting('newSessionDefaultPersistenceModeV1');
     const newSessionDefaultPersistenceModeByTargetKeyV1 = useSetting('newSessionDefaultPersistenceModeByTargetKeyV1');
+    const accountCodingPromptBehaviorRaw = useSetting('codingPromptBehaviorV1');
+    const accountCodingPromptBehavior = React.useMemo(
+        () => resolveCodingPromptBehaviorV1({ codingPromptBehaviorV1: accountCodingPromptBehaviorRaw }),
+        [accountCodingPromptBehaviorRaw],
+    );
 
     const [defaultPermissionModesByTargetKey, setDefaultPermissionModesByTargetKey] = React.useState<Record<string, PermissionMode | null>>(() => {
         const explicitByTargetKey = (profile.defaultPermissionModeByTargetKey as Record<string, PermissionMode | undefined>) ?? {};
@@ -254,6 +264,12 @@ export function ProfileEditForm({
 
     const [authMode, setAuthMode] = React.useState<AIBackendProfile['authMode']>(profile.authMode);
     const [requiresMachineLogin, setRequiresMachineLogin] = React.useState<AIBackendProfile['requiresMachineLogin']>(profile.requiresMachineLogin);
+    const [codingPromptSessionTitleUpdates, setCodingPromptSessionTitleUpdates] = React.useState<CodingPromptSessionTitleUpdatesModeV1 | null>(
+        () => profile.codingPromptBehaviorV1?.sessionTitleUpdates ?? null,
+    );
+    const [codingPromptResponseOptions, setCodingPromptResponseOptions] = React.useState<CodingPromptBehaviorModeV1 | null>(
+        () => profile.codingPromptBehaviorV1?.responseOptions ?? null,
+    );
     /**
      * Requirements live in the env-var editor UI, but are persisted in `profile.envVarRequirements`
      * (derived) and `secretBindingsByProfileId` (per-profile default saved secret choice).
@@ -459,6 +475,7 @@ export function ProfileEditForm({
 
     const [openPermissionProvider, setOpenPermissionProvider] = React.useState<null | string>(null);
     const [openStorageProvider, setOpenStorageProvider] = React.useState<null | string>(null);
+    const [openCodingBehaviorControl, setOpenCodingBehaviorControl] = React.useState<null | 'title' | 'responseOptions'>(null);
 
     const canSelectMachineLogin = machineLoginRequirement.selectableTargetKey !== null;
     const effectiveAuthMode = authMode === 'machineLogin' && canSelectMachineLogin ? 'machineLogin' : undefined;
@@ -537,6 +554,8 @@ export function ProfileEditForm({
             derivedEnvVarRequirements,
             // Bindings are settings-level but edited here; include for dirty tracking.
             secretBindings: secretBindingsByProfileId[profile.id] ?? null,
+            codingPromptSessionTitleUpdates,
+            codingPromptResponseOptions,
         });
     }
 
@@ -551,6 +570,8 @@ export function ProfileEditForm({
             requiresMachineLogin,
             derivedEnvVarRequirements,
             secretBindings: secretBindingsByProfileId[profile.id] ?? null,
+            codingPromptSessionTitleUpdates,
+            codingPromptResponseOptions,
         });
         return currentSnapshot !== initialSnapshotRef.current;
     }, [
@@ -563,6 +584,8 @@ export function ProfileEditForm({
         derivedEnvVarRequirements,
         requiresMachineLogin,
         secretBindingsByProfileId,
+        codingPromptSessionTitleUpdates,
+        codingPromptResponseOptions,
         profile.id,
     ]);
 
@@ -642,6 +665,10 @@ export function ProfileEditForm({
         }
 
         const persistedAuthMode = effectiveAuthMode;
+        const codingPromptBehaviorV1 = buildCodingPromptBehaviorOverrideV1({
+            sessionTitleUpdates: codingPromptSessionTitleUpdates,
+            responseOptions: codingPromptResponseOptions,
+        });
         return onSave({
             ...profileBase,
             name: name.trim(),
@@ -660,6 +687,7 @@ export function ProfileEditForm({
             defaultPersistenceModeByAgent: {},
             compatibilityByTargetKey,
             compatibility: {},
+            codingPromptBehaviorV1,
             updatedAt: Date.now(),
         });
     }, [
@@ -676,6 +704,8 @@ export function ProfileEditForm({
         effectiveAuthMode,
         machineLoginRequirement.selectableTargetKey,
         supportedDirectBackendEntries,
+        codingPromptSessionTitleUpdates,
+        codingPromptResponseOptions,
     ]);
 
     React.useEffect(() => {
@@ -989,6 +1019,131 @@ export function ProfileEditForm({
                         })}
                 </ItemGroup>
             ) : null}
+
+            <ItemGroup
+                title={t('profiles.codingPromptBehavior.title')}
+                footer={t('profiles.codingPromptBehavior.footer')}
+            >
+                <DropdownMenu
+                    open={openCodingBehaviorControl === 'title'}
+                    onOpenChange={(next) => setOpenCodingBehaviorControl(next ? 'title' : null)}
+                    popoverBoundaryRef={popoverBoundaryRef}
+                    variant="selectable"
+                    search={false}
+                    showCategoryTitles={false}
+                    matchTriggerWidth={true}
+                    connectToTrigger={true}
+                    rowKind="item"
+                    selectedId={codingPromptSessionTitleUpdates ?? '__account__'}
+                    trigger={({ open, toggle }) => (
+                        <Item
+                            selected={false}
+                            title={t('profiles.codingPromptBehavior.sessionTitleUpdates.label')}
+                            subtitle={codingPromptSessionTitleUpdates
+                                ? t(`profiles.codingPromptBehavior.sessionTitleUpdates.${codingPromptSessionTitleUpdates}`)
+                                : t('profiles.codingPromptBehavior.accountDefaultSubtitle', { label: t(`profiles.codingPromptBehavior.sessionTitleUpdates.${accountCodingPromptBehavior.sessionTitleUpdates}`) })
+                            }
+                            icon={<Ionicons name="text-outline" size={29} color={theme.colors.text.secondary} />}
+                            rightElement={(
+                                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                                    <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={20} color={theme.colors.text.secondary} />
+                                </View>
+                            )}
+                            showChevron={false}
+                            onPress={toggle}
+                            showDivider={true}
+                        />
+                    )}
+                    items={[
+                        {
+                            id: '__account__',
+                            title: t('profiles.codingPromptBehavior.useSystemDefault'),
+                            subtitle: t('profiles.codingPromptBehavior.currently', { label: t(`profiles.codingPromptBehavior.sessionTitleUpdates.${accountCodingPromptBehavior.sessionTitleUpdates}`) }),
+                            icon: (
+                                <View style={{ width: 32, height: 32, alignItems: 'center', justifyContent: 'center' }}>
+                                    <Ionicons name="settings-outline" size={22} color={theme.colors.text.secondary} />
+                                </View>
+                            ),
+                        },
+                        ...(['ongoing', 'initial', 'disabled'] as const).map((mode) => ({
+                            id: mode,
+                            title: t(`profiles.codingPromptBehavior.sessionTitleUpdates.${mode}`),
+                            icon: (
+                                <View style={{ width: 32, height: 32, alignItems: 'center', justifyContent: 'center' }}>
+                                    <Ionicons name={mode === 'disabled' ? 'close-circle-outline' : mode === 'initial' ? 'flag-outline' : 'sync-outline'} size={22} color={theme.colors.text.secondary} />
+                                </View>
+                            ),
+                        })),
+                    ]}
+                    onSelect={(id) => {
+                        if (id === '__account__') {
+                            setCodingPromptSessionTitleUpdates(null);
+                        } else {
+                            setCodingPromptSessionTitleUpdates(id as CodingPromptSessionTitleUpdatesModeV1);
+                        }
+                        setOpenCodingBehaviorControl(null);
+                    }}
+                />
+                <DropdownMenu
+                    open={openCodingBehaviorControl === 'responseOptions'}
+                    onOpenChange={(next) => setOpenCodingBehaviorControl(next ? 'responseOptions' : null)}
+                    popoverBoundaryRef={popoverBoundaryRef}
+                    variant="selectable"
+                    search={false}
+                    showCategoryTitles={false}
+                    matchTriggerWidth={true}
+                    connectToTrigger={true}
+                    rowKind="item"
+                    selectedId={codingPromptResponseOptions ?? '__account__'}
+                    trigger={({ open, toggle }) => (
+                        <Item
+                            selected={false}
+                            title={t('profiles.codingPromptBehavior.responseOptions.label')}
+                            subtitle={codingPromptResponseOptions
+                                ? t(`profiles.codingPromptBehavior.responseOptions.${codingPromptResponseOptions}`)
+                                : t('profiles.codingPromptBehavior.accountDefaultSubtitle', { label: t(`profiles.codingPromptBehavior.responseOptions.${accountCodingPromptBehavior.responseOptions}`) })
+                            }
+                            icon={<Ionicons name="options-outline" size={29} color={theme.colors.text.secondary} />}
+                            rightElement={(
+                                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                                    <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={20} color={theme.colors.text.secondary} />
+                                </View>
+                            )}
+                            showChevron={false}
+                            onPress={toggle}
+                        />
+                    )}
+                    items={[
+                        {
+                            id: '__account__',
+                            title: t('profiles.codingPromptBehavior.useSystemDefault'),
+                            subtitle: t('profiles.codingPromptBehavior.currently', { label: t(`profiles.codingPromptBehavior.responseOptions.${accountCodingPromptBehavior.responseOptions}`) }),
+                            icon: (
+                                <View style={{ width: 32, height: 32, alignItems: 'center', justifyContent: 'center' }}>
+                                    <Ionicons name="settings-outline" size={22} color={theme.colors.text.secondary} />
+                                </View>
+                            ),
+                        },
+                        ...(['agent', 'disabled'] as const).map((mode) => ({
+                            id: mode,
+                            title: t(`profiles.codingPromptBehavior.responseOptions.${mode}`),
+                            icon: (
+                                <View style={{ width: 32, height: 32, alignItems: 'center', justifyContent: 'center' }}>
+                                    <Ionicons name={mode === 'disabled' ? 'close-circle-outline' : 'checkmark-circle-outline'} size={22} color={theme.colors.text.secondary} />
+                                </View>
+                            ),
+                        })),
+                    ]}
+                    onSelect={(id) => {
+                        if (id === '__account__') {
+                            setCodingPromptResponseOptions(null);
+                        } else {
+                            setCodingPromptResponseOptions(id as CodingPromptBehaviorModeV1);
+                        }
+                        setOpenCodingBehaviorControl(null);
+                    }}
+                />
+            </ItemGroup>
 
             {!routeMachine && (
                 <ItemGroup title={t('profiles.previewMachine.title')}>

--- a/apps/ui/sources/components/profiles/edit/ProfileEditForm.tsx
+++ b/apps/ui/sources/components/profiles/edit/ProfileEditForm.tsx
@@ -1043,10 +1043,10 @@ export function ProfileEditForm({
                                 ? t(`profiles.codingPromptBehavior.sessionTitleUpdates.${codingPromptSessionTitleUpdates}`)
                                 : t('profiles.codingPromptBehavior.accountDefaultSubtitle', { label: t(`profiles.codingPromptBehavior.sessionTitleUpdates.${accountCodingPromptBehavior.sessionTitleUpdates}`) })
                             }
-                            icon={<Ionicons name="text-outline" size={29} color={theme.colors.text.secondary} />}
+                            icon={<Icon name="note-pencil" size={29} color={theme.colors.text.secondary} />}
                             rightElement={(
                                 <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                                    <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={20} color={theme.colors.text.secondary} />
+                                    <Icon name={open ? 'caret-up' : 'caret-down'} size={20} color={theme.colors.text.secondary} />
                                 </View>
                             )}
                             showChevron={false}
@@ -1061,7 +1061,7 @@ export function ProfileEditForm({
                             subtitle: t('profiles.codingPromptBehavior.currently', { label: t(`profiles.codingPromptBehavior.sessionTitleUpdates.${accountCodingPromptBehavior.sessionTitleUpdates}`) }),
                             icon: (
                                 <View style={{ width: 32, height: 32, alignItems: 'center', justifyContent: 'center' }}>
-                                    <Ionicons name="settings-outline" size={22} color={theme.colors.text.secondary} />
+                                    <Icon name="gear" size={22} color={theme.colors.text.secondary} />
                                 </View>
                             ),
                         },
@@ -1070,7 +1070,7 @@ export function ProfileEditForm({
                             title: t(`profiles.codingPromptBehavior.sessionTitleUpdates.${mode}`),
                             icon: (
                                 <View style={{ width: 32, height: 32, alignItems: 'center', justifyContent: 'center' }}>
-                                    <Ionicons name={mode === 'disabled' ? 'close-circle-outline' : mode === 'initial' ? 'flag-outline' : 'sync-outline'} size={22} color={theme.colors.text.secondary} />
+                                    <Icon name={mode === 'disabled' ? 'x-circle' : mode === 'initial' ? 'target' : 'arrows-clockwise'} size={22} color={theme.colors.text.secondary} />
                                 </View>
                             ),
                         })),
@@ -1103,10 +1103,10 @@ export function ProfileEditForm({
                                 ? t(`profiles.codingPromptBehavior.responseOptions.${codingPromptResponseOptions}`)
                                 : t('profiles.codingPromptBehavior.accountDefaultSubtitle', { label: t(`profiles.codingPromptBehavior.responseOptions.${accountCodingPromptBehavior.responseOptions}`) })
                             }
-                            icon={<Ionicons name="options-outline" size={29} color={theme.colors.text.secondary} />}
+                            icon={<Icon name="sliders-horizontal" size={29} color={theme.colors.text.secondary} />}
                             rightElement={(
                                 <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                                    <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={20} color={theme.colors.text.secondary} />
+                                    <Icon name={open ? 'caret-up' : 'caret-down'} size={20} color={theme.colors.text.secondary} />
                                 </View>
                             )}
                             showChevron={false}
@@ -1120,7 +1120,7 @@ export function ProfileEditForm({
                             subtitle: t('profiles.codingPromptBehavior.currently', { label: t(`profiles.codingPromptBehavior.responseOptions.${accountCodingPromptBehavior.responseOptions}`) }),
                             icon: (
                                 <View style={{ width: 32, height: 32, alignItems: 'center', justifyContent: 'center' }}>
-                                    <Ionicons name="settings-outline" size={22} color={theme.colors.text.secondary} />
+                                    <Icon name="gear" size={22} color={theme.colors.text.secondary} />
                                 </View>
                             ),
                         },
@@ -1129,7 +1129,7 @@ export function ProfileEditForm({
                             title: t(`profiles.codingPromptBehavior.responseOptions.${mode}`),
                             icon: (
                                 <View style={{ width: 32, height: 32, alignItems: 'center', justifyContent: 'center' }}>
-                                    <Ionicons name={mode === 'disabled' ? 'close-circle-outline' : 'checkmark-circle-outline'} size={22} color={theme.colors.text.secondary} />
+                                    <Icon name={mode === 'disabled' ? 'x-circle' : 'check-circle'} size={22} color={theme.colors.text.secondary} />
                                 </View>
                             ),
                         })),

--- a/apps/ui/sources/components/profiles/edit/profileEditFormTestHelpers.ts
+++ b/apps/ui/sources/components/profiles/edit/profileEditFormTestHelpers.ts
@@ -135,6 +135,9 @@ export function installProfileEditFormModuleMocks(
     vi.mock('@/components/ui/lists/ItemGroup', () => ({
         ItemGroup: ({ children }: { children?: React.ReactNode }) =>
             React.createElement(React.Fragment, null, children),
+        // The real Item consumes this context; expose a real (empty-default) one so tests that
+        // mount actual Item rows through this stub don't hit a missing-export error.
+        ItemGroupSelectionContext: React.createContext(undefined),
     }));
 
     vi.mock('@/components/ui/forms/Switch', () => ({

--- a/apps/ui/sources/sync/domains/profiles/profileCompatibility.ts
+++ b/apps/ui/sources/sync/domains/profiles/profileCompatibility.ts
@@ -6,7 +6,9 @@ import {
     getProfileEnvironmentVariables as getProfileEnvironmentVariablesProtocol,
     isProfileCompatibleWithBackendTarget as isProfileCompatibleWithBackendTargetProtocol,
     isProfileCompatibleWithAgent as isProfileCompatibleWithAgentProtocol,
+    type CodingPromptBehaviorModeV1,
     type CodingPromptBehaviorOverrideV1,
+    type CodingPromptSessionTitleUpdatesModeV1,
 } from '@happier-dev/protocol';
 import type { AgentId } from '@/agents/catalog/catalog';
 
@@ -50,4 +52,27 @@ export function getProfileCodingPromptBehaviorOverride(profile: AIBackendProfile
         return null;
     }
     return profile.codingPromptBehaviorV1;
+}
+
+/**
+ * Builds a per-profile codingPromptBehaviorV1 override from explicit per-knob choices.
+ * A knob set to null/undefined is omitted so it inherits the account (system) default.
+ * Returns undefined when neither knob is set, so callers can omit the field entirely
+ * (omit-means-inherit semantics preserved on save).
+ */
+export function buildCodingPromptBehaviorOverrideV1(params: {
+    sessionTitleUpdates?: CodingPromptSessionTitleUpdatesModeV1 | null;
+    responseOptions?: CodingPromptBehaviorModeV1 | null;
+}): CodingPromptBehaviorOverrideV1 | undefined {
+    const sessionTitleUpdates = params.sessionTitleUpdates ?? null;
+    const responseOptions = params.responseOptions ?? null;
+    if (!sessionTitleUpdates && !responseOptions) return undefined;
+    const override: CodingPromptBehaviorOverrideV1 = { v: 1 };
+    if (sessionTitleUpdates) {
+        override.sessionTitleUpdates = sessionTitleUpdates;
+    }
+    if (responseOptions) {
+        override.responseOptions = responseOptions;
+    }
+    return override;
 }

--- a/apps/ui/sources/sync/domains/profiles/profileCompatibility.ts
+++ b/apps/ui/sources/sync/domains/profiles/profileCompatibility.ts
@@ -6,6 +6,7 @@ import {
     getProfileEnvironmentVariables as getProfileEnvironmentVariablesProtocol,
     isProfileCompatibleWithBackendTarget as isProfileCompatibleWithBackendTargetProtocol,
     isProfileCompatibleWithAgent as isProfileCompatibleWithAgentProtocol,
+    type CodingPromptBehaviorOverrideV1,
 } from '@happier-dev/protocol';
 import type { AgentId } from '@/agents/catalog/catalog';
 
@@ -42,4 +43,11 @@ export function isProfileCompatibleWithAgent(
 
 export function getProfileEnvironmentVariables(profile: AIBackendProfile): Record<string, string> {
     return getProfileEnvironmentVariablesProtocol(profile);
+}
+
+export function getProfileCodingPromptBehaviorOverride(profile: AIBackendProfile): CodingPromptBehaviorOverrideV1 | null {
+    if (profile.codingPromptBehaviorV1 === undefined) {
+        return null;
+    }
+    return profile.codingPromptBehaviorV1;
 }

--- a/apps/ui/sources/text/translations/ca.ts
+++ b/apps/ui/sources/text/translations/ca.ts
@@ -9568,6 +9568,25 @@ settingsSession: {
       useAccountDefault: 'Fes servir el predeterminat del compte',
       currently: ({ label }: { label: string }) => `Actualment: ${label}`,
     },
+        codingPromptBehavior: {
+            title: 'Coding prompt behavior',
+            footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+            useSystemDefault: 'Use system default',
+            accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+            currently: ({ label }: { label: string }) => `Currently: ${label}`,
+            sessionTitleUpdates: {
+                label: 'Session title updates',
+                ongoing: 'Ongoing',
+                initial: 'Initial only',
+                disabled: 'Disabled',
+            },
+            responseOptions: {
+                label: 'Response options',
+                agent: 'agent',
+                disabled: 'Disabled',
+            },
+        },
+
         aiBackend: {
             title: 'Backend d\'IA',
             selectAtLeastOneError: 'Selecciona com a mínim un backend d\'IA.',

--- a/apps/ui/sources/text/translations/en.ts
+++ b/apps/ui/sources/text/translations/en.ts
@@ -9696,6 +9696,24 @@ settingsSession: {
       useAccountDefault: 'Use account default',
       currently: ({ label }: { label: string }) => `Currently: ${label}`,
     },
+        codingPromptBehavior: {
+            title: 'Coding prompt behavior',
+            footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+            useSystemDefault: 'Use system default',
+            accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+            currently: ({ label }: { label: string }) => `Currently: ${label}`,
+            sessionTitleUpdates: {
+                label: 'Session title updates',
+                ongoing: 'Ongoing',
+                initial: 'Initial only',
+                disabled: 'Disabled',
+            },
+            responseOptions: {
+                label: 'Response options',
+                agent: 'agent',
+                disabled: 'Disabled',
+            },
+        },
         aiBackend: {
             title: 'AI Backend',
             selectAtLeastOneError: 'Select at least one AI backend.',

--- a/apps/ui/sources/text/translations/es.ts
+++ b/apps/ui/sources/text/translations/es.ts
@@ -10409,6 +10409,25 @@ settingsSession: {
       useAccountDefault: 'Usar el valor predeterminado de la cuenta',
       currently: ({ label }: { label: string }) => `Actualmente: ${label}`,
     },
+    codingPromptBehavior: {
+        title: 'Coding prompt behavior',
+        footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+        useSystemDefault: 'Use system default',
+        accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+        currently: ({ label }: { label: string }) => `Currently: ${label}`,
+        sessionTitleUpdates: {
+            label: 'Session title updates',
+            ongoing: 'Ongoing',
+            initial: 'Initial only',
+            disabled: 'Disabled',
+        },
+        responseOptions: {
+            label: 'Response options',
+            agent: 'agent',
+            disabled: 'Disabled',
+        },
+    },
+
     aiBackend: {
       title: "Backend de IA",
       selectAtLeastOneError: "Selecciona al menos un backend de IA.",

--- a/apps/ui/sources/text/translations/it.ts
+++ b/apps/ui/sources/text/translations/it.ts
@@ -1472,6 +1472,25 @@ export const it: TranslationStructure = {
       useAccountDefault: "Usa predefinito account",
       currently: ({ label }: { label: string }) => `Attualmente: ${label}`,
     },
+    codingPromptBehavior: {
+        title: 'Coding prompt behavior',
+        footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+        useSystemDefault: 'Use system default',
+        accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+        currently: ({ label }: { label: string }) => `Currently: ${label}`,
+        sessionTitleUpdates: {
+            label: 'Session title updates',
+            ongoing: 'Ongoing',
+            initial: 'Initial only',
+            disabled: 'Disabled',
+        },
+        responseOptions: {
+            label: 'Response options',
+            agent: 'agent',
+            disabled: 'Disabled',
+        },
+    },
+
     aiBackend: {
       title: "Backend IA",
       selectAtLeastOneError: "Seleziona almeno un backend IA.",

--- a/apps/ui/sources/text/translations/ja.ts
+++ b/apps/ui/sources/text/translations/ja.ts
@@ -1454,6 +1454,25 @@ export const ja: TranslationStructure = {
       useAccountDefault: "アカウント既定を使用",
       currently: ({ label }: { label: string }) => `現在: ${label}`,
     },
+    codingPromptBehavior: {
+        title: 'Coding prompt behavior',
+        footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+        useSystemDefault: 'Use system default',
+        accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+        currently: ({ label }: { label: string }) => `Currently: ${label}`,
+        sessionTitleUpdates: {
+            label: 'Session title updates',
+            ongoing: 'Ongoing',
+            initial: 'Initial only',
+            disabled: 'Disabled',
+        },
+        responseOptions: {
+            label: 'Response options',
+            agent: 'agent',
+            disabled: 'Disabled',
+        },
+    },
+
     aiBackend: {
       title: "AIバックエンド",
       selectAtLeastOneError:

--- a/apps/ui/sources/text/translations/pl.ts
+++ b/apps/ui/sources/text/translations/pl.ts
@@ -10405,6 +10405,25 @@ settingsSession: {
       useAccountDefault: 'Użyj domyślnego konta',
       currently: ({ label }: { label: string }) => `Aktualnie: ${label}`,
     },
+    codingPromptBehavior: {
+        title: 'Coding prompt behavior',
+        footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+        useSystemDefault: 'Use system default',
+        accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+        currently: ({ label }: { label: string }) => `Currently: ${label}`,
+        sessionTitleUpdates: {
+            label: 'Session title updates',
+            ongoing: 'Ongoing',
+            initial: 'Initial only',
+            disabled: 'Disabled',
+        },
+        responseOptions: {
+            label: 'Response options',
+            agent: 'agent',
+            disabled: 'Disabled',
+        },
+    },
+
     aiBackend: {
       title: "Backend AI",
       selectAtLeastOneError: "Wybierz co najmniej jeden backend AI.",

--- a/apps/ui/sources/text/translations/pt.ts
+++ b/apps/ui/sources/text/translations/pt.ts
@@ -10453,6 +10453,25 @@ settingsSession: {
       useAccountDefault: 'Usar padrão da conta',
       currently: ({ label }: { label: string }) => `Atual: ${label}`,
     },
+    codingPromptBehavior: {
+        title: 'Coding prompt behavior',
+        footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+        useSystemDefault: 'Use system default',
+        accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+        currently: ({ label }: { label: string }) => `Currently: ${label}`,
+        sessionTitleUpdates: {
+            label: 'Session title updates',
+            ongoing: 'Ongoing',
+            initial: 'Initial only',
+            disabled: 'Disabled',
+        },
+        responseOptions: {
+            label: 'Response options',
+            agent: 'agent',
+            disabled: 'Disabled',
+        },
+    },
+
     aiBackend: {
       title: "Backend de IA",
       selectAtLeastOneError: "Selecione pelo menos um backend de IA.",

--- a/apps/ui/sources/text/translations/ru.ts
+++ b/apps/ui/sources/text/translations/ru.ts
@@ -10319,6 +10319,25 @@ settingsSession: {
       useAccountDefault: "Использовать учетную запись по умолчанию",
       currently: ({ label }: { label: string }) => `Currently: ${label}`,
     },
+    codingPromptBehavior: {
+        title: 'Coding prompt behavior',
+        footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+        useSystemDefault: 'Use system default',
+        accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+        currently: ({ label }: { label: string }) => `Currently: ${label}`,
+        sessionTitleUpdates: {
+            label: 'Session title updates',
+            ongoing: 'Ongoing',
+            initial: 'Initial only',
+            disabled: 'Disabled',
+        },
+        responseOptions: {
+            label: 'Response options',
+            agent: 'agent',
+            disabled: 'Disabled',
+        },
+    },
+
     aiBackend: {
       title: "Бекенд ИИ",
       selectAtLeastOneError: "Выберите хотя бы один бекенд ИИ.",

--- a/apps/ui/sources/text/translations/zh-Hans.ts
+++ b/apps/ui/sources/text/translations/zh-Hans.ts
@@ -9939,6 +9939,25 @@ settingsSession: {
       useAccountDefault: "使用账号默认值",
       currently: ({ label }: { label: string }) => `当前：${label}`,
     },
+    codingPromptBehavior: {
+        title: 'Coding prompt behavior',
+        footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+        useSystemDefault: 'Use system default',
+        accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+        currently: ({ label }: { label: string }) => `Currently: ${label}`,
+        sessionTitleUpdates: {
+            label: 'Session title updates',
+            ongoing: 'Ongoing',
+            initial: 'Initial only',
+            disabled: 'Disabled',
+        },
+        responseOptions: {
+            label: 'Response options',
+            agent: 'agent',
+            disabled: 'Disabled',
+        },
+    },
+
     aiBackend: {
       title: "AI 后端",
       selectAtLeastOneError: "至少选择一个 AI 后端。",

--- a/apps/ui/sources/text/translations/zh-Hant.ts
+++ b/apps/ui/sources/text/translations/zh-Hant.ts
@@ -8138,6 +8138,25 @@ settingsSession: {
             confirm: '刪除',
             cancel: '取消',
         },
+        codingPromptBehavior: {
+            title: 'Coding prompt behavior',
+            footer: 'Overrides the account-level system-prompt behavior for coding sessions when this profile is selected.',
+            useSystemDefault: 'Use system default',
+            accountDefaultSubtitle: ({ label }: { label: string }) => `Account default: ${label}`,
+            currently: ({ label }: { label: string }) => `Currently: ${label}`,
+            sessionTitleUpdates: {
+                label: 'Session title updates',
+                ongoing: 'Ongoing',
+                initial: 'Initial only',
+                disabled: 'Disabled',
+            },
+            responseOptions: {
+                label: 'Response options',
+                agent: 'agent',
+                disabled: 'Disabled',
+            },
+        },
+
         aiBackend: {
             copilotSubtitleExperimental: 'GitHub Copilot CLI（實驗）',
             cursorSubtitleExperimental: 'Cursor Agent CLI（實驗）',

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -2831,6 +2831,13 @@ export {
   type CodingPromptSessionTitleUpdatesModeV1,
   type CodingPromptBehaviorV1,
 } from './prompts/codingPromptBehaviorV1.js';
+
+export {
+  CodingPromptBehaviorOverrideV1Schema,
+  resolveCodingPromptBehaviorV1WithOverride,
+  applyCodingPromptBehaviorOverrideToSettings,
+  type CodingPromptBehaviorOverrideV1,
+} from './prompts/codingPromptBehaviorV1.js';
 export {
   CHANGE_TITLE_INSTRUCTION_V1,
   buildChangeTitleInstructionV1,

--- a/packages/protocol/src/profiles/backendProfileSchema.ts
+++ b/packages/protocol/src/profiles/backendProfileSchema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { BackendTargetKeySchema } from '../backendTargets/backendTargetRef.js';
 import { SecretStringV1Schema } from '../crypto/settingsSecretStringsV1.js';
 import { SESSION_PERMISSION_MODES } from '../sessionMetadata/sessionPermissionModes.js';
+import { CodingPromptBehaviorOverrideV1Schema } from '../prompts/codingPromptBehaviorV1.js';
 
 const ENV_VAR_NAME_REGEX = /^[A-Z_][A-Z0-9_]*$/;
 
@@ -95,8 +96,11 @@ export const AIBackendProfileSchema = z.object({
   createdAt: z.number().default(() => Date.now()),
   updatedAt: z.number().default(() => Date.now()),
   version: z.string().default('1.0.0'),
+
+  // Per-profile coding prompt behavior overrides (partial, with .catch({}) to drop malformed)
+  codingPromptBehaviorV1: CodingPromptBehaviorOverrideV1Schema.optional(),
 })
-  // NOTE: Zod v4 marks `superRefine` as deprecated in favor of `.check(...)`.
+  // NOTE: Zod v4 marks `superRefine` as deprecated in favor of `.check(...)`. 
   // We use chained `.refine(...)` here to preserve per-field error paths/messages.
   .refine((profile) => {
     return !(profile.requiresMachineLoginTargetKey && profile.authMode !== 'machineLogin');

--- a/packages/protocol/src/profiles/resolveBackendProfile.test.ts
+++ b/packages/protocol/src/profiles/resolveBackendProfile.test.ts
@@ -203,4 +203,67 @@ describe('profiles (protocol)', () => {
     expect(getMissingRequiredConfigEnvVarNames(profile, { GOOGLE_CLOUD_PROJECT: false })).toEqual(['GOOGLE_CLOUD_PROJECT']);
     expect(getMissingRequiredConfigEnvVarNames(profile, { GOOGLE_CLOUD_PROJECT: true })).toEqual([]);
   });
+
+  describe('codingPromptBehaviorV1 override', () => {
+    it('(RED) accepts profile with codingPromptBehaviorV1: { responseOptions: "disabled" } and keeps that value', () => {
+      const result = AIBackendProfileSchema.safeParse({
+        id: 'test-profile',
+        name: 'Test Profile',
+        environmentVariables: [],
+        envVarRequirements: [],
+        isBuiltIn: false,
+        createdAt: 0,
+        updatedAt: 0,
+        version: '1.0.0',
+        codingPromptBehaviorV1: { responseOptions: 'disabled' as const },
+      });
+
+      // This should FAIL currently because codingPromptBehaviorV1 is not in the schema
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // Override includes v=1 from default, plus the set field
+        expect(result.data.codingPromptBehaviorV1).toEqual({ v: 1, responseOptions: 'disabled' });
+      }
+    });
+
+    it('(RED) profile WITHOUT codingPromptBehaviorV1 still parses (regression guard)', () => {
+      const result = AIBackendProfileSchema.safeParse({
+        id: 'test-profile-2',
+        name: 'Test Profile 2',
+        environmentVariables: [],
+        envVarRequirements: [],
+        isBuiltIn: false,
+        createdAt: 0,
+        updatedAt: 0,
+        version: '1.0.0',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // Should not have codingPromptBehaviorV1 field when omitted
+        expect('codingPromptBehaviorV1' in result.data).toBe(false);
+      }
+    });
+
+    it('(RED) malformed codingPromptBehaviorV1 drops override but keeps profile', () => {
+      const result = AIBackendProfileSchema.safeParse({
+        id: 'test-profile-3',
+        name: 'Test Profile 3',
+        environmentVariables: [],
+        envVarRequirements: [],
+        isBuiltIn: false,
+        createdAt: 0,
+        updatedAt: 0,
+        version: '1.0.0',
+        codingPromptBehaviorV1: { sessionTitleUpdates: 'bogus' as any },
+      });
+
+      // This should FAIL currently because the schema doesn't exist or doesn't have .catch({})
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // Override becomes minimal with v=1 only, effectively dropping malformed fields
+        expect(result.data.codingPromptBehaviorV1).toEqual({ v: 1 });
+      }
+    });
+  });
 });

--- a/packages/protocol/src/prompts/codingPromptBehaviorV1.test.ts
+++ b/packages/protocol/src/prompts/codingPromptBehaviorV1.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CodingPromptBehaviorOverrideV1Schema,
+  resolveCodingPromptBehaviorV1WithOverride,
+  applyCodingPromptBehaviorOverrideToSettings,
+  DEFAULT_CODING_PROMPT_BEHAVIOR_V1,
+} from './codingPromptBehaviorV1.js';
+
+describe('codingPromptBehaviorV1 (overrides)', () => {
+  describe('resolveCodingPromptBehaviorV1WithOverride', () => {
+    it('omitted field inherits global', () => {
+      const settings = { codingPromptBehaviorV1: {} };
+      const override: any = {}; // empty override
+
+      const result = resolveCodingPromptBehaviorV1WithOverride({
+        settingsLike: settings,
+        override,
+      });
+
+      expect(result).toEqual(DEFAULT_CODING_PROMPT_BEHAVIOR_V1);
+    });
+
+    it('set field wins', () => {
+      const settings = { codingPromptBehaviorV1: {} };
+      const override = { responseOptions: 'disabled' as const };
+
+      const result = resolveCodingPromptBehaviorV1WithOverride({
+        settingsLike: settings,
+        override,
+      });
+
+      expect(result).toEqual({
+        v: 1,
+        sessionTitleUpdates: 'ongoing', // from global default
+        responseOptions: 'disabled',   // from override
+      });
+    });
+
+    it('\'agent\' alias folds to \'ongoing\'', () => {
+      const settings = { codingPromptBehaviorV1: {} };
+      // Simulate parsing raw input through override schema first
+      const rawOverride = { sessionTitleUpdates: 'agent' as any };
+      const parsedOverride = CodingPromptBehaviorOverrideV1Schema.parse(rawOverride);
+
+      const result = resolveCodingPromptBehaviorV1WithOverride({
+        settingsLike: settings,
+        override: parsedOverride,
+      });
+
+      expect(result.sessionTitleUpdates).toBe('ongoing');
+    });
+
+    it('v always global (override v ignored)', () => {
+      const settings = { codingPromptBehaviorV1: {} }; // global will be default with v=1
+      const override = { v: 999 as any, responseOptions: 'disabled' }; // override tries to set v
+
+      const result = resolveCodingPromptBehaviorV1WithOverride({
+        settingsLike: settings,
+        override,
+      });
+
+      // v should come from global (1), not override (999)
+      expect(result.v).toBe(1);
+      expect(result.responseOptions).toBe('disabled');
+    });
+
+    it('no override => returns global', () => {
+      const settings = { codingPromptBehaviorV1: { responseOptions: 'disabled' } };
+
+      const result = resolveCodingPromptBehaviorV1WithOverride({
+        settingsLike: settings,
+        override: undefined,
+      });
+
+      expect(result).toEqual({ v: 1, sessionTitleUpdates: 'ongoing', responseOptions: 'disabled' });
+    });
+
+    it('null override => returns global', () => {
+      const settings = { codingPromptBehaviorV1: {} };
+
+      const result = resolveCodingPromptBehaviorV1WithOverride({
+        settingsLike: settings,
+        override: null,
+      });
+
+      expect(result).toEqual(DEFAULT_CODING_PROMPT_BEHAVIOR_V1);
+    });
+  });
+
+  describe('applyCodingPromptBehaviorOverrideToSettings', () => {
+    it('no override => settings unchanged reference', () => {
+      const settings = { foo: 'bar' };
+      const result = applyCodingPromptBehaviorOverrideToSettings({
+        settings,
+        override: undefined,
+      });
+
+      expect(result).toBe(settings); // same reference
+    });
+
+    it('null override => settings unchanged reference', () => {
+      const settings = { foo: 'bar' };
+      const result = applyCodingPromptBehaviorOverrideToSettings({
+        settings,
+        override: null,
+      });
+
+      expect(result).toBe(settings); // same reference
+    });
+
+    it('with override => returns merged settings with codingPromptBehaviorV1', () => {
+      const settings = { foo: 'bar' };
+      const override = { responseOptions: 'disabled' };
+
+      const result = applyCodingPromptBehaviorOverrideToSettings({
+        settings,
+        override,
+      });
+
+      expect(result).not.toBe(settings); // new reference
+      expect(result).toEqual({
+        foo: 'bar',
+        codingPromptBehaviorV1: {
+          v: 1,
+          sessionTitleUpdates: 'ongoing',
+          responseOptions: 'disabled',
+        },
+      });
+    });
+
+    it('with empty override => returns new settings with resolved behavior', () => {
+      const settings = { foo: 'bar' };
+      const override = {}; // empty but present
+
+      const result = applyCodingPromptBehaviorOverrideToSettings({
+        settings,
+        override,
+      });
+
+      expect(result).not.toBe(settings);
+      expect(result.codingPromptBehaviorV1).toEqual(DEFAULT_CODING_PROMPT_BEHAVIOR_V1);
+    });
+
+    it('settings is null => returns empty object with resolved behavior', () => {
+      const override = { responseOptions: 'disabled' };
+
+      const result = applyCodingPromptBehaviorOverrideToSettings({
+        settings: null,
+        override,
+      });
+
+      expect(result).toEqual({
+        codingPromptBehaviorV1: {
+          v: 1,
+          sessionTitleUpdates: 'ongoing',
+          responseOptions: 'disabled',
+        },
+      });
+    });
+
+    it('settings is undefined => returns empty object with resolved behavior', () => {
+      const override = { responseOptions: 'disabled' };
+
+      const result = applyCodingPromptBehaviorOverrideToSettings({
+        settings: undefined,
+        override,
+      });
+
+      expect(result).toEqual({
+        codingPromptBehaviorV1: {
+          v: 1,
+          sessionTitleUpdates: 'ongoing',
+          responseOptions: 'disabled',
+        },
+      });
+    });
+  });
+
+  describe('CodingPromptBehaviorOverrideV1Schema', () => {
+    it('parses valid override with both fields', () => {
+      const input = { v: 1, sessionTitleUpdates: 'ongoing', responseOptions: 'disabled' };
+      const result = CodingPromptBehaviorOverrideV1Schema.parse(input);
+      expect(result).toEqual(input);
+    });
+
+    it('parses valid override with partial fields', () => {
+      const input = { responseOptions: 'disabled' };
+      const result = CodingPromptBehaviorOverrideV1Schema.parse(input);
+      expect(result).toEqual({ v: 1, responseOptions: 'disabled' });
+    });
+
+    it('malformed override becomes minimal object with v=1 via .catch({ v: 1 })', () => {
+      const input = { sessionTitleUpdates: 'bogus' as any };
+      const result = CodingPromptBehaviorOverrideV1Schema.parse(input);
+      expect(result).toEqual({ v: 1 });
+    });
+
+    it('accepts agent alias and folds to ongoing', () => {
+      const input = { sessionTitleUpdates: 'agent' as any };
+      const result = CodingPromptBehaviorOverrideV1Schema.parse(input);
+      expect(result.sessionTitleUpdates).toBe('ongoing');
+    });
+  });
+});

--- a/packages/protocol/src/prompts/codingPromptBehaviorV1.ts
+++ b/packages/protocol/src/prompts/codingPromptBehaviorV1.ts
@@ -46,3 +46,52 @@ export function isCodingPromptSessionTitleUpdatesEnabled(settingsLike: unknown):
 export function isCodingPromptResponseOptionsEnabled(settingsLike: unknown): boolean {
   return resolveCodingPromptBehaviorV1(settingsLike).responseOptions === 'agent';
 }
+
+// Override schema for per-profile overrides (partial, no field defaults)
+export const CodingPromptBehaviorOverrideV1Schema = z.object({
+  v: z.literal(1).default(1),
+  sessionTitleUpdates: CodingPromptSessionTitleUpdatesInputV1Schema.optional(),
+  responseOptions: CodingPromptBehaviorModeV1Schema.optional(),
+}).catch({ v: 1 });
+
+export type CodingPromptBehaviorOverrideV1 = z.infer<typeof CodingPromptBehaviorOverrideV1Schema>;
+
+// Merge resolver: global defaults; override fields win when set; v from global
+export function resolveCodingPromptBehaviorV1WithOverride(params: {
+  settingsLike: unknown;
+  override?: CodingPromptBehaviorOverrideV1 | null;
+}): CodingPromptBehaviorV1 {
+  const global = resolveCodingPromptBehaviorV1(params.settingsLike);
+  
+  if (!params.override) {
+    return global;
+  }
+
+  // Override is an object (could be minimal from .catch({ v: 1 }))
+  const overrideObj = params.override as Record<string, unknown> | null;
+  
+  // Build merged result: v always from global, other fields use override if set
+  return {
+    v: global.v,
+    sessionTitleUpdates: (overrideObj?.sessionTitleUpdates ?? global.sessionTitleUpdates) as CodingPromptSessionTitleUpdatesModeV1,
+    responseOptions: (overrideObj?.responseOptions ?? global.responseOptions) as CodingPromptBehaviorModeV1,
+  };
+}
+
+// Settings-record helper: returns { ...settings, codingPromptBehaviorV1: <resolved full object> }
+export function applyCodingPromptBehaviorOverrideToSettings(params: {
+  settings: Readonly<Record<string, unknown>> | null | undefined;
+  override?: CodingPromptBehaviorOverrideV1 | null;
+}): Record<string, unknown> {
+  if (!params.override) {
+    // No override => settings unchanged reference
+    return params.settings ?? {};
+  }
+
+  const resolved = resolveCodingPromptBehaviorV1WithOverride({
+    settingsLike: params.settings,
+    override: params.override,
+  });
+
+  return { ...params.settings, codingPromptBehaviorV1: resolved };
+}


### PR DESCRIPTION
## Summary

Adds per-profile overrides for the two coding system-prompt behavior knobs — **session title updates** and **response options** — with the account-level setting remaining the default. A profile can override either knob; any knob omitted from the profile inherits the global account default.

## Changes

- **protocol** (`packages/protocol`): new `CodingPromptBehaviorOverrideV1Schema` (partial — no per-field defaults, so omit = inherit global) nested as optional `codingPromptBehaviorV1` on `AIBackendProfileSchema`. Adds `resolveCodingPromptBehaviorV1WithOverride()` and `applyCodingPromptBehaviorOverrideToSettings()`. A malformed override is dropped via `.catch({ v: 1 })` so the profile itself stays valid.
- **cli** (`apps/cli`): `resolveEffectiveCodingPrompt.ts` resolves the selected profile by id (non-throwing) and merges its override over global settings when building the base coding prompt. Built-in / unknown / override-free profiles fall back to the global default — unchanged behavior.
- **ui** (`apps/ui`): `getProfileCodingPromptBehaviorOverride` (read) + `buildCodingPromptBehaviorOverrideV1` (save) helpers, and a profile-level "Coding prompt behavior" editor section with two dropdowns, each offering "Use system default" to inherit the account setting. i18n across en + 9 locales.

## Verification

- protocol: 1289 unit tests pass; build + typecheck clean.
- cli: 10 unit tests pass (3 new override tests, RED→GREEN); typecheck clean.
- ui: typecheck exit 0; ProfileEditForm suite 18/18 pass (4 existing render suites + 9 new helper tests).

## Notes

- Backward compatible: field optional, no migration, no account-settings version bump.
- Non-English locales use English baseline copy for the new keys; translation review is the only outstanding follow-up.

Draft — opening for early review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788001169&installation_model_id=20481&pr_number=215&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F215&signature=6c0f51aaf357c21ba92d746548419a31855cd2173f7c130794cc52ff61fbdff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-profile coding prompt behavior override for session title updates and response options
> - Adds `codingPromptBehaviorV1` as an optional field on backend profiles, allowing each profile to override session title update mode and response options mode independently of account-level defaults.
> - Introduces `CodingPromptBehaviorOverrideV1Schema`, `resolveCodingPromptBehaviorV1WithOverride`, and `applyCodingPromptBehaviorOverrideToSettings` in `@happier-dev/protocol` to validate, merge, and apply per-profile overrides.
> - Updates `resolveEffectiveCodingPromptPlan` in the CLI agent to read the active profile's override and apply it before building the base coding prompt plan.
> - Adds two dropdown controls to the profile edit form (`ProfileEditForm`) for selecting session title update mode and response options mode, initialized from the profile and included in dirty tracking and save payload.
> - Adds translation strings for the new settings section across all supported locales.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e669080. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->