### PR TITLE
fix(server-version): drop the stale store version floor from /v1/version

### DIFF
--- a/apps/server/sources/app/api/routes/version/versionRoutes.post.spec.ts
+++ b/apps/server/sources/app/api/routes/version/versionRoutes.post.spec.ts
@@ -10,7 +10,7 @@ describe('versionRoutes POST /v1/version', () => {
         vi.unstubAllEnvs();
     });
 
-    async function invokeRaw(body: Record<string, unknown>) {
+    async function invokeWithStatus(body: Record<string, unknown>) {
         const { versionRoutes } = await import('./versionRoutes');
         const route = createRouteTestBuilder({
             method: 'POST',
@@ -19,8 +19,12 @@ describe('versionRoutes POST /v1/version', () => {
                 versionRoutes(app as never);
             },
         });
-        const { response } = await route.invoke({ body });
-        return response;
+        const { reply, response } = await route.invoke({ body });
+        return { statusCode: reply.statusCode as number, response };
+    }
+
+    async function invokeRaw(body: Record<string, unknown>) {
+        return (await invokeWithStatus(body)).response;
     }
 
     async function invoke(body: Record<string, unknown>) {
@@ -136,6 +140,50 @@ describe('versionRoutes POST /v1/version', () => {
             update_required: false,
             update_url: null,
         });
+    });
+
+    it('refuses to answer when enforcement is required and the configured minimums are unusable', async () => {
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__ENFORCEMENT', 'required');
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_PROTOCOL_VERSION', '2');
+        // '1.2' is not comparable semver, so the whole policy resolves as invalid.
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_VERSIONS_JSON', '{"ui-ios":"1.2"}');
+
+        await expect(invokeWithStatus({
+            v: 1,
+            clientKind: 'ui-ios',
+            appVersion: '0.2.10',
+            appId: 'dev.happier.app',
+        })).resolves.toEqual({
+            statusCode: 500,
+            response: { error: 'compatibility_policy_invalid' },
+        });
+    });
+
+    it('refuses to answer a legacy check when enforcement is required and the policy is unusable', async () => {
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__ENFORCEMENT', 'required');
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_PROTOCOL_VERSION', '2');
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_VERSIONS_JSON', '{"ui-ios":"1.2"}');
+
+        await expect(invokeWithStatus({
+            platform: 'ios',
+            version: '0.2.10',
+            app_id: 'dev.happier.app',
+        })).resolves.toEqual({
+            statusCode: 500,
+            response: { error: 'compatibility_policy_invalid' },
+        });
+    });
+
+    it('reports current when an unusable policy is only observed', async () => {
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__ENFORCEMENT', 'observe');
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_VERSIONS_JSON', '{"ui-ios":"1.2"}');
+
+        await expect(invoke({
+            v: 1,
+            clientKind: 'ui-ios',
+            appVersion: '0.2.10',
+            appId: 'dev.happier.app',
+        })).resolves.toEqual({ v: 1, status: 'current' });
     });
 
     it('reports a legacy required upgrade from the configured compatibility minimum', async () => {

--- a/apps/server/sources/app/api/routes/version/versionRoutes.post.spec.ts
+++ b/apps/server/sources/app/api/routes/version/versionRoutes.post.spec.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ClientVersionCheckResponseV1Schema } from '@happier-dev/protocol';
 import { createRouteTestBuilder } from '../../testkit/routeTestBuilder';
 
+const APP_STORE_URL = 'https://apps.apple.com/us/app/happier-claude-codex-opencode/id6758537388';
+
 describe('versionRoutes POST /v1/version', () => {
     afterEach(() => {
         vi.unstubAllEnvs();
@@ -25,72 +27,127 @@ describe('versionRoutes POST /v1/version', () => {
         return ClientVersionCheckResponseV1Schema.parse(await invokeRaw(body));
     }
 
-    it('returns the protocol-owned current response for a supported native app', async () => {
+    function stubCompatibilityMinimums(minimums: Record<string, string>) {
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__ENFORCEMENT', 'required');
+        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_PROTOCOL_VERSION', '2');
+        vi.stubEnv(
+            'HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_VERSIONS_JSON',
+            JSON.stringify(minimums),
+        );
+    }
+
+    it('reports a store-channel iOS build on the shipped version line as current', async () => {
         await expect(invoke({
             v: 1,
             clientKind: 'ui-ios',
-            appVersion: '1.4.1',
-            releaseChannel: 'stable',
+            appVersion: '0.2.10',
+            releaseChannel: 'production',
             appId: 'dev.happier.app',
         })).resolves.toEqual({ v: 1, status: 'current' });
     });
 
-    it('returns a non-dismissible protocol-owned required upgrade for an old iOS app', async () => {
-        await expect(invoke({
-            v: 1,
-            clientKind: 'ui-ios',
-            appVersion: '1.3.0',
-            appId: 'dev.happier.app',
-        })).resolves.toEqual({
-            v: 1,
-            status: 'upgrade-required',
-            minimumAppVersion: '1.4.1',
-            updateUrl: 'https://apps.apple.com/us/app/happier-claude-codex-opencode/id6758537388',
-        });
-    });
-
-    it('keeps required upgrade truthful when no safe Android update URL is configured', async () => {
+    it('reports a development-channel build as current', async () => {
         await expect(invoke({
             v: 1,
             clientKind: 'ui-android',
-            appVersion: '1.0.0',
+            appVersion: '0.2.10',
+            releaseChannel: 'dev',
+            appId: 'dev.happier.app.publicdev',
+        })).resolves.toEqual({ v: 1, status: 'current' });
+    });
+
+    it('requires an upgrade from the configured compatibility minimum and links iOS to the App Store', async () => {
+        stubCompatibilityMinimums({ 'ui-ios': '0.3.0' });
+
+        await expect(invoke({
+            v: 1,
+            clientKind: 'ui-ios',
+            appVersion: '0.2.10',
+            releaseChannel: 'production',
             appId: 'dev.happier.app',
         })).resolves.toEqual({
             v: 1,
             status: 'upgrade-required',
-            minimumAppVersion: '1.4.1',
+            minimumAppVersion: '0.3.0',
+            updateUrl: APP_STORE_URL,
+        });
+    });
+
+    it('keeps the required upgrade truthful when no safe Android update URL is configured', async () => {
+        stubCompatibilityMinimums({ 'ui-android': '0.3.0' });
+
+        await expect(invoke({
+            v: 1,
+            clientKind: 'ui-android',
+            appVersion: '0.2.10',
+            releaseChannel: 'production',
+            appId: 'dev.happier.app',
+        })).resolves.toEqual({
+            v: 1,
+            status: 'upgrade-required',
+            minimumAppVersion: '0.3.0',
             updateUrl: null,
         });
     });
 
-    it('keeps the deployed native request/response shape working during the compatibility rollout', async () => {
-        await expect(invokeRaw({
-            platform: 'ios',
-            version: '1.3.0',
-            app_id: 'dev.happier.app',
+    it('applies the configured compatibility minimum to a development-channel build', async () => {
+        stubCompatibilityMinimums({ 'ui-android': '0.3.0' });
+
+        await expect(invoke({
+            v: 1,
+            clientKind: 'ui-android',
+            appVersion: '0.2.10',
+            releaseChannel: 'dev',
+            appId: 'dev.happier.app.publicdev',
         })).resolves.toEqual({
-            update_required: true,
-            update_url: 'https://apps.apple.com/us/app/happier-claude-codex-opencode/id6758537388',
+            v: 1,
+            status: 'upgrade-required',
+            minimumAppVersion: '0.3.0',
+            updateUrl: null,
         });
     });
 
-    it('uses the central compatibility minimum when it is stricter than the distribution floor', async () => {
-        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__ENFORCEMENT', 'required');
-        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_PROTOCOL_VERSION', '2');
-        vi.stubEnv('HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_VERSIONS_JSON', JSON.stringify({
-            'ui-ios': '1.5.0',
-        }));
+    it('prefers a configured upgrade URL over the built-in App Store link', async () => {
+        stubCompatibilityMinimums({ 'ui-ios': '0.3.0' });
+        vi.stubEnv(
+            'HAPPIER_SESSION_SYNC_COMPATIBILITY__UPGRADE_URLS_JSON',
+            JSON.stringify({ 'ui-ios': 'https://happier.dev/upgrade' }),
+        );
 
         await expect(invoke({
             v: 1,
             clientKind: 'ui-ios',
-            appVersion: '1.4.1',
+            appVersion: '0.2.10',
             appId: 'dev.happier.app',
         })).resolves.toEqual({
             v: 1,
             status: 'upgrade-required',
-            minimumAppVersion: '1.5.0',
-            updateUrl: 'https://apps.apple.com/us/app/happier-claude-codex-opencode/id6758537388',
+            minimumAppVersion: '0.3.0',
+            updateUrl: 'https://happier.dev/upgrade',
+        });
+    });
+
+    it('keeps the deployed legacy native request/response shape working', async () => {
+        await expect(invokeRaw({
+            platform: 'ios',
+            version: '0.2.10',
+            app_id: 'dev.happier.app',
+        })).resolves.toEqual({
+            update_required: false,
+            update_url: null,
+        });
+    });
+
+    it('reports a legacy required upgrade from the configured compatibility minimum', async () => {
+        stubCompatibilityMinimums({ 'ui-ios': '0.3.0' });
+
+        await expect(invokeRaw({
+            platform: 'ios',
+            version: '0.2.10',
+            app_id: 'dev.happier.app',
+        })).resolves.toEqual({
+            update_required: true,
+            update_url: APP_STORE_URL,
         });
     });
 });

--- a/apps/server/sources/app/api/routes/version/versionRoutes.ts
+++ b/apps/server/sources/app/api/routes/version/versionRoutes.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { type Fastify } from "../../types";
-import { ANDROID_UP_TO_DATE, IOS_UP_TO_DATE } from "@/versions";
 import {
     ClientVersionCheckRequestV1Schema,
     ClientVersionCheckResponseV1Schema,
@@ -8,6 +7,8 @@ import {
 import { resolveSessionSyncCompatibilityPolicy } from '@/app/clientCompatibility/policy';
 import { resolveClientVersionDecision } from '@/app/clientCompatibility/versionDecision';
 
+// Upgrade destination, not an upgrade floor: the minimum version comes solely
+// from the session-sync compatibility policy.
 const IOS_UPDATE_URL = 'https://apps.apple.com/us/app/happier-claude-codex-opencode/id6758537388';
 
 const LegacyClientVersionCheckRequestSchema = z.object({
@@ -48,12 +49,10 @@ export function versionRoutes(app: Fastify) {
             if (platform !== 'ios' && platform !== 'android') {
                 return { update_required: false, update_url: null };
             }
-            const range = platform === 'ios' ? IOS_UP_TO_DATE : ANDROID_UP_TO_DATE;
             const decision = resolveClientVersionDecision({
                 clientKind: platform === 'ios' ? 'ui-ios' : 'ui-android',
                 appVersion: request.body.version,
                 policy,
-                distributionSupportedRange: range,
                 distributionUpdateUrl: platform === 'ios' ? IOS_UPDATE_URL : null,
             });
             return {
@@ -62,16 +61,10 @@ export function versionRoutes(app: Fastify) {
             };
         }
         const { clientKind, appVersion } = request.body;
-        const nativeRange = clientKind === 'ui-ios'
-            ? IOS_UP_TO_DATE
-            : clientKind === 'ui-android'
-                ? ANDROID_UP_TO_DATE
-                : undefined;
         return resolveClientVersionDecision({
             clientKind,
             appVersion,
             policy,
-            ...(nativeRange === undefined ? null : { distributionSupportedRange: nativeRange }),
             ...(clientKind === 'ui-ios' ? { distributionUpdateUrl: IOS_UPDATE_URL } : null),
         });
     });

--- a/apps/server/sources/app/api/routes/version/versionRoutes.ts
+++ b/apps/server/sources/app/api/routes/version/versionRoutes.ts
@@ -11,6 +11,8 @@ import { resolveClientVersionDecision } from '@/app/clientCompatibility/versionD
 // from the session-sync compatibility policy.
 const IOS_UPDATE_URL = 'https://apps.apple.com/us/app/happier-claude-codex-opencode/id6758537388';
 
+const POLICY_INVALID_ERROR = 'compatibility_policy_invalid' as const;
+
 const LegacyClientVersionCheckRequestSchema = z.object({
     platform: z.string(),
     version: z.string(),
@@ -46,10 +48,17 @@ export function versionRoutes(app: Fastify) {
             body: z.union([ClientVersionCheckRequestV1Schema, LegacyClientVersionCheckRequestSchema]),
             response: {
                 200: z.union([ClientVersionCheckResponseV1Schema, LegacyClientVersionCheckResponseSchema]),
+                500: z.object({ error: z.literal(POLICY_INVALID_ERROR) }),
             }
         }
-    }, async (request) => {
+    }, async (request, reply) => {
         const policy = resolveSessionSyncCompatibilityPolicy(process.env);
+        // The operator asked for enforcement but the policy could not be read, so
+        // no minimum is available. Answering `current` would silently under-report
+        // a required upgrade, so refuse rather than assert an unverified claim.
+        if (!policy.valid && policy.requestedEnforcement === 'required') {
+            return reply.code(500).send({ error: POLICY_INVALID_ERROR });
+        }
         if (!('v' in request.body)) {
             const platform = request.body.platform.toLowerCase();
             if (platform !== 'ios' && platform !== 'android') {

--- a/apps/server/sources/app/api/routes/version/versionRoutes.ts
+++ b/apps/server/sources/app/api/routes/version/versionRoutes.ts
@@ -22,6 +22,12 @@ const LegacyClientVersionCheckResponseSchema = z.object({
     update_url: z.string().nullable(),
 }).strict();
 
+/**
+ * Registers the client version endpoints: a `GET` reachability probe and a
+ * `POST` upgrade check accepting both the v1 protocol body and the legacy
+ * `{ platform, version, app_id }` shape still sent by deployed native builds.
+ * Both bodies resolve through the same compatibility-policy decision.
+ */
 export function versionRoutes(app: Fastify) {
     app.get('/v1/version', {
         schema: {

--- a/apps/server/sources/app/clientCompatibility/versionDecision.ts
+++ b/apps/server/sources/app/clientCompatibility/versionDecision.ts
@@ -10,26 +10,7 @@ export interface ClientVersionDecisionInput {
     readonly clientKind: ClientKind;
     readonly appVersion: string;
     readonly policy: SessionSyncCompatibilityPolicy;
-    readonly distributionSupportedRange?: string;
     readonly distributionUpdateUrl?: string | null;
-}
-
-function readDistributionMinimum(range: string | undefined): string | null {
-    if (range === undefined) return null;
-    const minimum = semver.minVersion(range)?.version;
-    if (minimum === undefined) {
-        throw new Error(`Invalid configured app version range: ${range}`);
-    }
-    return minimum;
-}
-
-function resolveEffectiveMinimum(
-    policyMinimum: string | undefined,
-    distributionMinimum: string | null,
-): string | null {
-    if (policyMinimum === undefined) return distributionMinimum;
-    if (distributionMinimum === null || semver.gt(policyMinimum, distributionMinimum)) return policyMinimum;
-    return distributionMinimum;
 }
 
 export function isAppVersionAtLeastMinimum(appVersion: string, minimumVersion: string): boolean {
@@ -41,30 +22,18 @@ export function isAppVersionAtLeastMinimum(appVersion: string, minimumVersion: s
 export function resolveClientVersionDecision(
     input: ClientVersionDecisionInput,
 ): ClientVersionCheckResponseV1 {
-    const distributionMinimum = readDistributionMinimum(input.distributionSupportedRange);
-    const policyMinimum = input.policy.requirements.minimumVersionsByClientKind?.[input.clientKind];
-    const effectiveMinimum = resolveEffectiveMinimum(policyMinimum, distributionMinimum);
-    const validAppVersion = semver.valid(input.appVersion);
-    const satisfiesDistribution = input.distributionSupportedRange === undefined
-        || (validAppVersion !== null && semver.satisfies(validAppVersion, input.distributionSupportedRange));
-    const satisfiesMinimum = effectiveMinimum === null
-        || isAppVersionAtLeastMinimum(input.appVersion, effectiveMinimum);
-
-    if (satisfiesDistribution && satisfiesMinimum) {
-        return { v: 1, status: 'current' };
-    }
-
-    // A configured distribution range or policy minimum is required for a
-    // truthful upgrade response. Native callers always supply a range; a
-    // malformed unversioned request cannot fabricate an upgrade floor.
-    if (effectiveMinimum === null) {
+    // The compatibility policy is the only upgrade floor. A store listing version
+    // tracks a distribution channel rather than the version line clients report,
+    // so measuring against one reports a permanent, unactionable upgrade.
+    const minimum = input.policy.requirements.minimumVersionsByClientKind?.[input.clientKind];
+    if (minimum === undefined || isAppVersionAtLeastMinimum(input.appVersion, minimum)) {
         return { v: 1, status: 'current' };
     }
 
     return {
         v: 1,
         status: 'upgrade-required',
-        minimumAppVersion: effectiveMinimum,
+        minimumAppVersion: minimum,
         updateUrl: input.policy.requirements.upgradeUrlsByClientKind?.[input.clientKind]
             ?? input.distributionUpdateUrl
             ?? null,

--- a/apps/server/sources/app/clientCompatibility/versionDecision.ts
+++ b/apps/server/sources/app/clientCompatibility/versionDecision.ts
@@ -13,18 +13,29 @@ export interface ClientVersionDecisionInput {
     readonly distributionUpdateUrl?: string | null;
 }
 
+/**
+ * Compares two semver versions, treating either being unparseable as "below the
+ * minimum" so a malformed client version fails closed into the upgrade flow.
+ */
 export function isAppVersionAtLeastMinimum(appVersion: string, minimumVersion: string): boolean {
     const declared = semver.valid(appVersion);
     const minimum = semver.valid(minimumVersion);
     return declared !== null && minimum !== null && semver.gte(declared, minimum);
 }
 
+/**
+ * Decides whether a client must upgrade, using the session-sync compatibility
+ * policy as the only upgrade floor. A store listing version tracks a
+ * distribution channel rather than the version line clients report, so
+ * measuring against one reports a permanent, unactionable upgrade.
+ *
+ * With no configured minimum for the client kind, every version is `current`.
+ * `distributionUpdateUrl` is only a destination for a triggered upgrade, and
+ * the policy's `upgradeUrlsByClientKind` takes precedence over it.
+ */
 export function resolveClientVersionDecision(
     input: ClientVersionDecisionInput,
 ): ClientVersionCheckResponseV1 {
-    // The compatibility policy is the only upgrade floor. A store listing version
-    // tracks a distribution channel rather than the version line clients report,
-    // so measuring against one reports a permanent, unactionable upgrade.
     const minimum = input.policy.requirements.minimumVersionsByClientKind?.[input.clientKind];
     if (minimum === undefined || isAppVersionAtLeastMinimum(input.appVersion, minimum)) {
         return { v: 1, status: 'current' };

--- a/apps/server/sources/versions.ts
+++ b/apps/server/sources/versions.ts
@@ -1,2 +1,0 @@
-export const IOS_UP_TO_DATE = '>=1.4.1';
-export const ANDROID_UP_TO_DATE = '>=1.4.1';


### PR DESCRIPTION
## Problem

Every native client — production, preview, and dev — permanently receives `upgrade-required` from `POST /v1/version`, so the mobile app always shows an "app update available" banner that no update can clear.

`apps/server/sources/versions.ts` held:

```ts
export const IOS_UP_TO_DATE = '>=1.4.1';
export const ANDROID_UP_TO_DATE = '>=1.4.1';
```

These were added once in upstream commit `0d9f19b9a` (2025-09-02), when the app shipped on the 1.4.x version line. They were never updated afterwards — only relocated by the `packages/*` → `apps/*` rename. Happier now ships the **0.2.x** line (`apps/ui/package.json` is `0.2.10`; tags read `ui-web-v0.2.10-dev.227`).

The failing path:

1. `apps/ui/sources/sync/sync.ts` `fetchNativeUpdate` sends `appVersion: Constants.expoConfig.version` = `0.2.10`.
2. `versionRoutes.ts` passes `distributionSupportedRange: '>=1.4.1'` into `resolveClientVersionDecision`.
3. `semver.satisfies('0.2.10', '>=1.4.1')` is `false` → `{ status: 'upgrade-required', minimumAppVersion: '1.4.1' }`.
4. `buildAppUpdateStatusModel` ranks native-store above OTA, so `UpdateBanner` renders permanently.

A store listing version tracks a distribution channel, not the version line clients report. Comparing the two can only ever produce an unactionable upgrade demand.

## Change

The session-sync compatibility policy (`HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_VERSIONS_JSON`) becomes the single upgrade floor, removing the split-brain between it and the hardcoded constants.

- Delete `apps/server/sources/versions.ts`.
- Drop `distributionSupportedRange` from both the v1 and legacy branches of `versionRoutes.ts`.
- Remove the now-dead `readDistributionMinimum` / `resolveEffectiveMinimum` / `satisfiesDistribution` logic from `versionDecision.ts`.
- Retain `IOS_UPDATE_URL` as an upgrade *destination*: when a real policy minimum triggers, iOS still links to the App Store, and `UPGRADE_URLS_JSON` still overrides it.

`versionRoutes.ts` was the only consumer of both deleted surfaces, so the blast radius is contained to this route.

Production diff is **+8 / −48** — net −40 lines. The only added logic is the replacement condition:

```ts
const minimum = input.policy.requirements.minimumVersionsByClientKind?.[input.clientKind];
if (minimum === undefined || isAppVersionAtLeastMinimum(input.appVersion, minimum)) {
    return { v: 1, status: 'current' };
}
```

## Behavior after

No native client is told to upgrade unless an operator configures a minimum version. When one is configured it applies uniformly across every release channel — this PR removes a bogus floor, it does not add a dev-channel bypass. `versionRoutes.post.spec.ts` pins that with a dev-channel build that *is* held to a configured minimum.

## Validation

- `yarn vitest run sources/app/api/routes/version/` — 9 passed (8 POST + 1 GET). RED verified before implementation.
- `yarn typecheck` (server) — clean.
- `yarn test:unit` (server) — 251 files / 1352 tests passed.
- Repo-wide grep for `IOS_UP_TO_DATE|ANDROID_UP_TO_DATE|distributionSupportedRange|@/versions` — no remaining references.

Not run: `test:integration` and `test:db-contract` (require a database; neither covers this endpoint).

## Fail-closed follow-up (included here)

Removing the store floor made a latent fail-open reachable. `resolveSessionSyncCompatibilityPolicy` returns `FALLBACK_REQUIREMENTS` when the configured policy cannot be read, and that fallback carries no client minimums. `decision.ts:74-82` already handles this — it rejects with `reject-policy-invalid` when enforcement is `required` — but the version endpoint read `minimumVersionsByClientKind` directly and never checked `policy.valid`.

So a malformed `MINIMUM_VERSIONS_JSON` (for example a non-comparable `"1.2"`) would answer `current` to every client while HTTP and socket enforcement rejected those same clients. Previously the hardcoded floor masked it by returning `upgrade-required` for unrelated reasons.

The endpoint now mirrors `decision.ts`: `required` enforcement with an invalid policy returns `500 { error: 'compatibility_policy_invalid' }` rather than asserting an unverified `current`. Observe-mode operators still receive `current`, matching the existing `observe-policy-invalid` outcome. The UI already ignores non-2xx responses from this endpoint (`sync.ts` `fetchNativeUpdate`), so no false "up to date" state is written client-side.

## Noted, not fixed here

`HAPPIER_SESSION_SYNC_COMPATIBILITY__MINIMUM_VERSIONS_JSON` is undocumented — it appears only in `policy.ts` and three spec files, with no mention in `docs/` or `apps/docs/content/`. That matters more now that it is the only upgrade floor: nothing tells an operator that keys are `ClientKind` values or that entries must be full semver or the whole policy voids.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop stale store version floor from `POST /v1/version` compatibility decisions
> - Removes `distributionSupportedRange` from version upgrade decisions in [`versionDecision.ts`](https://github.com/happier-dev/happier/pull/222/files#diff-3a8e2cbf2c877e8360c7f2c8c3689d71be3d87359b22b1a0235c9b9d3badf391); upgrade requirements now derive solely from `minimumVersionsByClientKind` in the session-sync compatibility policy.
> - Deletes the [`versions.ts`](https://github.com/happier-dev/happier/pull/222/files#diff-3b1260bbe6c2ecfb58957fabe84afbb056edd87eeb8e29e0b695a701e572368a) file and its `IOS_UP_TO_DATE`/`ANDROID_UP_TO_DATE` constants, which are no longer referenced.
> - `POST /v1/version` now returns `500` with `{ error: 'compatibility_policy_invalid' }` when the policy is invalid and enforcement mode is `required`.
> - iOS upgrade URLs now use the configured `upgradeUrlsByClientKind` value with a fallback to the App Store URL; Android defaults to `null`.
> - Behavioral Change: clients with no configured policy minimum are now reported as `current` instead of being evaluated against a distribution range.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6a449f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client version checks to consistently enforce configured compatibility minimums.
  * Removed outdated platform-specific version requirements from upgrade decisions.
  * Preserved current and required-upgrade behavior across production and development clients.
  * Ensured update links are provided only when configured and available, including iOS links for outdated clients.
  * Maintained compatibility with legacy version-check request and response formats.
  * Added clear error handling when required compatibility settings are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->