### PR TITLE
fix(server): log afterTx callback failures

### DIFF
--- a/apps/server/sources/storage/inTx.spec.ts
+++ b/apps/server/sources/storage/inTx.spec.ts
@@ -110,6 +110,37 @@ describe("inTx", () => {
         );
     });
 
+    it("logs async afterTx callback rejections without an unhandled rejection", async () => {
+        restoreEnv(envSnapshot);
+        applyEnvValues({
+            HAPPY_DB_PROVIDER: undefined,
+            HAPPIER_DB_PROVIDER: undefined,
+        });
+
+        const failure = new Error("async fan-out failed");
+        const unhandled = vi.fn();
+        process.once("unhandledRejection", unhandled);
+        const { inTx, afterTx } = await import("./inTx");
+        const { warn } = await import("@/utils/logging/log");
+
+        const result = await inTx(async (tx) => {
+            afterTx(tx, async () => {
+                throw failure;
+            });
+            return 654;
+        });
+
+        expect(result).toBe(654);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledWith(
+            expect.objectContaining({ module: "inTx", error: failure }),
+            expect.any(String),
+        );
+        expect(unhandled).not.toHaveBeenCalled();
+        process.removeListener("unhandledRejection", unhandled);
+    });
+
     it("retries P2034 and eventually succeeds", async () => {
         restoreEnv(envSnapshot);
         applyEnvValues({

--- a/apps/server/sources/storage/inTx.spec.ts
+++ b/apps/server/sources/storage/inTx.spec.ts
@@ -13,6 +13,7 @@ installDbModuleMock({
 });
 
 vi.mock("@/utils/runtime/delay", () => ({ delay: delayMock }));
+vi.mock("@/utils/logging/log", () => ({ log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }));
 
 describe("inTx", () => {
     const envSnapshot = snapshotEnv();
@@ -77,6 +78,35 @@ describe("inTx", () => {
                 maxWait: 7000,
                 timeout: 12000,
             }),
+        );
+    });
+
+    it("logs afterTx callback failures and still runs remaining callbacks", async () => {
+        restoreEnv(envSnapshot);
+        applyEnvValues({
+            HAPPY_DB_PROVIDER: undefined,
+            HAPPIER_DB_PROVIDER: undefined,
+        });
+
+        const failure = new Error("fan-out failed");
+        const laterCallback = vi.fn();
+        const { inTx, afterTx } = await import("./inTx");
+        const { warn } = await import("@/utils/logging/log");
+
+        const result = await inTx(async (tx) => {
+            afterTx(tx, () => {
+                throw failure;
+            });
+            afterTx(tx, laterCallback);
+            return 321;
+        });
+
+        expect(result).toBe(321);
+        expect(laterCallback).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledWith(
+            expect.objectContaining({ module: "inTx", error: failure }),
+            expect.any(String),
         );
     });
 

--- a/apps/server/sources/storage/inTx.ts
+++ b/apps/server/sources/storage/inTx.ts
@@ -3,6 +3,7 @@ import { delay } from "@/utils/runtime/delay";
 import { db } from "@/storage/db";
 import { getDbProviderFromEnv, isPrismaErrorCode, type TransactionClient } from "@/storage/prisma";
 import { isRetryableSqliteWriteError } from "@/storage/sqliteRetryClassifier";
+import { warn } from "@/utils/logging/log";
 
 export type Tx = TransactionClient;
 
@@ -123,8 +124,10 @@ export async function inTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
             for (let callback of result.callbacks) {
                 try {
                     callback();
-                } catch {
-                    // Ignore callback failures; transactional result is already committed.
+                } catch (error) {
+                    // The transaction is already committed, so the failure must not propagate,
+                    // but a silent drop here loses post-commit fan-out (socket updates etc.).
+                    warn({ module: "inTx", error }, "afterTx callback failed after commit");
                 }
             }
             return result.result;

--- a/apps/server/sources/storage/inTx.ts
+++ b/apps/server/sources/storage/inTx.ts
@@ -90,13 +90,21 @@ export function isRetryableTransactionError(params: Readonly<{ provider: string;
     return false;
 }
 
-export function afterTx(tx: Tx, callback: () => void) {
+type AfterTxCallback = () => void | Promise<void>;
+
+function logAfterTxCallbackFailure(error: unknown) {
+    // The transaction is already committed, so the failure must not propagate,
+    // but a silent drop here loses post-commit fan-out (socket updates etc.).
+    warn({ module: "inTx", error }, "afterTx callback failed after commit");
+}
+
+export function afterTx(tx: Tx, callback: AfterTxCallback) {
     // Golden rule:
     // - Do NOT emit socket updates inside a DB transaction.
     // - Instead, schedule them with afterTx so they only fire after commit.
     //
     // `afterTx` is only valid for transactions created via `inTx()`.
-    const callbacks = (tx as any)[symbol] as (() => void)[] | undefined;
+    const callbacks = (tx as any)[symbol] as AfterTxCallback[] | undefined;
     if (!callbacks) {
         throw new Error('afterTx(tx, ...) called outside inTx() transaction');
     }
@@ -112,7 +120,7 @@ export async function inTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
     let wrapped = async (tx: Tx) => {
         (tx as any)[symbol] = [];
         let result = await fn(tx);
-        let callbacks = (tx as any)[symbol] as (() => void)[];
+        let callbacks = (tx as any)[symbol] as AfterTxCallback[];
         return { result, callbacks };
     }
     while (true) {
@@ -123,11 +131,14 @@ export async function inTx<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
             let result = await db.$transaction(wrapped, txOpts);
             for (let callback of result.callbacks) {
                 try {
-                    callback();
+                    // Callbacks stay fire-and-forget: async ones are not awaited, only
+                    // observed so their rejections are logged instead of going unhandled.
+                    const value = callback();
+                    if (value instanceof Promise) {
+                        value.catch(logAfterTxCallbackFailure);
+                    }
                 } catch (error) {
-                    // The transaction is already committed, so the failure must not propagate,
-                    // but a silent drop here loses post-commit fan-out (socket updates etc.).
-                    warn({ module: "inTx", error }, "afterTx callback failed after commit");
+                    logAfterTxCallbackFailure(error);
                 }
             }
             return result.result;


### PR DESCRIPTION
afterTx callbacks were swallowed by a bare catch in inTx, silently dropping post-commit fan-out such as socket updates; log them at warn, with a unit test covering the behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788033051&installation_model_id=20481&pr_number=216&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F216&signature=2ff1ead4376ddce964180f4d00c3f56c138b04f3c058998d3869da1b955b8554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log afterTx callback failures in `inTx` instead of silently ignoring them
> - Both sync throws and async rejections from `afterTx` callbacks are now caught and logged via `warn` with `{ module: 'inTx', error }` context.
> - Async rejections no longer cause unhandled promise rejections on the process; the `.catch` is attached without awaiting the callback.
> - Remaining callbacks continue to run after a failure.
> - `afterTx` now accepts `() => void | Promise<void>` callbacks at the type level.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3477e2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of errors from post-transaction (`afterTx`) callbacks so they no longer silently fail.
  * Ensured all remaining `afterTx` callbacks continue running even if one throws or rejects.
  * Added warning logs when `afterTx` callback execution fails, without affecting the already-completed transaction.

* **New Features**
  * Enabled `afterTx` callbacks to be asynchronous (support `Promise<void>`).

* **Tests**
  * Extended coverage for synchronous and async `afterTx` failure scenarios, including logging and rejection safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->