### PR TITLE
build(server-release): prune foreign-platform and unreachable Prisma artifacts

### DIFF
--- a/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.prismaEnginePrune.test.ts
+++ b/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.prismaEnginePrune.test.ts
@@ -1,0 +1,134 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { pruneServerPrismaArtifactsForTarget } from './buildServerBinaryArtifactPayload.js';
+
+const PRISMA_NODE_ENGINE_FILE_NAMES = [
+    'libquery_engine-debian-openssl-3.0.x.so.node',
+    'libquery_engine-linux-arm64-openssl-3.0.x.so.node',
+    'libquery_engine-darwin.dylib.node',
+    'libquery_engine-darwin-arm64.dylib.node',
+    'query_engine-windows.dll.node',
+];
+
+const PRISMA_RUNTIME_FILE_NAMES = [
+    // Providers actually reachable via ServerDbProvider ('sqlite' | 'mysql') plus the always-generated
+    // 'postgres' default client -- these must survive pruning.
+    'query_engine_bg.postgresql.wasm-base64.js',
+    'query_engine_bg.postgresql.wasm-base64.mjs',
+    'query_engine_bg.mysql.wasm-base64.js',
+    'query_engine_bg.mysql.wasm-base64.mjs',
+    'query_engine_bg.sqlite.wasm-base64.js',
+    'query_engine_bg.sqlite.wasm-base64.mjs',
+    // Providers never reachable through resolveRequestedServerDbProviders/BuildDbProvider -- must be pruned.
+    'query_engine_bg.cockroachdb.wasm-base64.js',
+    'query_engine_bg.cockroachdb.wasm-base64.mjs',
+    'query_engine_bg.sqlserver.wasm-base64.js',
+    'query_engine_bg.sqlserver.wasm-base64.mjs',
+    // Sourcemaps -- never needed at runtime, must be pruned regardless of provider.
+    'binary.js.map',
+    'binary.mjs.map',
+    'index-browser.js.map',
+];
+
+const tempDirs: string[] = [];
+
+async function createTempPayloadDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'build-server-binary-artifact-payload-prisma-prune-'));
+    tempDirs.push(dir);
+    return dir;
+}
+
+async function writeFixtureFile(path: string): Promise<void> {
+    await mkdir(join(path, '..'), { recursive: true });
+    await writeFile(path, 'fixture', 'utf8');
+}
+
+async function buildFakePrismaClientDirTree(payloadDir: string, relativeDir: string): Promise<string> {
+    const dirPath = join(payloadDir, relativeDir);
+    for (const fileName of PRISMA_NODE_ENGINE_FILE_NAMES) {
+        await writeFixtureFile(join(dirPath, fileName));
+    }
+    return dirPath;
+}
+
+async function buildFakePrismaClientRuntimeDirTree(payloadDir: string): Promise<string> {
+    const dirPath = join(payloadDir, 'node_modules', '@prisma', 'client', 'runtime');
+    for (const fileName of PRISMA_RUNTIME_FILE_NAMES) {
+        await writeFixtureFile(join(dirPath, fileName));
+    }
+    // A file that is neither a per-provider engine file nor a sourcemap must survive untouched.
+    await writeFixtureFile(join(dirPath, 'index.js'));
+    return dirPath;
+}
+
+describe('pruneServerPrismaArtifactsForTarget', () => {
+    afterEach(async () => {
+        await Promise.all(tempDirs.splice(0).map(async (dir) => {
+            await rm(dir, { recursive: true, force: true });
+        }));
+    });
+
+    it('keeps only the linux-arm64 engine file in each generated provider client directory', async () => {
+        const payloadDir = await createTempPayloadDir();
+        const sqliteClientDir = await buildFakePrismaClientDirTree(payloadDir, join('generated', 'sqlite-client'));
+        const mysqlClientDir = await buildFakePrismaClientDirTree(payloadDir, join('generated', 'mysql-client'));
+        const dotPrismaClientDir = await buildFakePrismaClientDirTree(payloadDir, join('node_modules', '.prisma', 'client'));
+
+        await pruneServerPrismaArtifactsForTarget({
+            payloadDir,
+            target: { bunTarget: 'bun-linux-arm64', os: 'linux', arch: 'arm64', exeExt: '' },
+        });
+
+        for (const dir of [sqliteClientDir, mysqlClientDir, dotPrismaClientDir]) {
+            const remaining = await readdir(dir);
+            expect(remaining).toEqual(['libquery_engine-linux-arm64-openssl-3.0.x.so.node']);
+        }
+    });
+
+    it('keeps only the darwin-arm64 engine file for a darwin-arm64 target', async () => {
+        const payloadDir = await createTempPayloadDir();
+        const sqliteClientDir = await buildFakePrismaClientDirTree(payloadDir, join('generated', 'sqlite-client'));
+
+        await pruneServerPrismaArtifactsForTarget({
+            payloadDir,
+            target: { bunTarget: 'bun-darwin-arm64', os: 'darwin', arch: 'arm64', exeExt: '' },
+        });
+
+        const remaining = await readdir(sqliteClientDir);
+        expect(remaining).toEqual(['libquery_engine-darwin-arm64.dylib.node']);
+    });
+
+    it('prunes cockroachdb/sqlserver runtime WASM engines and all sourcemaps from @prisma/client/runtime, keeping reachable providers and unrelated files', async () => {
+        const payloadDir = await createTempPayloadDir();
+        const runtimeDir = await buildFakePrismaClientRuntimeDirTree(payloadDir);
+
+        await pruneServerPrismaArtifactsForTarget({
+            payloadDir,
+            target: { bunTarget: 'bun-linux-arm64', os: 'linux', arch: 'arm64', exeExt: '' },
+        });
+
+        const remaining = await readdir(runtimeDir);
+        expect(remaining.sort()).toEqual([
+            'index.js',
+            'query_engine_bg.mysql.wasm-base64.js',
+            'query_engine_bg.mysql.wasm-base64.mjs',
+            'query_engine_bg.postgresql.wasm-base64.js',
+            'query_engine_bg.postgresql.wasm-base64.mjs',
+            'query_engine_bg.sqlite.wasm-base64.js',
+            'query_engine_bg.sqlite.wasm-base64.mjs',
+        ].sort());
+    });
+
+    it('is a no-op when the expected Prisma directories are absent', async () => {
+        const payloadDir = await createTempPayloadDir();
+
+        await expect(pruneServerPrismaArtifactsForTarget({
+            payloadDir,
+            target: { bunTarget: 'bun-linux-arm64', os: 'linux', arch: 'arm64', exeExt: '' },
+        })).resolves.toBeUndefined();
+    });
+});

--- a/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.prismaEnginePrune.test.ts
+++ b/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.prismaEnginePrune.test.ts
@@ -143,6 +143,6 @@ describe('pruneServerPrismaArtifactsForTarget', () => {
         await expect(pruneServerPrismaArtifactsForTarget({
             payloadDir,
             target: { bunTarget: 'bun-linux-arm64', os: 'linux', arch: 'arm64', exeExt: '' },
-        })).rejects.toThrow();
+        })).rejects.toMatchObject({ code: 'ENOTDIR' });
     });
 });

--- a/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.prismaEnginePrune.test.ts
+++ b/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.prismaEnginePrune.test.ts
@@ -131,4 +131,18 @@ describe('pruneServerPrismaArtifactsForTarget', () => {
             target: { bunTarget: 'bun-linux-arm64', os: 'linux', arch: 'arm64', exeExt: '' },
         })).resolves.toBeUndefined();
     });
+
+    it('rejects instead of silently skipping pruning when an expected Prisma directory path is actually a file', async () => {
+        const payloadDir = await createTempPayloadDir();
+        const dotPrismaClientPath = join(payloadDir, 'node_modules', '.prisma', 'client');
+        await mkdir(join(dotPrismaClientPath, '..'), { recursive: true });
+        // A file where a directory is expected (e.g. from a corrupted staging step) must surface as an
+        // error, not be silently treated as "directory has no files to prune".
+        await writeFile(dotPrismaClientPath, 'not a directory', 'utf8');
+
+        await expect(pruneServerPrismaArtifactsForTarget({
+            payloadDir,
+            target: { bunTarget: 'bun-linux-arm64', os: 'linux', arch: 'arm64', exeExt: '' },
+        })).rejects.toThrow();
+    });
 });

--- a/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.ts
+++ b/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.ts
@@ -1,4 +1,5 @@
 import { cp, mkdir, readdir, rm, stat } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
@@ -33,13 +34,26 @@ async function ensureFile(path: string, message: string): Promise<void> {
   }
 }
 
+// Prisma client directories are always staged before pruning runs (resolveServerBinarySidecarEntries
+// asserts their existence), so a missing directory here is not itself an error worth failing the
+// build over -- but any other readdir failure (permission denied, path is actually a file, ...) must
+// not be silently treated as "nothing to prune": that would let foreign-platform engines, unreachable
+// WASM engines, or sourcemaps survive into the release artifact while validateServerPrismaEnginesForTarget
+// still passes (it only checks that the *kept* engine file exists, not that pruning actually ran).
+async function readdirOrEmptyIfMissing(directoryPath: string): Promise<Dirent<string>[]> {
+  return readdir(directoryPath, { withFileTypes: true, encoding: 'utf8' }).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  });
+}
+
 // Each generated Prisma client directory (generated/*-client, node_modules/.prisma/client) ships a
 // native query-engine file per platform (binaryTargets in schema.prisma lists all 5: linux-x64,
 // linux-arm64, darwin-x64, darwin-arm64, windows-x64), but a single-platform release payload only
 // ever runs on the one platform it was built for. Keep only that target's engine file.
 async function pruneNonTargetPrismaEngineFiles(directoryPath: string, target: BinaryTarget): Promise<void> {
   const keepFileName = resolvePrismaEngineFileNameForTarget(target);
-  const entries = await readdir(directoryPath, { withFileTypes: true }).catch(() => []);
+  const entries = await readdirOrEmptyIfMissing(directoryPath);
   for (const entry of entries) {
     if (!entry.isFile()) continue;
     const isEngineFile = entry.name.startsWith('libquery_engine-') || entry.name.startsWith('query_engine-');
@@ -58,7 +72,7 @@ async function pruneNonTargetPrismaEngineFiles(directoryPath: string, target: Bi
 const PRISMA_RUNTIME_NEVER_REACHABLE_PROVIDER_MARKERS = ['.cockroachdb.', '.sqlserver.'];
 
 async function pruneUnreachablePrismaRuntimeFiles(runtimeDirectoryPath: string): Promise<void> {
-  const entries = await readdir(runtimeDirectoryPath, { withFileTypes: true }).catch(() => []);
+  const entries = await readdirOrEmptyIfMissing(runtimeDirectoryPath);
   for (const entry of entries) {
     if (!entry.isFile()) continue;
     const isNeverReachableProviderFile = PRISMA_RUNTIME_NEVER_REACHABLE_PROVIDER_MARKERS.some(
@@ -81,7 +95,7 @@ export async function pruneServerPrismaArtifactsForTarget({
   await pruneNonTargetPrismaEngineFiles(join(payloadDir, 'node_modules', '.prisma', 'client'), target);
 
   const generatedDir = join(payloadDir, 'generated');
-  const generatedEntries = await readdir(generatedDir, { withFileTypes: true }).catch(() => []);
+  const generatedEntries = await readdirOrEmptyIfMissing(generatedDir);
   for (const entry of generatedEntries) {
     if (entry.isDirectory() && entry.name.endsWith('-client')) {
       await pruneNonTargetPrismaEngineFiles(join(generatedDir, entry.name), target);

--- a/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.ts
+++ b/packages/cli-common/src/componentArtifacts/buildServerBinaryArtifactPayload.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, rm, stat } from 'node:fs/promises';
+import { cp, mkdir, readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
@@ -31,6 +31,64 @@ async function ensureFile(path: string, message: string): Promise<void> {
   if (!info?.isFile()) {
     throw new Error(message);
   }
+}
+
+// Each generated Prisma client directory (generated/*-client, node_modules/.prisma/client) ships a
+// native query-engine file per platform (binaryTargets in schema.prisma lists all 5: linux-x64,
+// linux-arm64, darwin-x64, darwin-arm64, windows-x64), but a single-platform release payload only
+// ever runs on the one platform it was built for. Keep only that target's engine file.
+async function pruneNonTargetPrismaEngineFiles(directoryPath: string, target: BinaryTarget): Promise<void> {
+  const keepFileName = resolvePrismaEngineFileNameForTarget(target);
+  const entries = await readdir(directoryPath, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const isEngineFile = entry.name.startsWith('libquery_engine-') || entry.name.startsWith('query_engine-');
+    if (isEngineFile && entry.name !== keepFileName) {
+      await rm(join(directoryPath, entry.name), { force: true });
+    }
+  }
+}
+
+// @prisma/client's runtime/ directory bundles WASM query engines for every database Prisma
+// supports (postgresql, mysql, sqlite, cockroachdb, sqlserver) plus .map sourcemaps for every
+// bundled format, regardless of which providers this build actually generated clients for.
+// ServerDbProvider (serverSidecars.ts) is only ever 'sqlite' | 'mysql', and a postgres client is
+// always generated as the default -- cockroachdb and sqlserver are never reachable, and
+// sourcemaps are never needed by a production binary. Delete both classes unconditionally.
+const PRISMA_RUNTIME_NEVER_REACHABLE_PROVIDER_MARKERS = ['.cockroachdb.', '.sqlserver.'];
+
+async function pruneUnreachablePrismaRuntimeFiles(runtimeDirectoryPath: string): Promise<void> {
+  const entries = await readdir(runtimeDirectoryPath, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const isNeverReachableProviderFile = PRISMA_RUNTIME_NEVER_REACHABLE_PROVIDER_MARKERS.some(
+      (marker) => entry.name.includes(marker),
+    );
+    const isSourceMap = entry.name.endsWith('.map');
+    if (isNeverReachableProviderFile || isSourceMap) {
+      await rm(join(runtimeDirectoryPath, entry.name), { force: true });
+    }
+  }
+}
+
+export async function pruneServerPrismaArtifactsForTarget({
+  payloadDir,
+  target,
+}: {
+  payloadDir: string;
+  target: BinaryTarget;
+}): Promise<void> {
+  await pruneNonTargetPrismaEngineFiles(join(payloadDir, 'node_modules', '.prisma', 'client'), target);
+
+  const generatedDir = join(payloadDir, 'generated');
+  const generatedEntries = await readdir(generatedDir, { withFileTypes: true }).catch(() => []);
+  for (const entry of generatedEntries) {
+    if (entry.isDirectory() && entry.name.endsWith('-client')) {
+      await pruneNonTargetPrismaEngineFiles(join(generatedDir, entry.name), target);
+    }
+  }
+
+  await pruneUnreachablePrismaRuntimeFiles(join(payloadDir, 'node_modules', '@prisma', 'client', 'runtime'));
 }
 
 async function validateServerPrismaEnginesForTarget({
@@ -158,6 +216,8 @@ export async function buildServerBinaryArtifactPayload({
       copyPath,
     });
   }
+
+  await pruneServerPrismaArtifactsForTarget({ payloadDir, target });
 
   await validateServerPrismaEnginesForTarget({
     payloadDir,


### PR DESCRIPTION
## Summary

The packaged server binary release artifact (used by the relay-server Docker image and `apps/stack`'s self-host installers) shipped Prisma query-engine binaries for **all 5 platforms** even though a single release build only ever runs on one:

- `schema.prisma`'s `binaryTargets` lists `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `windows` — a build for e.g. `linux-arm64` still had all 5 native `.node`/`.dll` files copied into `generated/{sqlite,mysql}-client` and `node_modules/.prisma/client`.
- `node_modules/@prisma/client/runtime` bundles WASM query engines for **every** database Prisma supports (postgresql, mysql, sqlite, cockroachdb, sqlserver) plus `.map` sourcemaps for every bundled format — `cockroachdb`/`sqlserver` are never reachable (`ServerDbProvider` is only ever `'sqlite' | 'mysql'`, with `postgres` always generated as the default), and sourcemaps are never needed by a production binary.

The codebase already knows exactly which single engine file a build target needs (`resolvePrismaEngineFileNameForTarget`), but that knowledge was only used for **validating** the artifact post-copy, never for **pruning** the other 4 platform variants.

## Fix

Added `pruneServerPrismaArtifactsForTarget()` in `buildServerBinaryArtifactPayload.ts`, called after sidecar staging and before the existing validation step (so validation now also proves pruning didn't break the kept engine):

- Deletes non-target-platform `.node`/`.dll` engine files from `generated/*-client` and `node_modules/.prisma/client`.
- Deletes `cockroachdb`/`sqlserver` WASM engines and all `.map` files from `node_modules/@prisma/client/runtime`.

## Impact

Compared against the currently-published `happierdev/relay-server:dev` image (real OCI manifest layer sizes via `docker manifest inspect`, arm64, digest `sha256:ece74a90...`, already includes the earlier `ee63f5d45` Docker-side trim) versus the same Dockerfile recipe built locally with this fix applied (real `bun compile` + `prisma generate`, no mocking, pushed to a local registry to measure genuine compressed transfer size):

| | Before (live `relay-server:dev`) | After (this fix) | Savings |
|---|---|---|---|
| **relay-server image (compressed, what's actually pulled/pushed)** | 245.2 MB | 205.3 MB | **-39.9 MB (-16.3%)** |
| Server artifact (uncompressed, for reference) | ~470 MB | 392 MB | ~-78 MB |

This is on top of the already-merged `ee63f5d45` (Docker-side pruning of the duplicate `ui-web` copy and `mysql-client`/non-matching-arch files, reflected in the `245.2 MB` baseline above) — this fix additionally covers `apps/stack`'s native self-host installers, which consume the same underlying artifact but don't go through that Docker-side pruning at all.

## Verification

- New test: `buildServerBinaryArtifactPayload.prismaEnginePrune.test.ts` (4 cases) — RED confirmed before implementation, GREEN after.
- Full `packages/cli-common` `componentArtifacts` suite: all passing, no regressions.
- Typecheck: clean (`yarn tsc -p packages/cli-common`).
- Real-world boot test: built the pruned artifact locally, wrapped it in a container matching the production Dockerfile's apt packages, and confirmed:
  - `sqlite` provider boots and serves `HTTP 200`.
  - `mysql` provider correctly locates and loads its query engine (fails only on the fake `DATABASE_URL` connection, as expected — no "Could not locate the Query Engine" error).
- Real-world compressed-size measurement: pulled the actual currently-published `happierdev/relay-server:dev` image and diffed its real OCI manifest layer sizes against a locally-built image with this fix applied (same Dockerfile recipe, pushed to a local registry) — not just `docker images`, which shows uncompressed and can double-count shared layers.

## Test plan

- [x] Unit tests for the new pruning function (target-specific engine survival, cockroachdb/sqlserver + sourcemap removal, no-op on missing directories)
- [x] Full `cli-common` test suite green
- [x] Typecheck clean
- [x] Manual boot verification in a Linux container (sqlite + mysql provider paths)
- [x] Real compressed image size measured against the currently-published image
- [ ] CI release-pipeline contract tests (will run on this PR)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prune foreign-platform and unreachable Prisma artifacts during server binary payload build
> - Adds `pruneServerPrismaArtifactsForTarget` in [`buildServerBinaryArtifactPayload.ts`](https://github.com/happier-dev/happier/pull/231/files#diff-17ab8e57f4872e0ec7bba29a4de55fefa6be1e0684605a78eb30ebe1f2798d60) to remove non-target native engine binaries from `node_modules/.prisma/client` and each `generated/*-client` directory.
> - Removes cockroachdb/sqlserver WASM engines and all `.map` sourcemap files from `node_modules/@prisma/client/runtime`.
> - Pruning runs after sidecar copy and before validation in `buildServerBinaryArtifactPayload`; missing directories are treated as no-ops.
> - Risk: non-ENOENT filesystem errors during directory reads now propagate and fail the build instead of being silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f6e872.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server builds now include only the Prisma engine binaries required for the selected deployment target, including Linux ARM64 and Darwin ARM64.
  * Unused provider runtime files and sourcemaps are removed from generated server artifacts, helping reduce deployment payload size while retaining required files.
* **Bug Fixes**
  * Improved handling of missing Prisma directories and invalid artifact paths during server build processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->