### PR TITLE
build(docker): slim relay-server image by pruning unused artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -370,11 +370,18 @@ RUN set -eux; \
       --pubkey /tmp/happier-release.pub; \
     rm -rf /opt/happier/server/ui-web; \
     rm -rf /opt/happier/server/generated/mysql-client; \
-    find /opt/happier/server/generated/sqlite-client -name '*.node' \
-        ! -name "libquery_engine-debian-openssl-3.0.x.so.node" \
-        ! -name "libquery_engine-linux-arm64-openssl-3.0.x.so.node" -delete; \
-    rm -rf /opt/happier/server/node_modules/@img/sharp-libvips-linuxmusl-x64 \
-           /opt/happier/server/node_modules/@img/sharp-linuxmusl-x64
+    case "$TARGETARCH" in \
+      amd64) \
+        find /opt/happier/server/generated/sqlite-client -name '*.node' \
+            ! -name "libquery_engine-debian-openssl-3.0.x.so.node" -delete; \
+        rm -rf /opt/happier/server/node_modules/@img/sharp-libvips-linuxmusl-x64 \
+               /opt/happier/server/node_modules/@img/sharp-linuxmusl-x64 ;; \
+      arm64) \
+        find /opt/happier/server/generated/sqlite-client -name '*.node' \
+            ! -name "libquery_engine-linux-arm64-openssl-3.0.x.so.node" -delete; \
+        rm -rf /opt/happier/server/node_modules/@img/sharp-libvips-linuxmusl-arm64 \
+               /opt/happier/server/node_modules/@img/sharp-linuxmusl-arm64 ;; \
+    esac
 
 FROM debian:12-slim AS relay-server
 WORKDIR /opt/happier/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -367,7 +367,14 @@ RUN set -eux; \
       --os web \
       --arch any \
       --dest /opt/happier/ui-web \
-      --pubkey /tmp/happier-release.pub
+      --pubkey /tmp/happier-release.pub; \
+    rm -rf /opt/happier/server/ui-web; \
+    rm -rf /opt/happier/server/generated/mysql-client; \
+    find /opt/happier/server/generated/sqlite-client -name '*.node' \
+        ! -name "libquery_engine-debian-openssl-3.0.x.so.node" \
+        ! -name "libquery_engine-linux-arm64-openssl-3.0.x.so.node" -delete; \
+    rm -rf /opt/happier/server/node_modules/@img/sharp-libvips-linuxmusl-x64 \
+           /opt/happier/server/node_modules/@img/sharp-linuxmusl-x64
 
 FROM debian:12-slim AS relay-server
 WORKDIR /opt/happier/server


### PR DESCRIPTION
## Summary

The `relay-artifacts` fetch stage downloads the server tarball and UI bundle but doesn't strip content that is unused in the relay image, resulting in a significantly larger image than necessary.

This PR adds four pruning steps at the end of the `relay-artifacts` RUN block:

- **Bundled `ui-web`** (`rm -rf .../server/ui-web`) — the server tarball includes a `ui-web` bundle, but the relay image fetches UI separately via the dedicated `happier-ui-web` artifact anyway. The copy inside the server tarball is redundant.
- **MySQL Prisma client** (`rm -rf .../generated/mysql-client`) — the relay image uses SQLite only (`HAPPIER_DB_PROVIDER=sqlite`). The MySQL query engine is dead weight.
- **Redundant platform Prisma `.node` files** — the server ships query engine binaries for multiple platforms. Only the `debian-openssl-3.0.x` variant is used at runtime on the `debian:12-slim` base. All others are deleted.
- **musl Sharp libs** (`@img/sharp-libvips-linuxmusl-x64`, `@img/sharp-linuxmusl-x64`) — Alpine/musl targets, unused on Debian/glibc.

## Size impact

Server layer (same version, amd64):

| Image | Server layer (uncompressed) |
|---|---|
| Before (official `dev`) | 659 MB |
| After (this PR) | 336 MB |

**~323 MB reduction** on the server layer. Compressed registry size reduces proportionally.

## Test plan

- [ ] Build `relay-server` target locally and confirm server starts and reaches `Ready`
- [ ] Verify SQLite DB is created and migrations apply on first boot
- [ ] Confirm layer sizes with `docker history`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788260579&installation_model_id=20481&pr_number=219&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F219&signature=e6cacf077627f4af53b5ff8dfa7d61509d8d514b18a773ea6718cab9b055b682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Slim relay-server Docker image by removing unused artifacts and architecture-specific binaries
> - Deletes `server/ui-web` and `server/generated/mysql-client` from the relay artifacts build step.
> - Uses `TARGETARCH` to retain only the matching Prisma SQLite `.node` engine (`debian-openssl-3.0.x` on amd64, `linux-arm64-openssl-3.0.x` on arm64) and removes the others.
> - Removes musl-targeted sharp native packages from `node_modules` for the target architecture.
> - Behavioral Change: The relay-server image now ships fewer native binaries and no MySQL client assets compared to previous builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d91f2f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of relay artifact downloads by ensuring UI artifact retrieval completes cleanly.
  * Reduced downloaded server artifact size by removing unused UI files, database clients, unsupported SQLite binaries, and unnecessary architecture-specific packages.
  * Improved portability by ensuring artifacts contain only the required runtime components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->