### PR TITLE
fix(cli): keep Claude server pending rows blocked during an active turn

### DIFF
--- a/apps/cli/src/agent/runtime/sessionInput/SessionProviderInputConsumer.test.ts
+++ b/apps/cli/src/agent/runtime/sessionInput/SessionProviderInputConsumer.test.ts
@@ -95,72 +95,25 @@ describe('SessionProviderInputConsumer drainPending', () => {
     expect(popPendingMessage).not.toHaveBeenCalled();
   });
 
-  it('passes the active-turn delivery policy into the drain preflight gate', async () => {
-    const shouldAttemptPendingMaterialization = vi.fn((
-      opts?: { activeTurnDeliveryPolicy?: 'block' | 'allow_live_delivery' },
-    ) => opts?.activeTurnDeliveryPolicy === 'allow_live_delivery');
-    const materializeNextPendingMessageSafely = vi
-      .fn<() => Promise<MaterializeNextPendingResult>>()
-      .mockResolvedValue({
-        type: 'materialized',
-        localId: 'local-live',
-        seq: 11,
-        content: null,
-      });
-
-    const consumer = createDrainConsumer(
-      {
-        popPendingMessage: vi.fn(async () => false),
-        materializeNextPendingMessageSafely,
-        shouldAttemptPendingMaterialization,
-        waitForMetadataUpdate: async () => false,
-      },
-      { activeTurnDeliveryPolicy: 'allow_live_delivery' },
-    );
-
-    await expect(consumer.drainPending?.({ reason: 'test-live-preflight' })).resolves.toEqual({
-      materialized: 1,
-      stoppedReason: 'max_pop_per_wake',
-    });
-    expect(shouldAttemptPendingMaterialization).toHaveBeenCalledWith({
-      activeTurnDeliveryPolicy: 'allow_live_delivery',
-    });
-    expect(materializeNextPendingMessageSafely).toHaveBeenCalledWith({
-      reconcileWhenEmpty: 'force',
-      activeTurnDeliveryPolicy: 'allow_live_delivery',
-    });
-  });
-
-  it('lets an explicit drain active-turn policy override a default resolver', async () => {
+  it('leaves active-turn delivery policy to the session client instead of overriding it per drain', async () => {
     const shouldAttemptPendingMaterialization = vi.fn(() => true);
     const materializeNextPendingMessageSafely = vi
       .fn<() => Promise<MaterializeNextPendingResult>>()
       .mockResolvedValue({ type: 'no_pending' });
 
-    const consumer = createDrainConsumer(
-      {
-        popPendingMessage: vi.fn(async () => false),
-        materializeNextPendingMessageSafely,
-        shouldAttemptPendingMaterialization,
-        waitForMetadataUpdate: async () => false,
-      },
-      { resolveActiveTurnDeliveryPolicy: () => 'allow_live_delivery' },
-    );
+    const consumer = createDrainConsumer({
+      popPendingMessage: vi.fn(async () => false),
+      materializeNextPendingMessageSafely,
+      shouldAttemptPendingMaterialization,
+      waitForMetadataUpdate: async () => false,
+    });
 
-    await expect(consumer.drainPending?.({
-      reason: 'test-explicit-block-over-default-resolver',
-      activeTurnDeliveryPolicy: 'block',
-    })).resolves.toEqual({
+    await expect(consumer.drainPending?.({ reason: 'test-no-policy-override' })).resolves.toEqual({
       materialized: 0,
       stoppedReason: 'no_pending',
     });
-    expect(shouldAttemptPendingMaterialization).toHaveBeenCalledWith({
-      activeTurnDeliveryPolicy: 'block',
-    });
-    expect(materializeNextPendingMessageSafely).toHaveBeenCalledWith({
-      reconcileWhenEmpty: 'force',
-      activeTurnDeliveryPolicy: 'block',
-    });
+    expect(shouldAttemptPendingMaterialization).toHaveBeenCalledWith();
+    expect(materializeNextPendingMessageSafely).toHaveBeenCalledWith({ reconcileWhenEmpty: 'force' });
   });
 
   it('returns an error result when reconciliation fails during drain', async () => {
@@ -232,7 +185,7 @@ describe('SessionProviderInputConsumer waitForNextInput', () => {
     expect(popPendingMessage).not.toHaveBeenCalled();
   });
 
-  it('logs text-free materialization decisions with delivery policy metadata', async () => {
+  it('logs text-free materialization decisions', async () => {
     const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
     const materializeNextPendingMessageSafely = vi
       .fn<() => Promise<MaterializeNextPendingResult>>()
@@ -250,7 +203,6 @@ describe('SessionProviderInputConsumer waitForNextInput', () => {
         materializeNextPendingMessageSafely,
         waitForMetadataUpdate: async () => false,
       },
-      activeTurnDeliveryPolicy: 'allow_live_delivery',
       reconcileWhenEmpty: 'skip',
       idleWakePollIntervalMs: 0,
     });
@@ -258,7 +210,6 @@ describe('SessionProviderInputConsumer waitForNextInput', () => {
     await expect(consumer.waitForNextInput({ abortSignal: new AbortController().signal })).resolves.toBeNull();
 
     expect(debugSpy).toHaveBeenCalledWith('[pendingQueue] input consumer materialization decision', {
-      activeTurnDeliveryPolicy: 'allow_live_delivery',
       localId: 'local-secret',
       reconcileWhenEmpty: 'skip',
       resultType: 'materialized',

--- a/apps/cli/src/agent/runtime/sessionInput/SessionProviderInputConsumer.ts
+++ b/apps/cli/src/agent/runtime/sessionInput/SessionProviderInputConsumer.ts
@@ -7,7 +7,6 @@ import type {
   DrainPendingOptions,
   DrainPendingResult,
   MessageBatch,
-  PendingMaterializationActiveTurnPolicy,
   PendingMaterializationReconcileWhenEmpty,
   PendingMaterializationResult,
   SessionProviderInputConsumer,
@@ -24,12 +23,9 @@ export class PendingQueueMaterializationAuthError extends Error {
 export interface SessionProviderInputConsumerSession {
   materializeNextPendingMessageSafely?: ((opts?: {
     reconcileWhenEmpty?: PendingMaterializationReconcileWhenEmpty;
-    activeTurnDeliveryPolicy?: PendingMaterializationActiveTurnPolicy;
   }) => Promise<PendingMaterializationResult>) | undefined;
   popPendingMessage: () => Promise<boolean>;
-  shouldAttemptPendingMaterialization?: ((opts?: {
-    activeTurnDeliveryPolicy?: PendingMaterializationActiveTurnPolicy;
-  }) => boolean) | undefined;
+  shouldAttemptPendingMaterialization?: (() => boolean) | undefined;
   reconcilePendingQueueState?: ((opts: { force: boolean }) => unknown | Promise<unknown>) | undefined;
   waitForMetadataUpdate: (abortSignal?: AbortSignal) => Promise<boolean>;
 }
@@ -39,44 +35,20 @@ export interface SessionProviderInputConsumerOptions<Mode, Message> {
   session: SessionProviderInputConsumerSession;
   onMetadataUpdate?: (() => void | Promise<void>) | null | undefined;
   reconcileWhenEmpty?: PendingMaterializationReconcileWhenEmpty | undefined;
-  activeTurnDeliveryPolicy?: PendingMaterializationActiveTurnPolicy | undefined;
-  resolveActiveTurnDeliveryPolicy?: (() => PendingMaterializationActiveTurnPolicy | undefined) | undefined;
   idleWakePollIntervalMs?: number | undefined;
   pendingDrainMaxPopPerWake?: number | undefined;
 }
 
 type WakeWinner = { kind: 'queue'; hasMessages: boolean } | { kind: 'meta'; ok: boolean } | { kind: 'idle' };
 
-function buildMaterializeOptions(
-  reconcileWhenEmpty: PendingMaterializationReconcileWhenEmpty,
-  activeTurnDeliveryPolicy: PendingMaterializationActiveTurnPolicy | undefined,
-): {
-  reconcileWhenEmpty: PendingMaterializationReconcileWhenEmpty;
-  activeTurnDeliveryPolicy?: PendingMaterializationActiveTurnPolicy;
-} {
-  return {
-    reconcileWhenEmpty,
-    ...(activeTurnDeliveryPolicy ? { activeTurnDeliveryPolicy } : {}),
-  };
-}
-
-function readActiveTurnDeliveryPolicy(opts: {
-  activeTurnDeliveryPolicy?: PendingMaterializationActiveTurnPolicy | undefined;
-  resolveActiveTurnDeliveryPolicy?: (() => PendingMaterializationActiveTurnPolicy | undefined) | undefined;
-}): PendingMaterializationActiveTurnPolicy | undefined {
-  return opts.resolveActiveTurnDeliveryPolicy?.() ?? opts.activeTurnDeliveryPolicy;
-}
-
 function logInputConsumerMaterializationDecision(opts: {
   source: 'waitForNextInput' | 'drainPending';
   reconcileWhenEmpty: PendingMaterializationReconcileWhenEmpty;
-  activeTurnDeliveryPolicy: PendingMaterializationActiveTurnPolicy | undefined;
   result: PendingMaterializationResult;
 }): void {
   logger.debug('[pendingQueue] input consumer materialization decision', {
     source: opts.source,
     reconcileWhenEmpty: opts.reconcileWhenEmpty,
-    activeTurnDeliveryPolicy: opts.activeTurnDeliveryPolicy ?? 'block',
     resultType: opts.result.type,
     ...(opts.result.type === 'materialized'
       ? {
@@ -99,8 +71,6 @@ export function createSessionProviderInputConsumer<Mode, Message>(
       return await drainPendingMessages(withDefaultDrainOptions(
         opts.session,
         opts.pendingDrainMaxPopPerWake,
-        opts.activeTurnDeliveryPolicy,
-        opts.resolveActiveTurnDeliveryPolicy,
         drainOpts,
       ));
     },
@@ -113,7 +83,7 @@ export function createSessionProviderPendingDrainAdapter(
 ): Pick<SessionProviderInputConsumer<never, never>, 'drainPending'> {
   return {
     async drainPending(drainOpts) {
-      return await drainPendingMessages(withDefaultDrainOptions(session, defaults?.maxPopPerWake, undefined, undefined, drainOpts));
+      return await drainPendingMessages(withDefaultDrainOptions(session, defaults?.maxPopPerWake, drainOpts));
     },
   };
 }
@@ -246,15 +216,10 @@ async function materializePendingMessage<Mode, Message>(
   const safeMaterialize = opts.session.materializeNextPendingMessageSafely;
   if (safeMaterialize) {
     const reconcileWhenEmpty = opts.reconcileWhenEmpty ?? 'skip';
-    const activeTurnDeliveryPolicy = readActiveTurnDeliveryPolicy(opts);
-    const result = await safeMaterialize(buildMaterializeOptions(
-      reconcileWhenEmpty,
-      activeTurnDeliveryPolicy,
-    ));
+    const result = await safeMaterialize({ reconcileWhenEmpty });
     logInputConsumerMaterializationDecision({
       source: 'waitForNextInput',
       reconcileWhenEmpty,
-      activeTurnDeliveryPolicy,
       result,
     });
     if (result.type === 'materialized') {
@@ -267,9 +232,7 @@ async function materializePendingMessage<Mode, Message>(
     return;
   }
 
-  if (!(opts.session.shouldAttemptPendingMaterialization?.({
-    activeTurnDeliveryPolicy: readActiveTurnDeliveryPolicy(opts),
-  }) ?? true)) {
+  if (!(opts.session.shouldAttemptPendingMaterialization?.() ?? true)) {
     return;
   }
 
@@ -279,19 +242,12 @@ async function materializePendingMessage<Mode, Message>(
 function withDefaultDrainOptions(
   session: SessionProviderInputConsumerSession,
   defaultMaxPopPerWake: number | undefined,
-  defaultActiveTurnDeliveryPolicy: PendingMaterializationActiveTurnPolicy | undefined,
-  defaultResolveActiveTurnDeliveryPolicy: (() => PendingMaterializationActiveTurnPolicy | undefined) | undefined,
   drainOpts: DrainPendingOptions | undefined,
 ): DrainPendingOptions & { session: SessionProviderInputConsumerSession } {
-  const drainPolicyOverride = drainOpts?.activeTurnDeliveryPolicy !== undefined;
-
   return {
     ...(drainOpts ?? {}),
     session,
     maxPopPerWake: drainOpts?.maxPopPerWake ?? defaultMaxPopPerWake,
-    activeTurnDeliveryPolicy: drainOpts?.activeTurnDeliveryPolicy ?? defaultActiveTurnDeliveryPolicy,
-    resolveActiveTurnDeliveryPolicy: drainOpts?.resolveActiveTurnDeliveryPolicy
-      ?? (drainPolicyOverride ? undefined : defaultResolveActiveTurnDeliveryPolicy),
   };
 }
 
@@ -310,15 +266,13 @@ async function drainPendingMessages(
         return { materialized, stoppedReason: 'drain_disallowed' };
       }
 
-      const activeTurnDeliveryPolicy = readActiveTurnDeliveryPolicy(opts);
-      const attemptOpts = { activeTurnDeliveryPolicy };
-      const canMaterialize = opts.session.shouldAttemptPendingMaterialization?.(attemptOpts) ?? true;
+      const canMaterialize = opts.session.shouldAttemptPendingMaterialization?.() ?? true;
       if (!canMaterialize) {
         await opts.session.reconcilePendingQueueState?.({ force: true });
         if (opts.abortSignal?.aborted) {
           return { materialized, stoppedReason: 'aborted' };
         }
-        if (!(opts.session.shouldAttemptPendingMaterialization?.(attemptOpts) ?? true)) {
+        if (!(opts.session.shouldAttemptPendingMaterialization?.() ?? true)) {
           return { materialized, stoppedReason: 'materialization_blocked' };
         }
       }
@@ -345,12 +299,10 @@ async function materializeNextPendingForDrain(
   if (safeMaterialize) {
     try {
       const reconcileWhenEmpty = 'force';
-      const activeTurnDeliveryPolicy = readActiveTurnDeliveryPolicy(opts);
-      const result = await safeMaterialize(buildMaterializeOptions(reconcileWhenEmpty, activeTurnDeliveryPolicy));
+      const result = await safeMaterialize({ reconcileWhenEmpty });
       logInputConsumerMaterializationDecision({
         source: 'drainPending',
         reconcileWhenEmpty,
-        activeTurnDeliveryPolicy,
         result,
       });
       if (result.type === 'materialized') {

--- a/apps/cli/src/agent/runtime/sessionInput/types.ts
+++ b/apps/cli/src/agent/runtime/sessionInput/types.ts
@@ -1,5 +1,4 @@
 import type { MaterializeNextPendingResult } from '@/api/session/sessionClientPort';
-import type { PendingMaterializationActiveTurnPolicy } from '@/api/session/pendingMaterializationActiveTurnPolicy';
 import type { PendingQueueReconcileWhenEmpty } from '@/api/session/pendingQueueReadPolicy';
 
 export type MessageBatch<Mode, Message> = {
@@ -22,7 +21,6 @@ export type MessageBatch<Mode, Message> = {
 };
 
 export type PendingMaterializationReconcileWhenEmpty = PendingQueueReconcileWhenEmpty;
-export type { PendingMaterializationActiveTurnPolicy };
 
 export type PendingMaterializationResult = MaterializeNextPendingResult;
 
@@ -42,8 +40,6 @@ export type DrainPendingOptions = {
   abortSignal?: AbortSignal | undefined;
   shouldContinue?: (() => boolean) | undefined;
   logPrefix?: string | undefined;
-  activeTurnDeliveryPolicy?: PendingMaterializationActiveTurnPolicy | undefined;
-  resolveActiveTurnDeliveryPolicy?: (() => PendingMaterializationActiveTurnPolicy | undefined) | undefined;
 };
 
 export type DrainPendingResult = {

--- a/apps/cli/src/backends/claude/claudeRemoteLauncher.integration.test.ts
+++ b/apps/cli/src/backends/claude/claudeRemoteLauncher.integration.test.ts
@@ -1591,7 +1591,6 @@ function createRemoteHarness(options?: {
     const consumerOptions = createSessionProviderInputConsumerSpy.mock.calls.at(-1)?.[0] as
       | SessionProviderInputConsumerOptions<EnhancedMode, string>
       | undefined;
-    expect(consumerOptions?.resolveActiveTurnDeliveryPolicy?.()).toBe('allow_live_delivery');
     expect(consumerOptions?.session.materializeNextPendingMessageSafely).toEqual(expect.any(Function));
 
     await expect(consumerOptions?.session.popPendingMessage()).resolves.toBe(true);

--- a/apps/cli/src/backends/claude/createClaudePendingAwareInputConsumer.test.ts
+++ b/apps/cli/src/backends/claude/createClaudePendingAwareInputConsumer.test.ts
@@ -1,68 +1,168 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { MessageQueue2 } from '@/agent/runtime/modeMessageQueue';
+import {
+  blocksPendingMaterializationDuringActiveTurn,
+  type PendingMaterializationActiveTurnPolicy,
+} from '@/api/session/pendingMaterializationActiveTurnPolicy';
+import type { MaterializeNextPendingResult } from '@/api/session/sessionClientPort';
 
 import { createClaudePendingAwareInputConsumer } from './createClaudePendingAwareInputConsumer';
 import type { EnhancedMode } from './loop';
 import type { Session } from './session';
 
+type PendingMaterializationCallOptions = {
+  activeTurnDeliveryPolicy?: PendingMaterializationActiveTurnPolicy;
+};
+
+/**
+ * Boundary fake for the session client. The active-turn gate defers to the canonical
+ * policy helper the real client uses (`sessionClient.isPendingMaterializationBlocked`)
+ * so the caller-supplied policy — not a re-implementation of it — decides the outcome.
+ */
 function createSessionHarness(accountSettings: Record<string, unknown> | null) {
-  const materializeNextPendingMessageSafely = vi.fn(async () => ({ type: 'no_pending' as const }));
+  const turn = { active: false };
+  const isMaterializationBlocked = (opts?: PendingMaterializationCallOptions) =>
+    turn.active && blocksPendingMaterializationDuringActiveTurn(opts?.activeTurnDeliveryPolicy);
+  const materializeNextPendingMessageSafely = vi.fn<(
+    opts?: PendingMaterializationCallOptions,
+  ) => Promise<MaterializeNextPendingResult>>(async () => ({ type: 'no_pending' }));
   const session = {
     queue: new MessageQueue2<EnhancedMode>(() => 'mode'),
     accountSettings,
     client: {
       materializeNextPendingMessageSafely,
       popPendingMessage: vi.fn(async () => false),
-      shouldAttemptPendingMaterialization: vi.fn(() => true),
+      shouldAttemptPendingMaterialization: vi.fn((opts?: PendingMaterializationCallOptions) =>
+        !isMaterializationBlocked(opts)),
       reconcilePendingQueueState: vi.fn(async () => false),
       waitForMetadataUpdate: vi.fn(async () => false),
     },
   } as unknown as Session;
 
-  return { session, materializeNextPendingMessageSafely };
+  return { session, materializeNextPendingMessageSafely, isMaterializationBlocked, turn };
 }
 
 describe('createClaudePendingAwareInputConsumer', () => {
-  it('allows active-turn materialization for Claude live steering by default', async () => {
-    const { session, materializeNextPendingMessageSafely } = createSessionHarness(null);
-
+  it.each([
+    { label: 'the account setting is missing', accountSettings: null },
+    {
+      label: 'busy steering uses immediate direct delivery',
+      accountSettings: { sessionBusySteerSendPolicy: 'steer_immediately' },
+    },
+    {
+      label: 'busy steering uses server pending',
+      accountSettings: { sessionBusySteerSendPolicy: 'server_pending' },
+    },
+  ])('holds server-pending rows until the active turn ends when $label', async ({ accountSettings }) => {
+    const { session, materializeNextPendingMessageSafely, turn } = createSessionHarness(accountSettings);
+    turn.active = true;
     const consumer = createClaudePendingAwareInputConsumer(session);
 
-    await consumer.drainPending({ reason: 'test-live-steer-default' });
+    await expect(consumer.drainPending({
+      reason: 'test-active-turn',
+    })).resolves.toEqual({
+      materialized: 0,
+      stoppedReason: 'materialization_blocked',
+    });
+    expect(materializeNextPendingMessageSafely).not.toHaveBeenCalled();
 
+    turn.active = false;
+    await expect(consumer.drainPending({
+      reason: 'test-turn-ended',
+    })).resolves.toEqual({
+      materialized: 0,
+      stoppedReason: 'no_pending',
+    });
     expect(materializeNextPendingMessageSafely).toHaveBeenCalledWith({
       reconcileWhenEmpty: 'force',
-      activeTurnDeliveryPolicy: 'allow_live_delivery',
     });
   });
 
-  it('allows active-turn materialization when busy steering is configured for immediate delivery', async () => {
-    const { session, materializeNextPendingMessageSafely } = createSessionHarness({
+  it('keeps waitForNextInput from materializing server pending until the active turn ends', async () => {
+    const {
+      session,
+      materializeNextPendingMessageSafely,
+      isMaterializationBlocked,
+      turn,
+    } = createSessionHarness({
       sessionBusySteerSendPolicy: 'steer_immediately',
     });
-
+    const pendingMode = {
+      permissionMode: 'default',
+      claudeUnifiedTerminalEnabled: true,
+    } as EnhancedMode;
+    turn.active = true;
+    let releaseMetadataUpdate: ((value: boolean) => void) | undefined;
+    session.client.waitForMetadataUpdate = vi.fn(() => new Promise<boolean>((resolve) => {
+      releaseMetadataUpdate = resolve;
+    }));
+    materializeNextPendingMessageSafely.mockImplementation(async (opts) => {
+      if (isMaterializationBlocked(opts)) {
+        return { type: 'no_pending' as const };
+      }
+      session.queue.push('server pending after turn', pendingMode);
+      return {
+        type: 'materialized' as const,
+        localId: 'pending-local-id',
+        seq: 42,
+        content: null,
+      };
+    });
     const consumer = createClaudePendingAwareInputConsumer(session);
+    const abortController = new AbortController();
+    let waitResolved = false;
 
-    await consumer.drainPending({ reason: 'test-live-steer-immediate' });
+    const inputPromise = consumer.waitForNextInput({
+      abortSignal: abortController.signal,
+    }).then((input) => {
+      waitResolved = true;
+      return input;
+    });
 
-    expect(materializeNextPendingMessageSafely).toHaveBeenCalledWith({
-      reconcileWhenEmpty: 'force',
-      activeTurnDeliveryPolicy: 'allow_live_delivery',
+    await vi.waitFor(() => {
+      expect(materializeNextPendingMessageSafely).toHaveBeenCalledTimes(1);
+      expect(releaseMetadataUpdate).toBeTypeOf('function');
+    });
+    expect(waitResolved).toBe(false);
+    expect(session.queue.size()).toBe(0);
+    expect(materializeNextPendingMessageSafely).toHaveBeenNthCalledWith(1, {
+      reconcileWhenEmpty: 'skip',
+    });
+
+    turn.active = false;
+    releaseMetadataUpdate?.(true);
+
+    await expect(inputPromise).resolves.toEqual(expect.objectContaining({
+      message: 'server pending after turn',
+      mode: pendingMode,
+    }));
+    expect(materializeNextPendingMessageSafely).toHaveBeenNthCalledWith(2, {
+      reconcileWhenEmpty: 'skip',
     });
   });
 
-  it('keeps the active-turn block when busy steering is configured as server pending', async () => {
-    const { session, materializeNextPendingMessageSafely } = createSessionHarness({
-      sessionBusySteerSendPolicy: 'server_pending',
+  it('still delivers direct-steer messages from the local queue while a turn is active', async () => {
+    const { session, materializeNextPendingMessageSafely, turn } = createSessionHarness({
+      sessionBusySteerSendPolicy: 'steer_immediately',
     });
+    const mode = {
+      permissionMode: 'default',
+      claudeUnifiedTerminalEnabled: true,
+    } as EnhancedMode;
+    // The active-turn hold applies to daemon-owned pending rows only: "steer immediately"
+    // sends arrive on this local queue and must still reach the running turn.
+    turn.active = true;
+    session.queue.push('steer the active turn', mode);
 
     const consumer = createClaudePendingAwareInputConsumer(session);
 
-    await consumer.drainPending({ reason: 'test-server-pending' });
-
-    expect(materializeNextPendingMessageSafely).toHaveBeenCalledWith({
-      reconcileWhenEmpty: 'force',
-    });
+    await expect(consumer.waitForNextInput({
+      abortSignal: new AbortController().signal,
+    })).resolves.toEqual(expect.objectContaining({
+      message: 'steer the active turn',
+      mode,
+    }));
+    expect(materializeNextPendingMessageSafely).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/backends/claude/createClaudePendingAwareInputConsumer.ts
+++ b/apps/cli/src/backends/claude/createClaudePendingAwareInputConsumer.ts
@@ -1,20 +1,9 @@
 import { createSessionProviderInputConsumer } from '@/agent/runtime/sessionInput/SessionProviderInputConsumer';
-import type {
-    PendingMaterializationActiveTurnPolicy,
-    SessionProviderInputConsumer,
-} from '@/agent/runtime/sessionInput/types';
+import type { SessionProviderInputConsumer } from '@/agent/runtime/sessionInput/types';
 import { resolveSessionPendingQueueMaxPopPerWake } from '@/agent/runtime/sessionInput/pendingQueueDrainPolicy';
 
 import type { EnhancedMode } from './loop';
 import type { Session } from './session';
-
-function resolveClaudePendingActiveTurnDeliveryPolicy(
-    accountSettings: Session['accountSettings'],
-): PendingMaterializationActiveTurnPolicy | undefined {
-    return accountSettings?.sessionBusySteerSendPolicy === 'server_pending'
-        ? undefined
-        : 'allow_live_delivery';
-}
 
 /**
  * Canonical Claude session input consumer: local agent queue + daemon-owned
@@ -39,6 +28,11 @@ export function createClaudePendingAwareInputConsumer(
             ? session.client.materializeNextPendingMessageSafely.bind(session.client)
             : null;
 
+    // Daemon-owned pending rows must keep the shared consumer's default
+    // active-turn block. "Steer immediately" belongs to the explicit UI
+    // send-now path, which writes to this local queue directly; applying that
+    // setting here would consume ordinary pending rows before they can still
+    // be edited or deleted.
     return createSessionProviderInputConsumer<EnhancedMode, string>({
         messageQueue: session.queue,
         session: {
@@ -59,16 +53,15 @@ export function createClaudePendingAwareInputConsumer(
                 }
                 return (await materializeNextPendingMessageSafely({ reconcileWhenEmpty: 'force' })).type === 'materialized';
             },
-            shouldAttemptPendingMaterialization: (attemptOpts) =>
+            shouldAttemptPendingMaterialization: () =>
                 session.queue.size() <= 0
-                && (session.client.shouldAttemptPendingMaterialization?.(attemptOpts) ?? true),
+                && (session.client.shouldAttemptPendingMaterialization?.() ?? true),
             reconcilePendingQueueState: async (reconcileOpts) => {
                 await session.client.reconcilePendingQueueState?.(reconcileOpts);
             },
             waitForMetadataUpdate: (signal) => session.client.waitForMetadataUpdate(signal),
         },
         pendingDrainMaxPopPerWake: resolveSessionPendingQueueMaxPopPerWake(session.accountSettings ?? null),
-        resolveActiveTurnDeliveryPolicy: () => resolveClaudePendingActiveTurnDeliveryPolicy(session.accountSettings),
         ...(opts?.onMetadataUpdate ? { onMetadataUpdate: opts.onMetadataUpdate } : {}),
     });
 }

--- a/apps/cli/src/backends/claude/unifiedTerminal/claudeUnifiedTerminalLauncher.test.ts
+++ b/apps/cli/src/backends/claude/unifiedTerminal/claudeUnifiedTerminalLauncher.test.ts
@@ -1176,7 +1176,6 @@ describe('claudeUnifiedTerminalLauncher', () => {
 
     expect(materializeNextPendingMessageSafely).toHaveBeenCalledWith({
       reconcileWhenEmpty: 'skip',
-      activeTurnDeliveryPolicy: 'allow_live_delivery',
     });
   });
 


### PR DESCRIPTION
Fixes the behavior reported in #217.

## Problem

`createClaudePendingAwareInputConsumer` mapped the UI setting `sessionBusySteerSendPolicy`
onto the CLI-side pending-materialization policy, passing `allow_live_delivery` whenever the
setting was anything other than `server_pending` — including when unset, since the UI default
is `steer_immediately`. Daemon-owned **server pending rows** were therefore materialized into a
turn that was already running.

That mapping conflates two different delivery paths. "Steer immediately" never reaches the CLI
through the pending queue: the UI delivery decision
(`apps/ui/sources/sync/domains/session/control/submitMode.ts:413-463`) routes it to
`mode: 'agent_queue'` with reason `busy_steer_immediate`, which writes to the CLI's **local**
queue. Server pending rows are produced only when the UI decided *not* to steer — non-steerable
payload while busy, local terminal control, busy + `server_pending` policy, offline, agent not
ready, or an explicit pending intent.

Delivering those rows mid-turn contradicts the reason they were queued, and consumes messages
the user can still edit or delete (`sync.updatePendingMessage`, `deletePendingMessageV2`).

## What changed

1. Claude keeps the shared consumer's default active-turn block, matching Codex.
2. With the override gone, nothing in production passes `activeTurnDeliveryPolicy` /
   `resolveActiveTurnDeliveryPolicy` into `createSessionProviderInputConsumer`, so the option
   pair, `readActiveTurnDeliveryPolicy`, `buildMaterializeOptions`, the `DrainPendingOptions`
   fields and the per-drain override branch are removed as dead configuration.
3. The `activeTurnDeliveryPolicy` primitive on `sessionClient` is **left in place** — it now has
   no production caller either, but whether to keep it as a seam is your call, so I did not touch
   that layer.

## Behavior change to be aware of

A pending row queued while the session was offline or not ready is now delivered after the
current turn ends rather than mid-turn. Delayed, not dropped — assuming the turn-end drain
trigger fires, which is exactly the path #213 shows can wedge. Worth weighing before merging.

## How to test

```
yarn workspace @happier-dev/cli typecheck
cd apps/cli && npx vitest run --config vitest.config.ts \
  src/backends/claude/createClaudePendingAwareInputConsumer.test.ts \
  src/agent/runtime/sessionInput/SessionProviderInputConsumer.test.ts
npx vitest run --config vitest.integration.config.ts \
  src/backends/claude/claudeRemoteLauncher.integration.test.ts
```

## What I ran

- `tsc --noEmit` for `@happier-dev/cli` — clean
- RED confirmed first: the new tests fail against unmodified `dev` (5 failures) in a detached
  worktree, then pass with this change
- `createClaudePendingAwareInputConsumer` + `SessionProviderInputConsumer` +
  `sessionClient.pendingTurnEndDrain` + `claudeUnifiedTerminalLauncher` unit tests — pass
- `claudeRemoteLauncher.integration` + `runCodex.acpResumePreflight.integration` — 127 pass
- CLI import-cycle guard — pass
- Full CLI unit lane — 27 failures, but the identical 27 fail on unmodified `dev` on this machine
  (git-worktree probing, api, daemon takeover, file watcher); the failing-test list is
  byte-identical with and without this change
- No e2e coverage exists for this path (`packages/tests/suites` has no busy-steer /
  live-delivery case)

Branched from `82aa106`, one commit behind `dev` at the time of writing; `de36d87` does not touch
any file in this diff.

## AI-assisted contribution disclosure

Written with Claude Code. I was reading the Claude pending-queue path for an unrelated reason
(the input-loop stall in #213) and asked it to check whether the `sessionBusySteerSendPolicy` →
`allow_live_delivery` mapping was sound; the UI-side delivery decision above is what convinced me
it isn't. I asked for the root-cause fix rather than a workaround, for test-first with an observed
RED, and for a baseline run of the failing tests on unmodified `dev` before claiming anything
passed. The numbers above are from runs I had it perform and report.

Happy to drop this or split the dead-config cleanup into a separate PR if you prefer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788131227&installation_model_id=20481&pr_number=218&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F218&signature=54931d5b877fbe01204d443e82dacd0e7ea7f743c03de76a08419d4640cb6ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block Claude server pending rows during active turns by deferring policy to session client
> - Removes `resolveActiveTurnDeliveryPolicy` and `activeTurnDeliveryPolicy` from `DrainPendingOptions`, `SessionProviderInputConsumer`, and related helpers so active-turn gating is no longer driven by the consumer layer.
> - The Claude-specific consumer in [`createClaudePendingAwareInputConsumer.ts`](https://github.com/happier-dev/happier/pull/218/files#diff-2a04696df408317489eedb169c8903d19aa161279a2e16ddaa23660b4797e024) previously forced `allow_live_delivery`, allowing server-pending rows to materialize mid-turn; it now defers blocking to the session client's `shouldAttemptPendingMaterialization`.
> - `drainPendingMessages`, `materializePendingMessage`, and `materializeNextPendingForDrain` are simplified to call the preflight gate and safe materializer with no active-turn options.
> - Behavioral Change: server-pending rows are now held during an active turn; only direct steering via the local queue proceeds while a turn is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized faa1806.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of queued input during active turns.
  * Ensured locally queued direct messages continue to deliver without prematurely materializing deferred messages.
  * Improved queue reconciliation when pending input is temporarily blocked.

* **Tests**
  * Expanded coverage for active-turn behavior, deferred delivery, asynchronous input waiting, and sensitive-content logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->