### PR TITLE
feat: add pi as a direct-session provider

### DIFF
--- a/apps/cli/src/agent/acp/runtime/__tests__/createAcpRuntime.sessionIdentity.test.ts
+++ b/apps/cli/src/agent/acp/runtime/__tests__/createAcpRuntime.sessionIdentity.test.ts
@@ -119,7 +119,7 @@ describe('createAcpRuntime session identity', () => {
     });
 
     await expect(runtime.startOrLoad({ resumeId: resumeReference })).resolves.toBe('pi-session-1');
-    expect(loadSession).toHaveBeenCalledWith(resumeReference);
+    expect(loadSession).toHaveBeenCalledWith(resumeReference, undefined);
     expect(persistBound).toHaveBeenCalledWith(expect.objectContaining({
       operation: 'resume',
       vendorSessionId: 'pi-session-1',

--- a/apps/cli/src/agent/acp/runtime/createCatalogProviderAcpRuntime.ts
+++ b/apps/cli/src/agent/acp/runtime/createCatalogProviderAcpRuntime.ts
@@ -37,6 +37,13 @@ type CatalogAcpProviderRuntimeParams<TBackendOptions extends object> = {
   onThinkingChange: (thinking: boolean) => void;
   getSessionOpenAbortSignal?: () => AbortSignal | undefined;
   backendOptions?: Omit<TBackendOptions, 'cwd' | 'mcpServers' | 'permissionHandler' | 'permissionMode' | 'happierSessionId'>;
+  /**
+   * Async resolver invoked inside `ensureBackend` before the backend is constructed.
+   * Returns additional backend options merged on top of `backendOptions`. Useful when
+   * an option (e.g. a resolved system prompt) depends on the live session and cannot
+   * be computed synchronously at runtime-construction time.
+   */
+  resolveBackendOptions?: (ctx: { session: ApiSessionClient }) => Promise<Partial<TBackendOptions>>;
   getPermissionMode?: () => PermissionMode | null | undefined;
   resolvePermissionMode?: (args: {
     getPermissionMode?: () => PermissionMode | null | undefined;
@@ -162,10 +169,15 @@ export function createCatalogProviderAcpRuntime<TBackendOptions extends object =
         : params.getPermissionMode?.();
       const permissionMode = typeof permissionModeRaw === 'string' ? permissionModeRaw : undefined;
 
+      const resolvedBackendOptions = params.resolveBackendOptions
+        ? await params.resolveBackendOptions({ session: params.session })
+        : {};
+
       const created = await createCatalogAcpBackend<TBackendOptions>(params.provider, {
         cwd: params.directory,
         mcpServers: params.mcpServers,
         ...(params.backendOptions ?? {}),
+        ...(resolvedBackendOptions ?? {}),
         permissionHandler: params.permissionHandler,
         permissionMode,
         happierSessionId: params.session.sessionId,

--- a/apps/cli/src/agent/acp/runtime/createCatalogProviderAcpRuntime.ts
+++ b/apps/cli/src/agent/acp/runtime/createCatalogProviderAcpRuntime.ts
@@ -37,6 +37,13 @@ type CatalogAcpProviderRuntimeParams<TBackendOptions extends object> = {
   onThinkingChange: (thinking: boolean) => void;
   getSessionOpenAbortSignal?: () => AbortSignal | undefined;
   backendOptions?: Omit<TBackendOptions, 'cwd' | 'mcpServers' | 'permissionHandler' | 'permissionMode' | 'happierSessionId'>;
+  /**
+   * Async resolver invoked inside `ensureBackend` before the backend is constructed.
+   * Returns additional backend options merged on top of `backendOptions`. Useful when
+   * an option (e.g. a resolved system prompt) depends on the live session and cannot
+   * be computed synchronously at runtime-construction time.
+   */
+  resolveBackendOptions?: (ctx: { session: ApiSessionClient }) => Promise<Partial<TBackendOptions>>;
   getPermissionMode?: () => PermissionMode | null | undefined;
   resolvePermissionMode?: (args: {
     getPermissionMode?: () => PermissionMode | null | undefined;
@@ -160,10 +167,15 @@ export function createCatalogProviderAcpRuntime<TBackendOptions extends object =
         : params.getPermissionMode?.();
       const permissionMode = typeof permissionModeRaw === 'string' ? permissionModeRaw : undefined;
 
+      const resolvedBackendOptions = params.resolveBackendOptions
+        ? await params.resolveBackendOptions({ session: params.session })
+        : {};
+
       const created = await createCatalogAcpBackend<TBackendOptions>(params.provider, {
         cwd: params.directory,
         mcpServers: params.mcpServers,
         ...(params.backendOptions ?? {}),
+        ...(resolvedBackendOptions ?? {}),
         permissionHandler: params.permissionHandler,
         permissionMode,
         happierSessionId: params.session.sessionId,

--- a/apps/cli/src/agent/prompting/coding/resolveEffectiveCodingPrompt.test.ts
+++ b/apps/cli/src/agent/prompting/coding/resolveEffectiveCodingPrompt.test.ts
@@ -241,6 +241,28 @@ describe('resolveEffectiveCodingPromptText', () => {
     expect(out).not.toContain('again if the task changes significantly');
   });
 
+  it('renders only tool-delivery blocks when renderBlockScopes restricts the rendered scopes', async () => {
+    const credentials = createCredentials();
+
+    const out = await resolveEffectiveCodingPromptText({
+      credentials,
+      settings: {},
+      profileId: null,
+      baseOverride: 'BASE',
+      executionRunsFeatureEnabled: false,
+      toolDelivery: 'shell_bridge',
+      toolDeliverySessionId: 's1',
+      toolDeliveryDirectory: '/tmp/worktree',
+      renderBlockScopes: ['tool_delivery'],
+      fetchPromptArtifactRecord: async () => null,
+    });
+
+    expect(out).toContain('Happier tools are available through the CLI bridge');
+    expect(out).toContain("'--session-id' 's1'");
+    expect(out).not.toContain('BASE');
+    expect(out).not.toContain('# Attachments');
+  });
+
   it('applies prompt personalization settings to the effective coding prompt', async () => {
     const credentials = createCredentials();
 

--- a/apps/cli/src/agent/prompting/coding/resolveEffectiveCodingPrompt.ts
+++ b/apps/cli/src/agent/prompting/coding/resolveEffectiveCodingPrompt.ts
@@ -2,7 +2,8 @@ import {
   buildCodingSessionPromptPlanBaseV1,
   buildPromptPlanDiagnosticsV1,
   buildPromptPlanV1,
-  renderPromptPlanV1,
+  renderPromptBlocksV1,
+  type PromptBlockScopeV1,
   type PromptBlockV1,
   type PromptPlanV1,
 } from '@happier-dev/protocol';
@@ -34,6 +35,14 @@ type ResolveEffectiveCodingPromptArgs = Readonly<{
   memoryMachineId?: string | null;
   cache?: Map<string, string | null>;
   fetchPromptArtifactRecord?: FetchPromptArtifactRecord;
+  /**
+   * When set, only blocks whose scope is listed here render into `text`; the
+   * plan and diagnostics still include every composed block. Used when the
+   * backend already delivers the session-scope system prompt at process spawn
+   * and a first-message prepend must carry only the remaining blocks (e.g.
+   * tool delivery).
+   */
+  renderBlockScopes?: readonly PromptBlockScopeV1[];
 }>;
 
 export async function resolveEffectiveCodingPromptText(
@@ -103,10 +112,13 @@ export async function resolveEffectiveCodingPromptPlan(
     modality: 'coding',
     blocks: [...basePlan.blocks, ...promptStackBlocks, ...providerBehaviorBlocks, ...toolDeliveryBlocks],
   });
+  const renderedBlocks = args.renderBlockScopes
+    ? plan.blocks.filter((block) => args.renderBlockScopes!.includes(block.scope))
+    : plan.blocks;
 
   return {
     plan,
-    text: renderPromptPlanV1(plan),
+    text: renderPromptBlocksV1(renderedBlocks),
     diagnostics: buildPromptPlanDiagnosticsV1(plan),
   };
 }

--- a/apps/cli/src/agent/runtime/runStandardAcpProvider.test.ts
+++ b/apps/cli/src/agent/runtime/runStandardAcpProvider.test.ts
@@ -569,6 +569,36 @@ describe('runStandardAcpProvider', () => {
     expect(resolvedPrompt).not.toContain('vendor-session-123');
   });
 
+  it('prepends only tool-delivery blocks when the backend delivers the system prompt at spawn', async () => {
+    const harness = createHarness();
+    harness.config.deliversSystemPromptAtSpawn = true;
+
+    let defaultPrepend = '';
+    let overridePrepend = '';
+    harness.deps.runPermissionModePromptLoopFn = async (params: Readonly<{
+      resolveFreshSessionSystemPrompt?: (args: { baseOverride?: string | null }) => Promise<string>;
+    }>) => {
+      defaultPrepend = await params.resolveFreshSessionSystemPrompt?.({}) ?? '';
+      overridePrepend = await params.resolveFreshSessionSystemPrompt?.({ baseOverride: 'USER SYSTEM OVERRIDE' }) ?? '';
+    };
+
+    await runStandardAcpProvider(harness.opts, harness.config, harness.deps);
+
+    // The spawn flag (--append-system-prompt) already carries the shared base
+    // sections, so the first-message prepend must not duplicate them.
+    expect(defaultPrepend).toContain('Happier tools are available through the CLI bridge');
+    expect(defaultPrepend).toContain("'--session-id' 'session-1'");
+    expect(defaultPrepend).not.toContain('# Session title');
+    expect(defaultPrepend).not.toContain('# Attachments');
+    // Explicit per-message base overrides cannot ride the spawn flag and must
+    // still reach the provider, ahead of the tool-delivery appendix.
+    expect(overridePrepend).toContain('USER SYSTEM OVERRIDE');
+    expect(overridePrepend).toContain('Happier tools are available through the CLI bridge');
+    expect(overridePrepend).not.toContain('# Attachments');
+    expect(overridePrepend.indexOf('USER SYSTEM OVERRIDE'))
+      .toBeLessThan(overridePrepend.indexOf('Happier tools are available through the CLI bridge'));
+  });
+
   it('in-flight steer controller calls steerPrompt with correct receiver', async () => {
     const harness = createHarness();
 

--- a/apps/cli/src/agent/runtime/runStandardAcpProvider.ts
+++ b/apps/cli/src/agent/runtime/runStandardAcpProvider.ts
@@ -155,6 +155,14 @@ export type StandardAcpProviderConfig = {
   onDispose?: (params: { session: ApiSessionClient; runtime: RuntimeForLoop }) => void | Promise<void>;
   startRuntimeBeforeFirstPrompt?: boolean;
   failClosedOnResumeFailure?: boolean;
+  /**
+   * True when the backend applies the effective coding system prompt itself at
+   * process spawn (e.g. pi's --append-system-prompt flag). The fresh-session
+   * first-message prepend then carries only tool-delivery blocks plus any
+   * explicit per-message base override, instead of duplicating the
+   * spawn-delivered system prompt.
+   */
+  deliversSystemPromptAtSpawn?: boolean;
   onTerminalDisplayControllerReady?: (controller: TerminalDisplayController) => void;
   shouldRenderTerminalDisplay?: (params: { opts: StandardAcpProviderRunOptions; session: ApiSessionClient; metadata: Metadata }) => boolean;
   resolveKeepAliveMode?: () => KeepAliveMode;
@@ -657,12 +665,11 @@ export async function runStandardAcpProvider(
       strictInitialResume: initialResumeId.length > 0,
       failClosedOnResumeFailure: config.failClosedOnResumeFailure === true,
       startRuntimeBeforeFirstPrompt: config.startRuntimeBeforeFirstPrompt === true,
-      resolveFreshSessionSystemPrompt: async ({ baseOverride }) =>
-        await resolveEffectiveCodingPromptText({
+      resolveFreshSessionSystemPrompt: async ({ baseOverride }) => {
+        const commonArgs = {
           credentials: opts.credentials,
           settings: opts.accountSettingsContext?.settings ?? null,
           profileId: session.getMetadataSnapshot()?.profileId ?? null,
-          baseOverride,
           executionRunsFeatureEnabled: resolveCliFeatureDecision({
             featureId: 'execution.runs',
             env: process.env,
@@ -674,7 +681,26 @@ export async function runStandardAcpProvider(
           memoryMachineId: machineId,
           memoryRecallGuidanceEnabled,
           cache: promptArtifactBodyCache,
-        }),
+        };
+        if (config.deliversSystemPromptAtSpawn !== true) {
+          return await resolveEffectiveCodingPromptText({ ...commonArgs, baseOverride });
+        }
+        // The backend applies the session system prompt at process spawn (e.g.
+        // pi's --append-system-prompt flag); the first-message prepend must not
+        // duplicate it. Carry only the tool-delivery bridge blocks, plus an
+        // explicit per-message base override, which cannot ride the spawn flag.
+        const explicitBaseOverride = typeof baseOverride === 'string' && baseOverride.trim()
+          ? baseOverride.trim()
+          : '';
+        const toolDeliveryText = await resolveEffectiveCodingPromptText({
+          ...commonArgs,
+          renderBlockScopes: ['tool_delivery'],
+        });
+        if (explicitBaseOverride && toolDeliveryText) {
+          return `${explicitBaseOverride}\n\n${toolDeliveryText}`;
+        }
+        return explicitBaseOverride || toolDeliveryText;
+      },
       onAfterStart: config.onAfterStart ? () => config.onAfterStart?.({ session, runtime }) : undefined,
       onAfterReset: config.onAfterReset ? () => config.onAfterReset?.({ session, runtime }) : undefined,
       formatPromptErrorMessage: config.formatPromptErrorMessage,

--- a/apps/cli/src/api/directSessions/linking/ensureDirectSessionLink.test.ts
+++ b/apps/cli/src/api/directSessions/linking/ensureDirectSessionLink.test.ts
@@ -608,4 +608,115 @@ describe('ensureDirectSessionLink', () => {
     expect(JSON.stringify(updatedMetadata)).not.toContain('OPENCODE_AUTH_CONTENT');
     expect(JSON.stringify(updatedMetadata)).not.toContain('must-not-be-copied');
   });
+
+  it('creates a pi direct link with piSessionId metadata and a piAgentDir source key', async () => {
+    getOrCreateSessionByTagMock.mockResolvedValueOnce({
+      session: { id: 'sess_direct_pi_1', metadata: {} },
+    });
+
+    const result = await ensureDirectSessionLink({
+      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
+      machineId: 'machine_1',
+      providerId: 'pi',
+      remoteSessionId: 'pi_sess_1',
+      source: { kind: 'piAgentDir', agentDir: '/home/user/.pi/agent' },
+      titleHint: 'Pi linked session',
+      directoryHint: '/repo',
+      nowMs: () => 123,
+    });
+
+    const expectedTag = `direct:v1:${sha256Hex('machine_1|pi|pi_sess_1|piAgentDir:/home/user/.pi/agent')}`;
+    expect(result.tag).toBe(expectedTag);
+    expect(getOrCreateSessionByTagMock.mock.calls[0]?.[0]?.tag).toBe(expectedTag);
+    const createdMetadata = getOrCreateSessionByTagMock.mock.calls[0]?.[0]?.metadata;
+    expect(createdMetadata).toMatchObject({
+      flavor: 'pi',
+      piSessionId: 'pi_sess_1',
+      directSessionV1: {
+        v: 1,
+        providerId: 'pi',
+        machineId: 'machine_1',
+        remoteSessionId: 'pi_sess_1',
+        source: { kind: 'piAgentDir', agentDir: '/home/user/.pi/agent' },
+      },
+    });
+  });
+
+  it('discriminates pi direct sessions by agentDir so identical remote ids do not collide', async () => {
+    getOrCreateSessionByTagMock.mockResolvedValueOnce({ session: { id: 'sess_direct_pi_a', metadata: {} } });
+    getOrCreateSessionByTagMock.mockResolvedValueOnce({ session: { id: 'sess_direct_pi_b', metadata: {} } });
+
+    const resultAlice = await ensureDirectSessionLink({
+      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
+      machineId: 'machine_1',
+      providerId: 'pi',
+      remoteSessionId: 'pi_sess_shared',
+      source: { kind: 'piAgentDir', agentDir: '/home/alice/.pi/agent' },
+      nowMs: () => 123,
+    });
+    const resultBob = await ensureDirectSessionLink({
+      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
+      machineId: 'machine_1',
+      providerId: 'pi',
+      remoteSessionId: 'pi_sess_shared',
+      source: { kind: 'piAgentDir', agentDir: '/home/bob/.pi/agent' },
+      nowMs: () => 123,
+    });
+
+    expect(resultAlice.tag).not.toBe(resultBob.tag);
+    expect(resultAlice.tag).toBe(`direct:v1:${sha256Hex('machine_1|pi|pi_sess_shared|piAgentDir:/home/alice/.pi/agent')}`);
+    expect(resultBob.tag).toBe(`direct:v1:${sha256Hex('machine_1|pi|pi_sess_shared|piAgentDir:/home/bob/.pi/agent')}`);
+  });
+
+  it('recognizes a pi daemon marker by flavor and resolves its remoteSessionId from piSessionId metadata', async () => {
+    const connectedServices = {
+      v: 1,
+      bindingsByServiceId: {
+        'openai-codex': { source: 'connected', selection: 'group', groupId: 'happier', profileId: 'work' },
+      },
+    } satisfies ConnectedServiceBindingsV1;
+    const materializationIdentity = {
+      v: 1,
+      id: 'csm_pi_link',
+      createdAtMs: 1_718_719_900_000,
+    } satisfies ConnectedServiceMaterializationIdentityV1;
+    listSessionMarkersMock.mockResolvedValueOnce([
+      {
+        pid: 12345,
+        updatedAt: 200,
+        flavor: 'pi',
+        cwd: '/repo',
+        metadata: { flavor: 'pi', path: '/repo', piSessionId: 'pi_connected' },
+        respawn: {
+          version: 1,
+          directory: '/repo',
+          backendTarget: { kind: 'builtInAgent', agentId: 'pi' },
+          connectedServices,
+          connectedServicesUpdatedAt: 1_718_719_899_000,
+          connectedServiceMaterializationIdentityV1: materializationIdentity,
+        },
+      },
+    ]);
+    getOrCreateSessionByTagMock.mockResolvedValueOnce({
+      session: { id: 'sess_direct_pi_connected', metadata: {} },
+    });
+
+    await ensureDirectSessionLink({
+      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
+      machineId: 'machine_1',
+      providerId: 'pi',
+      remoteSessionId: 'pi_connected',
+      source: { kind: 'piAgentDir', agentDir: '/home/user/.pi/agent' },
+      directoryHint: '/repo',
+      nowMs: () => 123,
+    });
+
+    const createdMetadata = getOrCreateSessionByTagMock.mock.calls[0]?.[0]?.metadata;
+    expect(createdMetadata).toMatchObject({
+      connectedServices,
+      connectedServicesUpdatedAt: 1_718_719_899_000,
+      connectedServiceMaterializationIdentityV1: materializationIdentity,
+      directSessionV1: { remoteSessionId: 'pi_connected' },
+    });
+  });
 });

--- a/apps/cli/src/api/directSessions/linking/ensureDirectSessionLink.test.ts
+++ b/apps/cli/src/api/directSessions/linking/ensureDirectSessionLink.test.ts
@@ -642,6 +642,44 @@ describe('ensureDirectSessionLink', () => {
     });
   });
 
+  it('reuses an imported persisted session without turning it back into a direct session', async () => {
+    const tag = `direct:v1:${sha256Hex('machine_1|pi|pi_imported|piAgentDir:/home/user/.pi/agent')}`;
+    const importedMetadata = {
+      tag,
+      path: '/repo',
+      machineId: 'machine_1',
+      flavor: 'pi',
+      piSessionId: 'pi_imported',
+      externalHistoryImportV1: {
+        v: 1,
+        providerId: 'pi',
+        remoteSessionId: 'pi_imported',
+        importedAtMs: 123,
+        source: { kind: 'piAgentDir', agentDir: '/home/user/.pi/agent' },
+      },
+    };
+    fetchSessionsPageMock.mockResolvedValueOnce({
+      sessions: [{ id: 'sess_imported_pi', metadata: importedMetadata }],
+      hasNext: false,
+      nextCursor: null,
+    });
+    tryDecryptSessionMetadataMock.mockImplementation(({ rawSession }: { rawSession: { metadata?: unknown } }) => rawSession.metadata);
+
+    const result = await ensureDirectSessionLink({
+      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
+      machineId: 'machine_1',
+      providerId: 'pi',
+      remoteSessionId: 'pi_imported',
+      source: { kind: 'piAgentDir', agentDir: '/home/user/.pi/agent' },
+      directoryHint: '/repo',
+      nowMs: () => 456,
+    });
+
+    expect(result).toEqual({ sessionId: 'sess_imported_pi', created: false, tag });
+    expect(getOrCreateSessionByTagMock).not.toHaveBeenCalled();
+    expect(updateSessionMetadataWithRetryMock).not.toHaveBeenCalled();
+  });
+
   it('discriminates pi direct sessions by agentDir so identical remote ids do not collide', async () => {
     getOrCreateSessionByTagMock.mockResolvedValueOnce({ session: { id: 'sess_direct_pi_a', metadata: {} } });
     getOrCreateSessionByTagMock.mockResolvedValueOnce({ session: { id: 'sess_direct_pi_b', metadata: {} } });

--- a/apps/cli/src/api/directSessions/linking/ensureDirectSessionLink.ts
+++ b/apps/cli/src/api/directSessions/linking/ensureDirectSessionLink.ts
@@ -25,6 +25,10 @@ import {
   type ConnectedServiceRuntimeSnapshot,
 } from '@/daemon/connectedServices/connectedServiceRuntimeSnapshot';
 import { listSessionMarkers, type DaemonSessionMarker } from '@/daemon/sessionRegistry';
+import {
+  directSessionMarkerMatches,
+  readDirectSessionMarkerProviderId,
+} from '@/api/directSessions/markers/readDirectSessionMarkerIdentity';
 import { normalizePathForComparison } from '@/utils/path/normalizePathForComparison';
 
 function sha256Hex(value: string): string {
@@ -50,77 +54,6 @@ function resolveSessionSummaryTitle(metadata: Readonly<Record<string, unknown>>)
 function resolveDirectRemoteSessionId(metadata: Readonly<Record<string, unknown>>): string | null {
   const directSession = asMetadataRecord(metadata.directSessionV1);
   return normalizeNullableString(directSession?.remoteSessionId);
-}
-
-function resolveMetadataRemoteSessionId(
-  metadata: Readonly<Record<string, unknown>> | null,
-  providerId: DirectSessionsProviderId,
-): string | null {
-  if (!metadata) return null;
-
-  const directSession = asMetadataRecord(metadata.directSessionV1);
-  if (directSession?.providerId === providerId) {
-    const directRemoteSessionId = normalizeNullableString(directSession.remoteSessionId);
-    if (directRemoteSessionId) return directRemoteSessionId;
-  }
-
-  switch (providerId) {
-    case 'codex': {
-      const codexSessionId = normalizeNullableString(metadata.codexSessionId);
-      if (codexSessionId) return codexSessionId;
-      break;
-    }
-    case 'claude': {
-      const claudeSessionId = normalizeNullableString(metadata.claudeSessionId);
-      if (claudeSessionId) return claudeSessionId;
-      break;
-    }
-    case 'opencode': {
-      const openCodeSessionId = normalizeNullableString(metadata.opencodeSessionId);
-      if (openCodeSessionId) return openCodeSessionId;
-      break;
-    }
-    case 'pi': {
-      const piSessionId = normalizeNullableString(metadata.piSessionId);
-      if (piSessionId) return piSessionId;
-      break;
-    }
-  }
-
-  const runtimeDescriptor = asMetadataRecord(metadata.agentRuntimeDescriptorV1);
-  if (runtimeDescriptor?.providerId !== providerId) return null;
-  const provider = asMetadataRecord(runtimeDescriptor.provider);
-  return normalizeNullableString(provider?.vendorSessionId);
-}
-
-function resolveMarkerProviderId(marker: DaemonSessionMarker): DirectSessionsProviderId | null {
-  const metadata = asMetadataRecord(marker.metadata);
-  const metadataFlavor = normalizeNullableString(metadata?.flavor);
-  if (metadataFlavor === 'claude' || metadataFlavor === 'codex' || metadataFlavor === 'opencode' || metadataFlavor === 'pi') {
-    return metadataFlavor;
-  }
-  if (marker.flavor === 'claude' || marker.flavor === 'codex' || marker.flavor === 'opencode' || marker.flavor === 'pi') {
-    return marker.flavor;
-  }
-  const respawn = asMetadataRecord(marker.respawn);
-  const backendTarget = asMetadataRecord(respawn?.backendTarget);
-  const agentId = normalizeNullableString(backendTarget?.agentId);
-  return agentId === 'claude' || agentId === 'codex' || agentId === 'opencode' || agentId === 'pi' ? agentId : null;
-}
-
-function resolveMarkerRemoteSessionId(marker: DaemonSessionMarker, providerId: DirectSessionsProviderId): string | null {
-  const respawn = asMetadataRecord(marker.respawn);
-  return normalizeNullableString(respawn?.resume)
-    ?? resolveMetadataRemoteSessionId(asMetadataRecord(marker.metadata), providerId);
-}
-
-function markerMatchesRemoteSession(
-  marker: DaemonSessionMarker,
-  providerId: DirectSessionsProviderId,
-  remoteSessionId: string,
-): boolean {
-  if (resolveMarkerProviderId(marker) !== providerId) return false;
-  return resolveMarkerRemoteSessionId(marker, providerId) === remoteSessionId;
 }
 
 function resolveMarkerDirectoryKeys(marker: DaemonSessionMarker): ReadonlySet<string> {
@@ -164,7 +97,11 @@ async function resolveConnectedServiceRuntimeSnapshotForDirectLink(params: Reado
     .filter((entry) => hasConnectedServiceBindings(entry.snapshot));
 
   const exactRemoteMatch = markersWithSnapshots
-    .filter((entry) => markerMatchesRemoteSession(entry.marker, params.providerId, params.remoteSessionId))
+    .filter((entry) => directSessionMarkerMatches({
+      marker: entry.marker,
+      providerId: params.providerId,
+      remoteSessionId: params.remoteSessionId,
+    }))
     .sort((left, right) => right.marker.updatedAt - left.marker.updatedAt)[0];
   if (exactRemoteMatch) return exactRemoteMatch.snapshot;
 
@@ -172,7 +109,7 @@ async function resolveConnectedServiceRuntimeSnapshotForDirectLink(params: Reado
   if (!directoryKey) return {};
 
   const contextualMatches = markersWithSnapshots
-    .filter((entry) => resolveMarkerProviderId(entry.marker) === params.providerId)
+    .filter((entry) => readDirectSessionMarkerProviderId(entry.marker) === params.providerId)
     .filter((entry) => resolveMarkerDirectoryKeys(entry.marker).has(directoryKey))
     .sort((left, right) => right.marker.updatedAt - left.marker.updatedAt);
 
@@ -574,10 +511,10 @@ async function findExistingSessionIdByTag(params: Readonly<{
   tag: string;
   metadataMatches?: (metadata: Readonly<Record<string, unknown>>) => boolean;
   metadataIdentityMatches?: (metadata: Readonly<Record<string, unknown>>) => boolean;
-}>): Promise<string | null> {
+}>): Promise<Readonly<{ sessionId: string; metadata: Record<string, unknown> }> | null> {
   const maxPages = resolveMaxScanPages();
 
-  const scan = async (archivedOnly: boolean): Promise<string | null> => {
+  const scan = async (archivedOnly: boolean): Promise<Readonly<{ sessionId: string; metadata: Record<string, unknown> }> | null> => {
     let cursor: string | undefined;
     for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
       const page = await fetchSessionsPage({ token: params.credentials.token, cursor, limit: 200, archivedOnly });
@@ -589,7 +526,7 @@ async function findExistingSessionIdByTag(params: Readonly<{
           (rowTag && rowTag === params.tag && (!params.metadataMatches || params.metadataMatches(meta)))
           || params.metadataIdentityMatches?.(meta) === true
         )) {
-          return row.id;
+          return { sessionId: row.id, metadata: meta };
         }
       }
       if (!page.hasNext || !page.nextCursor) break;
@@ -601,6 +538,18 @@ async function findExistingSessionIdByTag(params: Readonly<{
   const activeHit = await scan(false);
   if (activeHit) return activeHit;
   return await scan(true);
+}
+
+function isImportedPersistedSessionForIdentity(params: Readonly<{
+  metadata: Readonly<Record<string, unknown>>;
+  providerId: DirectSessionsProviderId;
+  remoteSessionId: string;
+}>): boolean {
+  if (asMetadataRecord(params.metadata.directSessionV1)) return false;
+  const imported = asMetadataRecord(params.metadata.externalHistoryImportV1);
+  return imported?.v === 1
+    && normalizeNullableString(imported.providerId) === params.providerId
+    && normalizeNullableString(imported.remoteSessionId) === params.remoteSessionId;
 }
 
 function metadataProvesCodexGroup(metadata: Readonly<Record<string, unknown>>, expectedGroupId: string): boolean {
@@ -760,8 +709,8 @@ export async function ensureDirectSessionLink(params: Readonly<{
     remoteSessionId,
     source,
   });
-  let existingSessionId = await findExistingSessionIdByTag({ credentials: params.credentials, tag });
-  if (!existingSessionId && params.providerId === 'codex' && source.kind === 'codexHome') {
+  let existingSession = await findExistingSessionIdByTag({ credentials: params.credentials, tag });
+  if (!existingSession && params.providerId === 'codex' && source.kind === 'codexHome') {
     const expectedGroupId = normalizeNullableString(source.connectedServiceGroupId);
     const predecessorTag = computeRemotePredecessorDirectSessionTag({
       machineId: params.machineId,
@@ -770,7 +719,7 @@ export async function ensureDirectSessionLink(params: Readonly<{
       source,
     });
     if (expectedGroupId && predecessorTag && predecessorTag !== tag) {
-      existingSessionId = await findExistingSessionIdByTag({
+      existingSession = await findExistingSessionIdByTag({
         credentials: params.credentials,
         tag: predecessorTag,
         metadataMatches: (metadata) => metadataProvesCodexGroup(metadata, expectedGroupId),
@@ -782,24 +731,33 @@ export async function ensureDirectSessionLink(params: Readonly<{
       });
     }
   }
-  if (existingSessionId) {
+  if (existingSession) {
+    const isImportedPersistedSession = isImportedPersistedSessionForIdentity({
+      metadata: existingSession.metadata,
+      providerId: params.providerId,
+      remoteSessionId,
+    });
     await refreshExistingDirectSessionMetadataIfNeeded({
       credentials: params.credentials,
-      sessionId: existingSessionId,
-      directSessionIdentity: {
-        tag,
-        machineId: params.machineId,
-        providerId: params.providerId,
-        remoteSessionId,
-        source,
-        codexBackendMode,
-        runtimeDescriptor,
-      },
+      sessionId: existingSession.sessionId,
+      ...(isImportedPersistedSession
+        ? {}
+        : {
+          directSessionIdentity: {
+            tag,
+            machineId: params.machineId,
+            providerId: params.providerId,
+            remoteSessionId,
+            source,
+            codexBackendMode,
+            runtimeDescriptor,
+          },
+        }),
       titleHint: params.titleHint,
       directoryHint: params.directoryHint,
       connectedServiceRuntimeSnapshot,
     });
-    return { sessionId: existingSessionId, created: false, tag };
+    return { sessionId: existingSession.sessionId, created: false, tag };
   }
 
   const metadata = buildDirectSessionMetadata({

--- a/apps/cli/src/api/directSessions/linking/ensureDirectSessionLink.ts
+++ b/apps/cli/src/api/directSessions/linking/ensureDirectSessionLink.ts
@@ -80,6 +80,11 @@ function resolveMetadataRemoteSessionId(
       if (openCodeSessionId) return openCodeSessionId;
       break;
     }
+    case 'pi': {
+      const piSessionId = normalizeNullableString(metadata.piSessionId);
+      if (piSessionId) return piSessionId;
+      break;
+    }
   }
 
   const runtimeDescriptor = asMetadataRecord(metadata.agentRuntimeDescriptorV1);
@@ -91,16 +96,16 @@ function resolveMetadataRemoteSessionId(
 function resolveMarkerProviderId(marker: DaemonSessionMarker): DirectSessionsProviderId | null {
   const metadata = asMetadataRecord(marker.metadata);
   const metadataFlavor = normalizeNullableString(metadata?.flavor);
-  if (metadataFlavor === 'claude' || metadataFlavor === 'codex' || metadataFlavor === 'opencode') {
+  if (metadataFlavor === 'claude' || metadataFlavor === 'codex' || metadataFlavor === 'opencode' || metadataFlavor === 'pi') {
     return metadataFlavor;
   }
-  if (marker.flavor === 'claude' || marker.flavor === 'codex' || marker.flavor === 'opencode') {
+  if (marker.flavor === 'claude' || marker.flavor === 'codex' || marker.flavor === 'opencode' || marker.flavor === 'pi') {
     return marker.flavor;
   }
   const respawn = asMetadataRecord(marker.respawn);
   const backendTarget = asMetadataRecord(respawn?.backendTarget);
   const agentId = normalizeNullableString(backendTarget?.agentId);
-  return agentId === 'claude' || agentId === 'codex' || agentId === 'opencode' ? agentId : null;
+  return agentId === 'claude' || agentId === 'codex' || agentId === 'opencode' || agentId === 'pi' ? agentId : null;
 }
 
 function resolveMarkerRemoteSessionId(marker: DaemonSessionMarker, providerId: DirectSessionsProviderId): string | null {
@@ -377,6 +382,11 @@ function resolveSourceKey(providerId: DirectSessionsProviderId, source: DirectSe
       const baseUrl = normalizeNullableString(source.baseUrl) ?? '';
       const directory = normalizeNullableString(source.directory) ?? '';
       return `opencodeServer:${baseUrl}:${directory}`;
+    }
+    case 'pi': {
+      if (source.kind !== 'piAgentDir') return 'piAgentDir:invalid';
+      const agentDir = normalizeNullableString(source.agentDir) ?? '';
+      return `piAgentDir:${agentDir}`;
     }
     default:
       return 'unknown';
@@ -678,6 +688,9 @@ function buildDirectSessionMetadata(params: Readonly<{
       break;
     case 'claude':
       base.claudeSessionId = params.remoteSessionId;
+      break;
+    case 'pi':
+      base.piSessionId = params.remoteSessionId;
       break;
     case 'opencode':
       base.opencodeSessionId = params.remoteSessionId;

--- a/apps/cli/src/api/directSessions/markers/readDirectSessionMarkerIdentity.ts
+++ b/apps/cli/src/api/directSessions/markers/readDirectSessionMarkerIdentity.ts
@@ -1,0 +1,70 @@
+import type { DirectSessionsProviderId } from '@happier-dev/protocol';
+
+import type { DaemonSessionMarker } from '@/daemon/sessionRegistry';
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readString(value: unknown): string | null {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized || null;
+}
+
+function readProviderId(value: unknown): DirectSessionsProviderId | null {
+  const normalized = readString(value);
+  return normalized === 'claude' || normalized === 'codex' || normalized === 'opencode' || normalized === 'pi'
+    ? normalized
+    : null;
+}
+
+export function readDirectSessionMarkerProviderId(marker: DaemonSessionMarker): DirectSessionsProviderId | null {
+  const metadata = readRecord(marker.metadata);
+  const respawn = readRecord(marker.respawn);
+  const backendTarget = readRecord(respawn?.backendTarget);
+  return readProviderId(metadata?.flavor)
+    ?? readProviderId(marker.flavor)
+    ?? readProviderId(backendTarget?.agentId);
+}
+
+export function readDirectSessionMarkerRemoteSessionId(
+  marker: DaemonSessionMarker,
+  providerId: DirectSessionsProviderId,
+): string | null {
+  const respawn = readRecord(marker.respawn);
+  const resume = readString(respawn?.resume);
+  if (resume) return resume;
+
+  const metadata = readRecord(marker.metadata);
+  const directSession = readRecord(metadata?.directSessionV1);
+  if (readProviderId(directSession?.providerId) === providerId) {
+    const directRemoteSessionId = readString(directSession?.remoteSessionId);
+    if (directRemoteSessionId) return directRemoteSessionId;
+  }
+
+  const legacyId = readString(metadata?.[
+    providerId === 'codex'
+      ? 'codexSessionId'
+      : providerId === 'claude'
+        ? 'claudeSessionId'
+        : providerId === 'opencode'
+          ? 'opencodeSessionId'
+          : 'piSessionId'
+  ]);
+  if (legacyId) return legacyId;
+
+  const runtimeDescriptor = readRecord(metadata?.agentRuntimeDescriptorV1);
+  if (readProviderId(runtimeDescriptor?.providerId) !== providerId) return null;
+  return readString(readRecord(runtimeDescriptor?.provider)?.vendorSessionId);
+}
+
+export function directSessionMarkerMatches(params: Readonly<{
+  marker: DaemonSessionMarker;
+  providerId: DirectSessionsProviderId;
+  remoteSessionId: string;
+}>): boolean {
+  return readDirectSessionMarkerProviderId(params.marker) === params.providerId
+    && readDirectSessionMarkerRemoteSessionId(params.marker, params.providerId) === params.remoteSessionId;
+}

--- a/apps/cli/src/api/directSessions/security/validateDirectMachineSource.test.ts
+++ b/apps/cli/src/api/directSessions/security/validateDirectMachineSource.test.ts
@@ -59,4 +59,45 @@ describe('validateDirectMachineSource', () => {
       },
     });
   });
+
+  it('accepts a pi piAgentDir source and resolves the agentDir from PI_CODING_AGENT_DIR', () => {
+    expect(
+      validateDirectMachineSource({
+        providerId: 'pi',
+        source: { kind: 'piAgentDir' },
+        env: {
+          HOME: '/Users/tester',
+          PI_CODING_AGENT_DIR: '~/.pi/agent',
+        },
+      }),
+    ).toEqual({
+      ok: true,
+      source: {
+        kind: 'piAgentDir',
+        agentDir: '/Users/tester/.pi/agent',
+      },
+    });
+  });
+
+  it('rejects a pi agentDir override that does not match the daemon-configured dir', () => {
+    const result = validateDirectMachineSource({
+      providerId: 'pi',
+      source: { kind: 'piAgentDir', agentDir: '/etc/passwd' },
+      env: { PI_CODING_AGENT_DIR: '/tmp/pi-agent-configured' },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('source agentDir override is not allowed');
+    }
+  });
+
+  it('rejects a pi provider with a mismatched source kind', () => {
+    expect(
+      validateDirectMachineSource({
+        providerId: 'pi',
+        source: { kind: 'claudeConfig', configDir: '/tmp/.claude' },
+        env: {},
+      }),
+    ).toEqual({ ok: false, error: 'provider/source mismatch' });
+  });
 });

--- a/apps/cli/src/api/directSessions/security/validateDirectMachineSource.ts
+++ b/apps/cli/src/api/directSessions/security/validateDirectMachineSource.ts
@@ -7,6 +7,7 @@ import { expandHomeDirPath } from '@happier-dev/cli-common/providers';
 import {
   resolveConfiguredClaudeConfigDir,
 } from '@/backends/claude/directSessions/resolveClaudeConfigDir';
+import { resolvePiAgentDir } from '@/backends/pi/directSessions/resolvePiAgentDir';
 
 type DirectSourceValidationResult =
   | Readonly<{ ok: true; source: DirectSessionsSource }>
@@ -69,6 +70,27 @@ export function validateDirectMachineSource(params: Readonly<{
         source: {
           ...source,
           configDir: configuredConfigDir,
+        },
+      };
+    }
+    case 'pi': {
+      if (source.kind !== 'piAgentDir') return err('provider/source mismatch');
+      const requestedAgentDir =
+        typeof source.agentDir === 'string' && source.agentDir.trim().length > 0
+          ? canonicalizePath(source.agentDir, env)
+          : null;
+      // The configured dir is daemon-controlled (env PI_CODING_AGENT_DIR or default ~/.pi/agent).
+      // A client may omit agentDir; if supplied it must match the configured dir (path-traversal guard,
+      // mirroring the claude configDir policy).
+      const configuredAgentDir = canonicalizePath(resolvePiAgentDir({ source: { kind: 'piAgentDir' }, env }), env);
+      if (requestedAgentDir && requestedAgentDir !== configuredAgentDir) {
+        return err('source agentDir override is not allowed');
+      }
+      return {
+        ok: true,
+        source: {
+          ...source,
+          agentDir: configuredAgentDir,
         },
       };
     }

--- a/apps/cli/src/api/directSessions/takeover/findTrustedDirectSessionOwner.test.ts
+++ b/apps/cli/src/api/directSessions/takeover/findTrustedDirectSessionOwner.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DaemonSessionMarker } from '@/daemon/sessionRegistry';
+
+import { findTrustedDirectSessionOwner } from './findTrustedDirectSessionOwner';
+
+describe('findTrustedDirectSessionOwner', () => {
+  it('finds a live Happier-managed pi owner by its persisted pi session id', () => {
+    const marker = {
+      pid: 4242,
+      happySessionId: 'happy_pi_owner',
+      updatedAt: 200,
+      flavor: 'pi',
+      metadata: { flavor: 'pi', piSessionId: 'pi-session-1' },
+    } as DaemonSessionMarker;
+
+    expect(findTrustedDirectSessionOwner({
+      markers: [marker],
+      providerId: 'pi',
+      remoteSessionId: 'pi-session-1',
+      isPidAlive: () => true,
+    })).toBe(marker);
+  });
+});

--- a/apps/cli/src/api/directSessions/takeover/findTrustedDirectSessionOwner.ts
+++ b/apps/cli/src/api/directSessions/takeover/findTrustedDirectSessionOwner.ts
@@ -1,32 +1,7 @@
 import type { DirectSessionsProviderId } from '@happier-dev/protocol';
 
 import type { DaemonSessionMarker } from '@/daemon/sessionRegistry';
-
-function extractVendorSessionIdFromMarkerMetadata(params: Readonly<{
-  providerId: DirectSessionsProviderId;
-  metadata: unknown;
-}>): string | null {
-  if (!params.metadata || typeof params.metadata !== 'object' || Array.isArray(params.metadata)) return null;
-  const rec = params.metadata as Record<string, unknown>;
-  const expectedFlavor = typeof rec.flavor === 'string' ? rec.flavor.trim() : '';
-  if (expectedFlavor && expectedFlavor !== params.providerId) return null;
-
-      const raw = (() => {
-        switch (params.providerId) {
-          case 'codex':
-            return rec.codexSessionId;
-          case 'claude':
-            return rec.claudeSessionId;
-          case 'opencode':
-            return rec.opencodeSessionId;
-          default:
-            return null;
-        }
-      })();
-
-  const normalized = typeof raw === 'string' ? raw.trim() : '';
-  return normalized.length > 0 ? normalized : null;
-}
+import { directSessionMarkerMatches } from '@/api/directSessions/markers/readDirectSessionMarkerIdentity';
 
 export function findTrustedDirectSessionOwner(params: Readonly<{
   markers: readonly DaemonSessionMarker[];
@@ -40,14 +15,7 @@ export function findTrustedDirectSessionOwner(params: Readonly<{
 
   const candidates = params.markers
     .filter((marker) => Number.isFinite(marker.pid) && marker.pid > 0 && isPidAlive(marker.pid))
-    .filter((marker) => marker.flavor === params.providerId)
-    .filter(
-      (marker) =>
-        extractVendorSessionIdFromMarkerMetadata({
-          providerId: params.providerId,
-          metadata: marker.metadata,
-        }) === remoteSessionId,
-    )
+    .filter((marker) => directSessionMarkerMatches({ marker, providerId: params.providerId, remoteSessionId }))
     .sort((a, b) => b.updatedAt - a.updatedAt || b.pid - a.pid);
 
   return candidates[0] ?? null;

--- a/apps/cli/src/api/directSessions/takeover/loadLinkedDirectSession.test.ts
+++ b/apps/cli/src/api/directSessions/takeover/loadLinkedDirectSession.test.ts
@@ -19,6 +19,62 @@ describe('loadLinkedDirectSession', () => {
     vi.clearAllMocks();
   });
 
+  it('re-links a converted session from its external history import record', async () => {
+    fetchSessionByIdMock.mockResolvedValueOnce({ id: 'sess_converted' });
+    tryDecryptSessionMetadataMock.mockReturnValueOnce({
+      path: '/home/kunde21',
+      tag: 'direct:v1:a94278a6cd532c1f472c99c66d7c6ade3ef4a38565ebded7bcfc1d76b6948841',
+      // takeover.persist deletes directSessionV1 after import and records the provenance instead.
+      externalHistoryImportV1: {
+        v: 1,
+        providerId: 'pi',
+        remoteSessionId: '01a00481-8cdc-78ff-a4aa-9b243badd9fb',
+        importedAtMs: 123,
+        source: { kind: 'piAgentDir', agentDir: '/home/kunde21/.pi/agent' },
+      },
+    });
+
+    const result = await loadLinkedDirectSession({
+      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
+      sessionId: 'sess_converted',
+      machineId: 'machine_1',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      session: expect.objectContaining({
+        providerId: 'pi',
+        machineId: 'machine_1',
+        remoteSessionId: '01a00481-8cdc-78ff-a4aa-9b243badd9fb',
+        source: { kind: 'piAgentDir', agentDir: '/home/kunde21/.pi/agent' },
+      }),
+    });
+  });
+
+  it('still rejects a converted session when no machine scope can back the relink', async () => {
+    fetchSessionByIdMock.mockResolvedValueOnce({ id: 'sess_converted_no_machine' });
+    tryDecryptSessionMetadataMock.mockReturnValueOnce({
+      externalHistoryImportV1: {
+        v: 1,
+        providerId: 'pi',
+        remoteSessionId: '01a00481-8cdc-78ff-a4aa-9b243badd9fb',
+        importedAtMs: 123,
+        source: { kind: 'piAgentDir', agentDir: '/home/kunde21/.pi/agent' },
+      },
+    });
+
+    const result = await loadLinkedDirectSession({
+      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
+      sessionId: 'sess_converted_no_machine',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      errorCode: 'invalid_request',
+      error: 'session_is_not_direct',
+    });
+  });
+
   it('prefers the nested OpenCode runtime descriptor over stale legacy metadata', async () => {
     fetchSessionByIdMock.mockResolvedValueOnce({ id: 'sess_1' });
     tryDecryptSessionMetadataMock.mockReturnValueOnce({

--- a/apps/cli/src/api/directSessions/takeover/loadLinkedDirectSession.test.ts
+++ b/apps/cli/src/api/directSessions/takeover/loadLinkedDirectSession.test.ts
@@ -19,7 +19,7 @@ describe('loadLinkedDirectSession', () => {
     vi.clearAllMocks();
   });
 
-  it('re-links a converted session from its external history import record', async () => {
+  it('does not reinterpret an imported persisted session as a direct session', async () => {
     fetchSessionByIdMock.mockResolvedValueOnce({ id: 'sess_converted' });
     tryDecryptSessionMetadataMock.mockReturnValueOnce({
       path: '/home/kunde21',
@@ -38,34 +38,6 @@ describe('loadLinkedDirectSession', () => {
       credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
       sessionId: 'sess_converted',
       machineId: 'machine_1',
-    });
-
-    expect(result).toEqual({
-      ok: true,
-      session: expect.objectContaining({
-        providerId: 'pi',
-        machineId: 'machine_1',
-        remoteSessionId: '01a00481-8cdc-78ff-a4aa-9b243badd9fb',
-        source: { kind: 'piAgentDir', agentDir: '/home/kunde21/.pi/agent' },
-      }),
-    });
-  });
-
-  it('still rejects a converted session when no machine scope can back the relink', async () => {
-    fetchSessionByIdMock.mockResolvedValueOnce({ id: 'sess_converted_no_machine' });
-    tryDecryptSessionMetadataMock.mockReturnValueOnce({
-      externalHistoryImportV1: {
-        v: 1,
-        providerId: 'pi',
-        remoteSessionId: '01a00481-8cdc-78ff-a4aa-9b243badd9fb',
-        importedAtMs: 123,
-        source: { kind: 'piAgentDir', agentDir: '/home/kunde21/.pi/agent' },
-      },
-    });
-
-    const result = await loadLinkedDirectSession({
-      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array([1]) } },
-      sessionId: 'sess_converted_no_machine',
     });
 
     expect(result).toEqual({

--- a/apps/cli/src/api/directSessions/takeover/loadLinkedDirectSession.ts
+++ b/apps/cli/src/api/directSessions/takeover/loadLinkedDirectSession.ts
@@ -104,42 +104,6 @@ function resolveCanonicalDirectSource(params: Readonly<{
   return params.source;
 }
 
-/**
- * Rebuild a direct-session identity for a session that takeover.persist converted
- * (directSessionV1 deleted, externalHistoryImportV1 recorded). The identity is
- * machine-scoped to the requesting machine, and the result still has to pass
- * DirectSessionMetadataSchema. Returns null when the record cannot back a relink.
- */
-function rebuildDirectSessionMetadataFromImportRecord(
-  metadata: Record<string, unknown>,
-  requestMachineId: string | undefined,
-): Record<string, unknown> | null {
-  const machineId = typeof requestMachineId === 'string' ? requestMachineId.trim() : '';
-  if (!machineId) return null;
-
-  const importRecord = metadata.externalHistoryImportV1;
-  if (!importRecord || typeof importRecord !== 'object' || Array.isArray(importRecord)) return null;
-  const record = importRecord as Record<string, unknown>;
-  if (record.v !== 1) return null;
-  if (!DirectSessionsProviderIdSchema.safeParse(record.providerId).success) return null;
-  if (typeof record.remoteSessionId !== 'string' || !record.remoteSessionId.trim()) return null;
-  if (!DirectSessionsSourceSchema.safeParse(record.source).success) return null;
-  const importedAtMs = record.importedAtMs;
-  if (typeof importedAtMs !== 'number' || !Number.isFinite(importedAtMs) || importedAtMs < 0) return null;
-
-  return {
-    ...metadata,
-    directSessionV1: {
-      v: 1,
-      providerId: record.providerId,
-      machineId,
-      remoteSessionId: record.remoteSessionId,
-      source: record.source,
-      linkedAtMs: Math.trunc(importedAtMs),
-    },
-  };
-}
-
 export async function loadLinkedDirectSession(params: Readonly<{
   credentials: Credentials;
   sessionId: string;
@@ -158,17 +122,7 @@ export async function loadLinkedDirectSession(params: Readonly<{
     return { ok: false, errorCode: 'provider_unavailable', error: 'session_metadata_unavailable' };
   }
 
-  let parsed = DirectSessionMetadataSchema.safeParse(metadata);
-  if (!parsed.success) {
-    // takeover.persist converts imported sessions by deleting directSessionV1 and recording
-    // externalHistoryImportV1. That conversion must not dead-end re-imports of the same remote
-    // session: rebuild the direct identity from the import record so a second take-over/import
-    // of the same vendor session stays idempotent.
-    const rebuilt = rebuildDirectSessionMetadataFromImportRecord(metadata, params.machineId);
-    if (rebuilt) {
-      parsed = DirectSessionMetadataSchema.safeParse(rebuilt);
-    }
-  }
+  const parsed = DirectSessionMetadataSchema.safeParse(metadata);
   if (!parsed.success) {
     return { ok: false, errorCode: 'invalid_request', error: 'session_is_not_direct' };
   }

--- a/apps/cli/src/api/directSessions/takeover/loadLinkedDirectSession.ts
+++ b/apps/cli/src/api/directSessions/takeover/loadLinkedDirectSession.ts
@@ -104,6 +104,42 @@ function resolveCanonicalDirectSource(params: Readonly<{
   return params.source;
 }
 
+/**
+ * Rebuild a direct-session identity for a session that takeover.persist converted
+ * (directSessionV1 deleted, externalHistoryImportV1 recorded). The identity is
+ * machine-scoped to the requesting machine, and the result still has to pass
+ * DirectSessionMetadataSchema. Returns null when the record cannot back a relink.
+ */
+function rebuildDirectSessionMetadataFromImportRecord(
+  metadata: Record<string, unknown>,
+  requestMachineId: string | undefined,
+): Record<string, unknown> | null {
+  const machineId = typeof requestMachineId === 'string' ? requestMachineId.trim() : '';
+  if (!machineId) return null;
+
+  const importRecord = metadata.externalHistoryImportV1;
+  if (!importRecord || typeof importRecord !== 'object' || Array.isArray(importRecord)) return null;
+  const record = importRecord as Record<string, unknown>;
+  if (record.v !== 1) return null;
+  if (!DirectSessionsProviderIdSchema.safeParse(record.providerId).success) return null;
+  if (typeof record.remoteSessionId !== 'string' || !record.remoteSessionId.trim()) return null;
+  if (!DirectSessionsSourceSchema.safeParse(record.source).success) return null;
+  const importedAtMs = record.importedAtMs;
+  if (typeof importedAtMs !== 'number' || !Number.isFinite(importedAtMs) || importedAtMs < 0) return null;
+
+  return {
+    ...metadata,
+    directSessionV1: {
+      v: 1,
+      providerId: record.providerId,
+      machineId,
+      remoteSessionId: record.remoteSessionId,
+      source: record.source,
+      linkedAtMs: Math.trunc(importedAtMs),
+    },
+  };
+}
+
 export async function loadLinkedDirectSession(params: Readonly<{
   credentials: Credentials;
   sessionId: string;
@@ -122,7 +158,17 @@ export async function loadLinkedDirectSession(params: Readonly<{
     return { ok: false, errorCode: 'provider_unavailable', error: 'session_metadata_unavailable' };
   }
 
-  const parsed = DirectSessionMetadataSchema.safeParse(metadata);
+  let parsed = DirectSessionMetadataSchema.safeParse(metadata);
+  if (!parsed.success) {
+    // takeover.persist converts imported sessions by deleting directSessionV1 and recording
+    // externalHistoryImportV1. That conversion must not dead-end re-imports of the same remote
+    // session: rebuild the direct identity from the import record so a second take-over/import
+    // of the same vendor session stays idempotent.
+    const rebuilt = rebuildDirectSessionMetadataFromImportRecord(metadata, params.machineId);
+    if (rebuilt) {
+      parsed = DirectSessionMetadataSchema.safeParse(rebuilt);
+    }
+  }
   if (!parsed.success) {
     return { ok: false, errorCode: 'invalid_request', error: 'session_is_not_direct' };
   }

--- a/apps/cli/src/api/directSessions/takeover/resolveDirectTakeoverSpawnOptions.ts
+++ b/apps/cli/src/api/directSessions/takeover/resolveDirectTakeoverSpawnOptions.ts
@@ -7,59 +7,18 @@ import {
   type ConnectedServiceRuntimeSnapshot,
 } from '@/daemon/connectedServices/connectedServiceRuntimeSnapshot';
 import { listSessionMarkers, type DaemonSessionMarker } from '@/daemon/sessionRegistry';
+import { directSessionMarkerMatches } from '@/api/directSessions/markers/readDirectSessionMarkerIdentity';
 import type { LoadedLinkedDirectSession } from './loadLinkedDirectSession';
-
-function readRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
-}
-
-function normalizeNullableString(value: unknown): string | null {
-  if (value === null) return null;
-  const normalized = String(value ?? '').trim();
-  return normalized ? normalized : null;
-}
-
-function resolveMarkerProviderId(marker: DaemonSessionMarker): LoadedLinkedDirectSession['providerId'] | null {
-  const metadata = readRecord(marker.metadata);
-  const metadataFlavor = normalizeNullableString(metadata?.flavor);
-  if (metadataFlavor === 'claude' || metadataFlavor === 'codex' || metadataFlavor === 'opencode') {
-    return metadataFlavor;
-  }
-  if (marker.flavor === 'claude' || marker.flavor === 'codex' || marker.flavor === 'opencode') {
-    return marker.flavor;
-  }
-  const respawn = readRecord(marker.respawn);
-  const backendTarget = readRecord(respawn?.backendTarget);
-  const agentId = normalizeNullableString(backendTarget?.agentId);
-  return agentId === 'claude' || agentId === 'codex' || agentId === 'opencode' ? agentId : null;
-}
-
-function resolveMetadataRemoteSessionId(
-  metadata: Readonly<Record<string, unknown>> | null,
-  providerId: LoadedLinkedDirectSession['providerId'],
-): string | null {
-  if (!metadata) return null;
-  const directSession = readRecord(metadata.directSessionV1);
-  if (directSession?.providerId === providerId) {
-    const directRemoteSessionId = normalizeNullableString(directSession.remoteSessionId);
-    if (directRemoteSessionId) return directRemoteSessionId;
-  }
-  if (providerId === 'codex') return normalizeNullableString(metadata.codexSessionId);
-  if (providerId === 'claude') return normalizeNullableString(metadata.claudeSessionId);
-  if (providerId === 'opencode') return normalizeNullableString(metadata.opencodeSessionId);
-  return null;
-}
 
 function markerMatchesDirectSession(
   marker: DaemonSessionMarker,
   linked: LoadedLinkedDirectSession,
 ): boolean {
-  if (resolveMarkerProviderId(marker) !== linked.providerId) return false;
-  const respawn = readRecord(marker.respawn);
-  const markerRemoteSessionId =
-    normalizeNullableString(respawn?.resume)
-    ?? resolveMetadataRemoteSessionId(readRecord(marker.metadata), linked.providerId);
-  return markerRemoteSessionId === linked.remoteSessionId;
+  return directSessionMarkerMatches({
+    marker,
+    providerId: linked.providerId,
+    remoteSessionId: linked.remoteSessionId,
+  });
 }
 
 async function resolveTrackedConnectedServiceRuntimeSnapshot(

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.linkEnsure.integration.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.linkEnsure.integration.test.ts
@@ -11,6 +11,7 @@ import { bindApiSessionSocketMock, createApiSessionSocketStub } from '@/testkit/
 import { createEnvKeyScope } from '@/testkit/env/envScope';
 import { createTempDir, removeTempDir } from '@/testkit/fs/tempDir';
 import type { Credentials } from '@/persistence';
+import type { RpcHandlerRegistrar } from '@/api/rpc/types';
 
 const { mockIo, readCredentialsMock } = vi.hoisted(() => ({
   mockIo: vi.fn(),
@@ -299,12 +300,12 @@ describe('daemon.directSessions.link.ensure (integration)', () => {
   it('creates a linked pi direct session with piSessionId metadata and an active-branch source', async () => {
     const { registerMachineDirectSessionsRpcHandlers } = await import('./rpcHandlers.directSessions');
 
-    const registered = new Map<string, (params: any) => Promise<any>>();
-    const rpcHandlerManager = {
-      registerHandler: (method: string, handler: (params: any) => Promise<any>) => {
-        registered.set(method, handler);
+    const registered = new Map<string, (params: unknown) => Promise<unknown>>();
+    const rpcHandlerManager: RpcHandlerRegistrar = {
+      registerHandler: (method, handler) => {
+        registered.set(method, async (params) => handler(params as never));
       },
-    } as any;
+    };
 
     registerMachineDirectSessionsRpcHandlers({ rpcHandlerManager });
 
@@ -318,7 +319,7 @@ describe('daemon.directSessions.link.ensure (integration)', () => {
       titleHint: 'Linked Pi Session',
       directoryHint: '/tmp/project-pi',
       source: { kind: 'piAgentDir' },
-    });
+    }) as { ok: boolean; created: boolean; sessionId: string };
 
     expect(res.ok).toBe(true);
     expect(res.created).toBe(true);

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.linkEnsure.integration.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.linkEnsure.integration.test.ts
@@ -35,6 +35,7 @@ describe('daemon.directSessions.link.ensure (integration)', () => {
     'HAPPIER_WEBAPP_URL',
     'HAPPIER_HOME_DIR',
     'HAPPIER_CLAUDE_CONFIG_DIR',
+    'PI_CODING_AGENT_DIR',
   ] as const;
   let envScope = createEnvKeyScope(envKeys);
   let server: Server | null = null;
@@ -147,6 +148,7 @@ describe('daemon.directSessions.link.ensure (integration)', () => {
     process.env.HAPPIER_WEBAPP_URL = 'http://127.0.0.1:3000';
     process.env.HAPPIER_HOME_DIR = happyHomeDir;
     process.env.HAPPIER_CLAUDE_CONFIG_DIR = '/tmp';
+    process.env.PI_CODING_AGENT_DIR = happyHomeDir;
 
     const { reloadConfiguration } = await import('@/configuration');
     reloadConfiguration();
@@ -292,6 +294,62 @@ describe('daemon.directSessions.link.ensure (integration)', () => {
 
     expect(parsedMeta.data.codexBackendMode).toBe('appServer');
     expect(parsedMeta.data.directSessionV1.codexBackendMode).toBe('appServer');
+  });
+
+  it('creates a linked pi direct session with piSessionId metadata and an active-branch source', async () => {
+    const { registerMachineDirectSessionsRpcHandlers } = await import('./rpcHandlers.directSessions');
+
+    const registered = new Map<string, (params: any) => Promise<any>>();
+    const rpcHandlerManager = {
+      registerHandler: (method: string, handler: (params: any) => Promise<any>) => {
+        registered.set(method, handler);
+      },
+    } as any;
+
+    registerMachineDirectSessionsRpcHandlers({ rpcHandlerManager });
+
+    const handler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSION_LINK_ENSURE);
+    expect(handler).toBeDefined();
+
+    const res = await handler!({
+      machineId: 'machine_1',
+      providerId: 'pi',
+      remoteSessionId: 'remote_pi_123',
+      titleHint: 'Linked Pi Session',
+      directoryHint: '/tmp/project-pi',
+      source: { kind: 'piAgentDir' },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.created).toBe(true);
+    expect(typeof res.sessionId).toBe('string');
+
+    const createdSession = sessionsById.get(res.sessionId);
+    const creds = await readCredentialsMock();
+    const meta = tryDecryptSessionMetadata({ credentials: creds!, rawSession: createdSession });
+    const parsedMeta = z.object({
+      tag: z.string().min(1),
+      name: z.string(),
+      path: z.string(),
+      piSessionId: z.string(),
+      directSessionV1: z.object({
+        providerId: z.literal('pi'),
+        remoteSessionId: z.string().min(1),
+        machineId: z.string().min(1),
+        source: z.object({ kind: z.literal('piAgentDir') }).passthrough(),
+      }).passthrough(),
+    }).passthrough().safeParse(meta);
+    if (!parsedMeta.success) {
+      throw new Error('Expected pi direct session metadata payload');
+    }
+
+    expect(parsedMeta.data.tag).toMatch(/^direct:v1:/);
+    expect(parsedMeta.data.name).toBe('Linked Pi Session');
+    expect(parsedMeta.data.path).toBe('/tmp/project-pi');
+    expect(parsedMeta.data.piSessionId).toBe('remote_pi_123');
+    expect(parsedMeta.data.directSessionV1.providerId).toBe('pi');
+    expect(parsedMeta.data.directSessionV1.remoteSessionId).toBe('remote_pi_123');
+    expect(parsedMeta.data.directSessionV1.source.kind).toBe('piAgentDir');
   });
 
   it('returns created=false and the same sessionId on repeat calls', async () => {

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.pi.integration.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.pi.integration.test.ts
@@ -1,0 +1,166 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RPC_METHODS } from '@happier-dev/protocol/rpc';
+
+vi.mock('@/configuration', () => ({
+  configuration: {
+    activeServerDir: '/tmp/happier-test-active-server',
+    happyHomeDir: '/tmp/happier-test-home',
+    logsDir: '/tmp',
+    isDaemonProcess: false,
+  },
+}));
+
+vi.mock('@/persistence', () => ({
+  readCredentials: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/session/transport/http/sessionsHttp', async () => {
+  const actual = await vi.importActual<typeof import('@/session/transport/http/sessionsHttp')>('@/session/transport/http/sessionsHttp');
+  return {
+    ...actual,
+    fetchSessionById: vi.fn().mockResolvedValue(null),
+    commitSessionStoredMessage: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('@/session/metadata/updateSessionMetadataWithRetry', () => ({
+  updateSessionMetadataWithRetry: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerMachineDirectSessionsRpcHandlers } from './rpcHandlers.directSessions';
+
+const SESSION_ID = '019f4a42-4617-767a-8e7c-189b454a0352';
+
+function freshAgentDir(): string {
+  return mkdtempSync(join(tmpdir(), 'pi-rpc-int-'));
+}
+
+function writeSession(agentDir: string, lines: readonly object[]): void {
+  const sessionsDir = join(agentDir, 'sessions', '--proj--');
+  mkdirSync(sessionsDir, { recursive: true });
+  const filePath = join(sessionsDir, `2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl`);
+  writeFileSync(filePath, lines.map((line) => JSON.stringify(line)).join('\n') + '\n');
+}
+
+const header = { type: 'session', id: SESSION_ID, timestamp: '2024-12-03T14:00:00.000Z', cwd: '/proj', version: 3 };
+
+function msg(id: string, parentId: string | null, role: string, text: string, ts: string): object {
+  return { type: 'message', id, parentId, timestamp: ts, message: { role, content: [{ type: 'text', text }], timestamp: Date.parse(ts) } };
+}
+
+/**
+ * Exercises the daemon→pi direct-session RPC wiring with the REAL catalog + REAL pi providerOps
+ * against a fixture pi session on disk. This proves the full local stack — request schema
+ * validation, validateDirectMachineSource, getDirectSessionProviderOps('pi'), provider discovery /
+ * paging / readAfter — without a server or auth. Discriminating: the fixture has an abandoned
+ * sibling branch so active-branch selection must come through the RPC layer too.
+ */
+describe('registerMachineDirectSessionsRpcHandlers: pi integration', () => {
+  let agentDir: string;
+  let registered: Map<string, (params: unknown) => Promise<unknown>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    agentDir = freshAgentDir();
+    vi.stubEnv('PI_CODING_AGENT_DIR', agentDir);
+
+    // Active branch is m1→m2→m3→m4 (leaf). m_alt is a sibling of m2 off m1; appended before the
+    // leaf so the last-in-file leaf rule still resolves to m4, excluding the abandoned branch.
+    writeSession(agentDir, [
+      header,
+      msg('m1', null, 'user', 'one', '2024-12-03T14:00:01.000Z'),
+      msg('m2', 'm1', 'assistant', 'two', '2024-12-03T14:00:02.000Z'),
+      msg('m_alt', 'm1', 'assistant', 'alt branch', '2024-12-03T14:00:02.500Z'),
+      msg('m3', 'm2', 'user', 'three', '2024-12-03T14:00:03.000Z'),
+      msg('m4', 'm3', 'assistant', 'four', '2024-12-03T14:00:04.000Z'),
+    ]);
+
+    registered = new Map();
+    const rpcHandlerManager = {
+      registerHandler: (method: string, handler: (params: unknown) => Promise<unknown>) => {
+        registered.set(method, handler);
+      },
+    } as unknown as Parameters<typeof registerMachineDirectSessionsRpcHandlers>[0]['rpcHandlerManager'];
+    registerMachineDirectSessionsRpcHandlers({ rpcHandlerManager });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('lists pi sessions through the daemon RPC wiring', async () => {
+    const handler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSIONS_CANDIDATES_LIST)!;
+    const res = (await handler({
+      machineId: 'm1',
+      providerId: 'pi',
+      source: { kind: 'piAgentDir' },
+    })) as { ok: boolean; candidates?: { remoteSessionId: string }[]; errorCode?: string; error?: string };
+
+    expect(res.ok).toBe(true);
+    expect(res.candidates?.some((c) => c.remoteSessionId === SESSION_ID)).toBe(true);
+  });
+
+  it('pages the pi active branch through the daemon RPC wiring, excluding the abandoned sibling', async () => {
+    const handler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSION_TRANSCRIPT_PAGE)!;
+    const res = (await handler({
+      machineId: 'm1',
+      providerId: 'pi',
+      source: { kind: 'piAgentDir' },
+      remoteSessionId: SESSION_ID,
+      direction: 'older',
+      maxItems: 10,
+    })) as { ok: boolean; items?: { id: string; createdAtMs: number }[]; errorCode?: string };
+
+    expect(res.ok).toBe(true);
+    expect(res.items).toHaveLength(4);
+    // active branch only — m_alt excluded
+    expect(res.items!.map((i) => i.id.slice(-2))).toEqual(['m1', 'm2', 'm3', 'm4']);
+    // chronological
+    for (let i = 1; i < res.items!.length; i += 1) {
+      expect(res.items![i]!.createdAtMs).toBeGreaterThanOrEqual(res.items![i - 1]!.createdAtMs);
+    }
+  });
+
+  it('readAfter returns the tail after a forward cursor through the daemon RPC wiring', async () => {
+    const pageHandler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSION_TRANSCRIPT_PAGE)!;
+    const firstPage = (await pageHandler({
+      machineId: 'm1',
+      providerId: 'pi',
+      source: { kind: 'piAgentDir' },
+      remoteSessionId: SESSION_ID,
+      direction: 'older',
+      maxItems: 2,
+    })) as { ok: boolean; items?: unknown[]; tailCursor?: string | null };
+
+    // tailCursor points at the end of the file; a static session has nothing after it.
+    const readAfterHandler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSION_TRANSCRIPT_READ_AFTER)!;
+    const res = (await readAfterHandler({
+      machineId: 'm1',
+      providerId: 'pi',
+      source: { kind: 'piAgentDir' },
+      remoteSessionId: SESSION_ID,
+      cursor: firstPage.tailCursor,
+    })) as { ok: boolean; items?: unknown[]; errorCode?: string };
+
+    expect(res.ok).toBe(true);
+    expect(res.items).toEqual([]);
+  });
+
+  it('rejects a client-supplied agentDir that does not match the daemon-configured dir', async () => {
+    const handler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSIONS_CANDIDATES_LIST)!;
+    const res = (await handler({
+      machineId: 'm1',
+      providerId: 'pi',
+      source: { kind: 'piAgentDir', agentDir: '/etc/passwd' },
+    })) as { ok: boolean; errorCode?: string };
+
+    expect(res.ok).toBe(false);
+    expect(res.errorCode).toBe('invalid_request');
+  });
+});

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.pi.integration.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.pi.integration.test.ts
@@ -1,10 +1,11 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RPC_METHODS } from '@happier-dev/protocol/rpc';
+import type { RpcHandlerRegistrar } from '@/api/rpc/types';
 
 vi.mock('@/configuration', () => ({
   configuration: {
@@ -82,16 +83,17 @@ describe('registerMachineDirectSessionsRpcHandlers: pi integration', () => {
     ]);
 
     registered = new Map();
-    const rpcHandlerManager = {
-      registerHandler: (method: string, handler: (params: unknown) => Promise<unknown>) => {
-        registered.set(method, handler);
+    const rpcHandlerManager: RpcHandlerRegistrar = {
+      registerHandler: (method, handler) => {
+        registered.set(method, async (params) => handler(params as never));
       },
-    } as unknown as Parameters<typeof registerMachineDirectSessionsRpcHandlers>[0]['rpcHandlerManager'];
+    };
     registerMachineDirectSessionsRpcHandlers({ rpcHandlerManager });
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    rmSync(agentDir, { recursive: true, force: true });
   });
 
   it('lists pi sessions through the daemon RPC wiring', async () => {

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
@@ -204,29 +204,48 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
       },
     } as any;
 
-    registerMachineDirectSessionsRpcHandlers({ rpcHandlerManager, spawnSession, stopSession });
+    const markerDir = join('/tmp/happier-test-home', 'tmp', 'daemon-sessions');
+    const markerPath = join(markerDir, `pid-${process.pid}.json`);
+    await mkdir(markerDir, { recursive: true });
+    await writeFile(markerPath, JSON.stringify({
+      pid: process.pid,
+      happySessionId: 'sess_existing_pi_owner',
+      happyHomeDir: '/tmp/happier-test-home',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      flavor: 'pi',
+      metadata: { flavor: 'pi', piSessionId },
+    }), 'utf8');
 
-    const handler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSION_TAKEOVER);
-    expect(handler).toBeDefined();
+    try {
+      registerMachineDirectSessionsRpcHandlers({ rpcHandlerManager, spawnSession, stopSession });
 
-    const res = await handler!({
-      machineId: 'm1',
-      sessionId: 'sess_happy_direct_pi',
-    });
+      const handler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSION_TAKEOVER);
+      expect(handler).toBeDefined();
 
-    expect(res).toEqual({ ok: true });
-    expect(stopSession).not.toHaveBeenCalled();
-    expect(spawnSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        directory: cwd,
-        backendTarget: { kind: 'builtInAgent', agentId: 'pi' },
-        existingSessionId: 'sess_happy_direct_pi',
-        resume: piSessionId,
-        approvedNewDirectoryCreation: true,
-        transcriptStorage: 'direct',
-        environmentVariables: expect.objectContaining({ PI_CODING_AGENT_DIR: resolvedAgentDir }),
-      }),
-    );
+      const res = await handler!({
+        machineId: 'm1',
+        sessionId: 'sess_happy_direct_pi',
+        forceStop: true,
+      });
+
+      expect(res).toEqual({ ok: true });
+      expect(stopSession).toHaveBeenCalledWith('sess_existing_pi_owner');
+      expect(spawnSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          directory: cwd,
+          backendTarget: { kind: 'builtInAgent', agentId: 'pi' },
+          existingSessionId: 'sess_happy_direct_pi',
+          resume: piSessionId,
+          approvedNewDirectoryCreation: true,
+          transcriptStorage: 'direct',
+          environmentVariables: expect.objectContaining({ PI_CODING_AGENT_DIR: resolvedAgentDir }),
+        }),
+      );
+      expect(stopSession.mock.invocationCallOrder[0]).toBeLessThan(spawnSession.mock.invocationCallOrder[0]);
+    } finally {
+      await rm(markerPath, { force: true });
+    }
   });
 
   it('requires forceStop before taking over when a trusted local runner still owns the provider session', async () => {

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RPC_METHODS } from '@happier-dev/protocol/rpc';
 import { writeFakeCodexAppServerThreadListScript } from '@/backends/codex/appServer/testkit/fakeCodexAppServer';
 import type { SpawnSessionOptions, SpawnSessionResult } from '@/rpc/handlers/registerSessionHandlers';
+import type { RpcHandlerRegistrar } from '@/api/rpc/types';
 
 const readCredentialsMock = vi.fn();
 const fetchSessionByIdMock = vi.fn();
@@ -111,12 +112,12 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
       sessionId: 'sess_happy_direct',
     }));
     const stopSession = vi.fn(async () => true);
-    const registered = new Map<string, (params: any) => Promise<any>>();
-    const rpcHandlerManager = {
-      registerHandler: (method: string, handler: (params: any) => Promise<any>) => {
-        registered.set(method, handler);
+    const registered = new Map<string, (params: unknown) => Promise<unknown>>();
+    const rpcHandlerManager: RpcHandlerRegistrar = {
+      registerHandler: (method, handler) => {
+        registered.set(method, async (params) => handler(params as never));
       },
-    } as any;
+    };
 
     registerMachineDirectSessionsRpcHandlers({ rpcHandlerManager, spawnSession, stopSession });
 
@@ -197,12 +198,12 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
       sessionId: 'sess_happy_direct_pi',
     }));
     const stopSession = vi.fn(async () => true);
-    const registered = new Map<string, (params: any) => Promise<any>>();
-    const rpcHandlerManager = {
-      registerHandler: (method: string, handler: (params: any) => Promise<any>) => {
-        registered.set(method, handler);
+    const registered = new Map<string, (params: unknown) => Promise<unknown>>();
+    const rpcHandlerManager: RpcHandlerRegistrar = {
+      registerHandler: (method, handler) => {
+        registered.set(method, async (params) => handler(params as never));
       },
-    } as any;
+    };
 
     const markerDir = join('/tmp/happier-test-home', 'tmp', 'daemon-sessions');
     const markerPath = join(markerDir, `pid-${process.pid}.json`);
@@ -227,7 +228,7 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
         machineId: 'm1',
         sessionId: 'sess_happy_direct_pi',
         forceStop: true,
-      });
+      }) as { ok: boolean };
 
       expect(res).toEqual({ ok: true });
       expect(stopSession).toHaveBeenCalledWith('sess_existing_pi_owner');
@@ -245,6 +246,7 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
       expect(stopSession.mock.invocationCallOrder[0]).toBeLessThan(spawnSession.mock.invocationCallOrder[0]);
     } finally {
       await rm(markerPath, { force: true });
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
@@ -115,6 +115,8 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
     const registered = new Map<string, (params: unknown) => Promise<unknown>>();
     const rpcHandlerManager: RpcHandlerRegistrar = {
       registerHandler: (method, handler) => {
+        // The registrar validates each method-specific handler before this heterogeneous test
+        // map erases its key.
         registered.set(method, async (params) => handler(params as never));
       },
     };
@@ -201,6 +203,8 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
     const registered = new Map<string, (params: unknown) => Promise<unknown>>();
     const rpcHandlerManager: RpcHandlerRegistrar = {
       registerHandler: (method, handler) => {
+        // The registrar validates each method-specific handler before this heterogeneous test
+        // map erases its key.
         registered.set(method, async (params) => handler(params as never));
       },
     };

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
@@ -178,7 +178,7 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
       metadataVersion: 1,
       encryptionMode: 'plain',
       metadata: JSON.stringify({
-        path: '',
+        path: '/tmp/stale-linked-pi-worktree',
         machineId: 'm1',
         flavor: 'pi',
         piSessionId,

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.test.ts
@@ -143,6 +143,92 @@ describe('registerMachineDirectSessionsRpcHandlers', () => {
     );
   });
 
+  it('takes over a direct pi session using header cwd and the configured agent dir', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'happier-directSessions-rpc-takeover-pi-'));
+    const agentDir = join(root, '.pi', 'agent');
+    const cwd = '/tmp/direct-pi-worktree';
+    const sessionsDir = join(agentDir, 'sessions', '--tmp-direct-pi-worktree--');
+    await mkdir(sessionsDir, { recursive: true });
+    const piSessionId = '019f4a42-4617-767a-8e7c-189b454a0352';
+    const sessionFile = join(sessionsDir, `2024-12-03T14-00-00-000Z_${piSessionId}.jsonl`);
+    await writeFile(
+      sessionFile,
+      [
+        jsonlLine({ type: 'session', id: piSessionId, timestamp: '2024-12-03T14:00:00.000Z', cwd, version: 3 }),
+        jsonlLine({
+          type: 'message',
+          id: 'm1',
+          parentId: null,
+          timestamp: '2024-12-03T14:00:01.000Z',
+          message: { role: 'user', content: [{ type: 'text', text: 'hello' }], timestamp: Date.parse('2024-12-03T14:00:01.000Z') },
+        }),
+      ].join(''),
+      'utf8',
+    );
+    const resolvedAgentDir = await realpath(agentDir).catch(() => agentDir);
+    vi.stubEnv('PI_CODING_AGENT_DIR', agentDir);
+
+    readCredentialsMock.mockResolvedValueOnce({
+      token: 'token-direct',
+      encryption: { type: 'legacy', secret: new Uint8Array([1, 2, 3]) },
+    });
+    fetchSessionByIdMock.mockResolvedValueOnce({
+      id: 'sess_happy_direct_pi',
+      metadataVersion: 1,
+      encryptionMode: 'plain',
+      metadata: JSON.stringify({
+        path: '',
+        machineId: 'm1',
+        flavor: 'pi',
+        piSessionId,
+        directSessionV1: {
+          v: 1,
+          providerId: 'pi',
+          machineId: 'm1',
+          remoteSessionId: piSessionId,
+          source: { kind: 'piAgentDir' },
+          linkedAtMs: Date.now(),
+        },
+      }),
+    });
+
+    const spawnSession = vi.fn(async (_options: SpawnSessionOptions): Promise<SpawnSessionResult> => ({
+      type: 'success',
+      sessionId: 'sess_happy_direct_pi',
+    }));
+    const stopSession = vi.fn(async () => true);
+    const registered = new Map<string, (params: any) => Promise<any>>();
+    const rpcHandlerManager = {
+      registerHandler: (method: string, handler: (params: any) => Promise<any>) => {
+        registered.set(method, handler);
+      },
+    } as any;
+
+    registerMachineDirectSessionsRpcHandlers({ rpcHandlerManager, spawnSession, stopSession });
+
+    const handler = registered.get(RPC_METHODS.DAEMON_DIRECT_SESSION_TAKEOVER);
+    expect(handler).toBeDefined();
+
+    const res = await handler!({
+      machineId: 'm1',
+      sessionId: 'sess_happy_direct_pi',
+    });
+
+    expect(res).toEqual({ ok: true });
+    expect(stopSession).not.toHaveBeenCalled();
+    expect(spawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: cwd,
+        backendTarget: { kind: 'builtInAgent', agentId: 'pi' },
+        existingSessionId: 'sess_happy_direct_pi',
+        resume: piSessionId,
+        approvedNewDirectoryCreation: true,
+        transcriptStorage: 'direct',
+        environmentVariables: expect.objectContaining({ PI_CODING_AGENT_DIR: resolvedAgentDir }),
+      }),
+    );
+  });
+
   it('requires forceStop before taking over when a trusted local runner still owns the provider session', async () => {
     vi.stubEnv('HAPPIER_CLAUDE_CONFIG_DIR', '/tmp/claude-direct');
     readCredentialsMock.mockResolvedValueOnce({

--- a/apps/cli/src/api/machine/rpcHandlers.directSessions.ts
+++ b/apps/cli/src/api/machine/rpcHandlers.directSessions.ts
@@ -41,7 +41,7 @@ import { updateSessionMetadataWithRetry } from '@/session/metadata/updateSession
 import { fetchSessionById } from '@/session/transport/http/sessionsHttp';
 import { logger } from '@/utils/logger';
 
-import type { RpcHandlerManager } from '../rpc/RpcHandlerManager';
+import type { RpcHandlerRegistrar } from '../rpc/types';
 import type { SpawnSessionOptions, SpawnSessionResult } from '@/rpc/handlers/registerSessionHandlers';
 
 type DirectSessionsErrorCode = 'invalid_request' | 'machine_offline' | 'provider_unavailable' | 'internal_error';
@@ -96,7 +96,7 @@ function isPidAlive(pid: number): boolean {
 }
 
 export function registerMachineDirectSessionsRpcHandlers(params: Readonly<{
-  rpcHandlerManager: RpcHandlerManager;
+  rpcHandlerManager: RpcHandlerRegistrar;
   spawnSession?: (options: SpawnSessionOptions) => Promise<SpawnSessionResult>;
   stopSession?: (sessionId: string) => Promise<boolean>;
   emitDirectSessionTranscriptUpdate?: (payload: DirectSessionTranscriptDeltaEphemeral) => void;

--- a/apps/cli/src/backends/catalog.test.ts
+++ b/apps/cli/src/backends/catalog.test.ts
@@ -218,6 +218,13 @@ describe('AGENTS', () => {
     await expect(getDirectSessionProviderOps('opencode')).resolves.toMatchObject({
       listCandidates: expect.any(Function),
     });
+    await expect(getDirectSessionProviderOps('pi')).resolves.toMatchObject({
+      listCandidates: expect.any(Function),
+      pageTranscript: expect.any(Function),
+      readAfterTranscript: expect.any(Function),
+      getActivity: expect.any(Function),
+      resolveTakeoverSpawnOptions: expect.any(Function),
+    });
   });
 
   it('loads provider-attach ops through backend catalog hooks only for supporting providers', async () => {

--- a/apps/cli/src/backends/pi/acp/backend.test.ts
+++ b/apps/cli/src/backends/pi/acp/backend.test.ts
@@ -16,6 +16,14 @@ const envKeys = ['PATH', 'HAPPIER_PI_PATH', HAPPIER_CONNECTED_SERVICE_SELECTIONS
 const TEMP_DIRS = new Set<string>();
 let envScope = createEnvKeyScope(envKeys);
 
+function readBackendArgs(backend: unknown): readonly string[] {
+  if (!backend || typeof backend !== 'object' || !('options' in backend)) return [];
+  const options = (backend as { options?: unknown }).options;
+  if (!options || typeof options !== 'object' || !('args' in options)) return [];
+  const args = (options as { args?: unknown }).args;
+  return Array.isArray(args) && args.every((arg) => typeof arg === 'string') ? args : [];
+}
+
 function createFakeBin(name: string): string {
   const dir = createTempDirSync('happier-pi-backend-');
   TEMP_DIRS.add(dir);
@@ -51,8 +59,7 @@ describe('pi backend argv', () => {
       permissionMode: 'default',
     });
 
-    const args = (backend as any).options?.args as string[] | undefined;
-    expect(Array.isArray(args)).toBe(true);
+    const args = readBackendArgs(backend);
     expect(args).toContain('--thinking');
     expect(args).toContain('high');
   });
@@ -66,8 +73,7 @@ describe('pi backend argv', () => {
       permissionMode: 'default',
     });
 
-    const args = (backend as any).options?.args as string[] | undefined;
-    expect(Array.isArray(args)).toBe(true);
+    const args = readBackendArgs(backend);
     expect(args).not.toContain('--thinking');
   });
 
@@ -168,11 +174,10 @@ describe('pi backend argv', () => {
       appendSystemPromptText: 'CLAUDE_PATTERN_PROMPT',
     });
 
-    const args = (backend as any).options?.args as string[] | undefined;
-    expect(Array.isArray(args)).toBe(true);
-    const flagIndex = args!.indexOf('--append-system-prompt');
+    const args = readBackendArgs(backend);
+    const flagIndex = args.indexOf('--append-system-prompt');
     expect(flagIndex).toBeGreaterThan(-1);
-    expect(args![flagIndex + 1]).toBe('CLAUDE_PATTERN_PROMPT');
+    expect(args[flagIndex + 1]).toBe('CLAUDE_PATTERN_PROMPT');
   });
 
   it('omits --append-system-prompt when appendSystemPromptText is blank', () => {
@@ -186,8 +191,7 @@ describe('pi backend argv', () => {
       appendSystemPromptText: '   ',
     });
 
-    const args = (backend as any).options?.args as string[] | undefined;
-    expect(Array.isArray(args)).toBe(true);
+    const args = readBackendArgs(backend);
     expect(args).not.toContain('--append-system-prompt');
   });
 });

--- a/apps/cli/src/backends/pi/acp/backend.test.ts
+++ b/apps/cli/src/backends/pi/acp/backend.test.ts
@@ -156,6 +156,61 @@ describe('pi backend argv', () => {
       resolvePiBrokerExtensionPath(agentDir),
     ]));
   });
+
+  it('forwards appendSystemPromptText as --append-system-prompt', () => {
+    process.env.PATH = '';
+    process.env.HAPPIER_PI_PATH = createFakeBin('pi');
+
+    const backend = createPiBackend({
+      cwd: '/tmp',
+      env: {},
+      permissionMode: 'default',
+      appendSystemPromptText: 'CLAUDE_PATTERN_PROMPT',
+    });
+
+    const args = (backend as any).options?.args as string[] | undefined;
+    expect(Array.isArray(args)).toBe(true);
+    const flagIndex = args!.indexOf('--append-system-prompt');
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(args![flagIndex + 1]).toBe('CLAUDE_PATTERN_PROMPT');
+  });
+
+  it('omits --append-system-prompt when appendSystemPromptText is blank', () => {
+    process.env.PATH = '';
+    process.env.HAPPIER_PI_PATH = createFakeBin('pi');
+
+    const backend = createPiBackend({
+      cwd: '/tmp',
+      env: {},
+      permissionMode: 'default',
+      appendSystemPromptText: '   ',
+    });
+
+    const args = (backend as any).options?.args as string[] | undefined;
+    expect(Array.isArray(args)).toBe(true);
+    expect(args).not.toContain('--append-system-prompt');
+  });
+});
+
+describe('buildPiRpcArgs', () => {
+  it('includes --append-system-prompt when appendSystemPromptText is provided', () => {
+    const args = buildPiRpcArgs({ appendSystemPromptText: 'extra instructions' });
+    const flagIndex = args.indexOf('--append-system-prompt');
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(args[flagIndex + 1]).toBe('extra instructions');
+  });
+
+  it('trims appendSystemPromptText before forwarding', () => {
+    const args = buildPiRpcArgs({ appendSystemPromptText: '  spaced  ' });
+    const flagIndex = args.indexOf('--append-system-prompt');
+    expect(args[flagIndex + 1]).toBe('spaced');
+  });
+
+  it('omits --append-system-prompt when appendSystemPromptText is empty/whitespace', () => {
+    expect(buildPiRpcArgs({ appendSystemPromptText: '' })).not.toContain('--append-system-prompt');
+    expect(buildPiRpcArgs({ appendSystemPromptText: '   ' })).not.toContain('--append-system-prompt');
+    expect(buildPiRpcArgs({})).not.toContain('--append-system-prompt');
+  });
 });
 
 describe('buildPiToolsForPermissionMode', () => {

--- a/apps/cli/src/backends/pi/acp/backend.ts
+++ b/apps/cli/src/backends/pi/acp/backend.ts
@@ -15,6 +15,12 @@ export interface PiBackendOptions extends AgentFactoryOptions {
   mcpServers?: Record<string, McpServerConfig>;
   permissionMode?: PermissionMode;
   happierSessionId?: string | null;
+  /**
+   * System prompt text appended to pi's default system prompt via the
+   * `--append-system-prompt` spawn flag. Applied once at process startup
+   * (pi has no runtime RPC command to change it mid-session).
+   */
+  appendSystemPromptText?: string;
 }
 
 // `null` means Happier must not override Pi's native tool catalog. Passing
@@ -41,13 +47,15 @@ export function buildPiToolsForPermissionMode(permissionMode?: PermissionMode): 
   return ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'];
 }
 
-export function buildPiRpcArgs(opts?: Readonly<{ permissionMode?: PermissionMode; thinkingLevel?: string | null }>): string[] {
+export function buildPiRpcArgs(opts?: Readonly<{ permissionMode?: PermissionMode; thinkingLevel?: string | null; appendSystemPromptText?: string | null }>): string[] {
   const permissionMode = opts?.permissionMode;
   const tools = buildPiToolsForPermissionMode(permissionMode);
   const args: string[] = ['--mode', 'rpc'];
   if (tools) args.push('--tools', tools.join(','));
   const thinking = providers.pi.normalizePiThinkingLevel(opts?.thinkingLevel);
   if (thinking) args.push('--thinking', thinking);
+  const appendSystemPromptText = typeof opts?.appendSystemPromptText === 'string' ? opts.appendSystemPromptText.trim() : '';
+  if (appendSystemPromptText) args.push('--append-system-prompt', appendSystemPromptText);
   return args;
 }
 
@@ -116,7 +124,7 @@ export function createPiBackend(options: PiBackendOptions): AgentBackend {
           launchSelection.modelScope,
         ]
         : []),
-      ...buildPiRpcArgs({ permissionMode: options.permissionMode, thinkingLevel }),
+      ...buildPiRpcArgs({ permissionMode: options.permissionMode, thinkingLevel, appendSystemPromptText: options.appendSystemPromptText }),
     ],
     happierSessionId: options.happierSessionId ?? null,
     env: {

--- a/apps/cli/src/backends/pi/acp/runtime.ts
+++ b/apps/cli/src/backends/pi/acp/runtime.ts
@@ -4,7 +4,10 @@ import { createCatalogProviderAcpRuntime } from '@/agent/acp/runtime/createCatal
 import type { SessionProviderInputConsumer } from '@/agent/runtime/sessionInput/types';
 import type { ApiSessionClient } from '@/api/session/sessionClient';
 import type { PermissionMode } from '@/api/types';
+import type { Credentials } from '@/persistence';
 import type { MessageBuffer } from '@/ui/ink/messageBuffer';
+import { resolveEffectiveCodingPromptText } from '@/agent/prompting/coding/resolveEffectiveCodingPrompt';
+import { resolveCliFeatureDecision } from '@/features/featureDecisionService';
 
 import type { PiBackendOptions } from '@/backends/pi/acp/backend';
 import { publishPiSessionIdMetadata } from '@/backends/pi/utils/piSessionIdMetadata';
@@ -23,6 +26,13 @@ export function createPiAcpRuntime(params: {
   getPermissionMode?: () => PermissionMode | null | undefined;
   pendingQueueDrainMaxPopPerWake?: number;
   providerInputConsumer: SessionProviderInputConsumer<unknown, unknown>;
+  /**
+   * When provided, the resolved coding system prompt is appended to pi's default
+   * system prompt via the `--append-system-prompt` spawn flag. Mirrors how the
+   * claude backend resolves and forwards its system prompt.
+   */
+  credentials?: Credentials;
+  accountSettings?: Record<string, unknown> | null;
 }) {
   const lastPublishedPiSessionId: { value: string | null; sessionFile?: string | null } = { value: null };
   let lastPiIdentityGeneration: number | null = null;
@@ -67,5 +77,27 @@ export function createPiAcpRuntime(params: {
     pendingQueueDrainMaxPopPerWake: params.pendingQueueDrainMaxPopPerWake,
     providerInputConsumer: params.providerInputConsumer,
     inFlightSteer: { enabled: true },
+    resolveBackendOptions: params.credentials
+      ? async ({ session }) => {
+          try {
+            const text = await resolveEffectiveCodingPromptText({
+              credentials: params.credentials as Credentials,
+              settings: params.accountSettings ?? null,
+              profileId: session.getMetadataSnapshot()?.profileId ?? null,
+              providerId: 'pi',
+              executionRunsFeatureEnabled: resolveCliFeatureDecision({
+                featureId: 'execution.runs',
+                env: process.env,
+              }).state === 'enabled',
+            });
+            const trimmed = typeof text === 'string' ? text.trim() : '';
+            return { appendSystemPromptText: trimmed || undefined };
+          } catch {
+            // Best-effort: if the prompt cannot be resolved, spawn pi with no
+            // append flag so it uses its own default system prompt.
+            return {};
+          }
+        }
+      : undefined,
   });
 }

--- a/apps/cli/src/backends/pi/directSessions/getPiDirectSessionActivity.ts
+++ b/apps/cli/src/backends/pi/directSessions/getPiDirectSessionActivity.ts
@@ -1,0 +1,28 @@
+import { stat } from 'node:fs/promises';
+
+import type { DirectSessionsSource } from '@happier-dev/protocol';
+
+import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
+
+/**
+ * Pi direct-session activity is derived from the session file's mtime. There is no live process
+ * probe in the direct-session model; liveness during background follow is owned by the polling
+ * follow-lease. `isRunning` is therefore always false, matching Claude's behavior.
+ */
+export async function getPiDirectSessionActivity(params: Readonly<{
+  source: DirectSessionsSource;
+  env?: NodeJS.ProcessEnv;
+  remoteSessionId: string;
+}>): Promise<Readonly<{ lastActivityAtMs: number | null }>> {
+  const resolved = await resolvePiDirectSessionFile({
+    source: params.source,
+    env: params.env,
+    remoteSessionId: params.remoteSessionId,
+  });
+  if (!resolved) return { lastActivityAtMs: null };
+
+  const s = await stat(resolved.filePath).catch(() => null);
+  if (!s) return { lastActivityAtMs: null };
+
+  return { lastActivityAtMs: Math.trunc(s.mtimeMs) };
+}

--- a/apps/cli/src/backends/pi/directSessions/getPiDirectSessionWorkingDirectory.ts
+++ b/apps/cli/src/backends/pi/directSessions/getPiDirectSessionWorkingDirectory.ts
@@ -1,6 +1,5 @@
 import type { DirectSessionsSource } from '@happier-dev/protocol';
 
-import { readPiSessionHeader } from './readPiSessionHeader';
 import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
 
 /**
@@ -20,7 +19,6 @@ export async function getPiDirectSessionWorkingDirectory(params: Readonly<{
   });
   if (!resolved) return null;
 
-  const header = await readPiSessionHeader(resolved.filePath);
-  const cwd = header?.cwd?.trim();
+  const cwd = resolved.header.cwd.trim();
   return cwd || null;
 }

--- a/apps/cli/src/backends/pi/directSessions/getPiDirectSessionWorkingDirectory.ts
+++ b/apps/cli/src/backends/pi/directSessions/getPiDirectSessionWorkingDirectory.ts
@@ -1,0 +1,26 @@
+import type { DirectSessionsSource } from '@happier-dev/protocol';
+
+import { readPiSessionHeader } from './readPiSessionHeader';
+import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
+
+/**
+ * Resolve a pi direct session's working directory from its authoritative source: the session
+ * header `cwd` field. The `sessions/--<cwd>--` directory name is not decoded here because the
+ * encoding collapses both separators and drive colons to `-`, making reverse decoding ambiguous.
+ */
+export async function getPiDirectSessionWorkingDirectory(params: Readonly<{
+  source: DirectSessionsSource;
+  env?: NodeJS.ProcessEnv;
+  remoteSessionId: string;
+}>): Promise<string | null> {
+  const resolved = await resolvePiDirectSessionFile({
+    source: params.source,
+    env: params.env,
+    remoteSessionId: params.remoteSessionId,
+  });
+  if (!resolved) return null;
+
+  const header = await readPiSessionHeader(resolved.filePath);
+  const cwd = header?.cwd?.trim();
+  return cwd || null;
+}

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.exactId.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.exactId.test.ts
@@ -42,12 +42,18 @@ function makeAgentDir(prefix: string): string {
   return agentDir;
 }
 
-function writeSession(agentDir: string, dirName: string, sessionId: string, fileName = `${sessionId}.jsonl`): string {
+function writeSession(
+  agentDir: string,
+  dirName: string,
+  sessionId: string,
+  fileName = `${sessionId}.jsonl`,
+  headerSessionId = sessionId,
+): string {
   const sessionsDir = join(agentDir, 'sessions', dirName);
   mkdirSync(sessionsDir, { recursive: true });
   const filePath = join(sessionsDir, fileName);
   writeFileSync(filePath, [
-    JSON.stringify({ type: 'session', id: sessionId, timestamp: '2024-12-03T14:00:00.000Z', cwd: `/${dirName}`, version: 3 }),
+    JSON.stringify({ type: 'session', id: headerSessionId, timestamp: '2024-12-03T14:00:00.000Z', cwd: `/${dirName}`, version: 3 }),
     JSON.stringify({ type: 'message', id: 'm1', parentId: null, timestamp: '2024-12-03T14:00:01.000Z', message: { role: 'user', content: sessionId } }),
   ].join('\n') + '\n');
   return filePath;
@@ -76,7 +82,26 @@ describe('listPiSessionCandidates exact-id lookup', () => {
     const result = await listPiSessionCandidates({ source, env, limit: 10, searchTerm: SESSION_A });
 
     expect(result.candidates.map((candidate) => candidate.remoteSessionId)).toEqual([SESSION_A]);
-    expect(trackedFs.openedPaths).toHaveLength(3);
+    // Exact lookup may inspect the target more than once to build its title, but it must not
+    // repeat the resolver's scan of unrelated headers through full candidate discovery.
+    expect(trackedFs.openedPaths.filter((path) => path.endsWith(`${SESSION_B}.jsonl`))).toHaveLength(1);
+  });
+
+  it('resolves a canonical session id when the stored header contains surrounding whitespace', async () => {
+    const agentDir = makeAgentDir('pi-resolve-trimmed-id-');
+    const filePath = writeSession(
+      agentDir,
+      '--proj-a--',
+      SESSION_A,
+      `${SESSION_A}.jsonl`,
+      `  ${SESSION_A}  `,
+    );
+    const source: DirectSessionsSource = { kind: 'piAgentDir' };
+    const env = { ...process.env, PI_CODING_AGENT_DIR: agentDir };
+
+    const resolved = await resolvePiDirectSessionFile({ source, env, remoteSessionId: SESSION_A });
+
+    expect(resolved?.filePath).toBe(filePath);
   });
 
   it('uses full mtime precision when choosing between copied session ids', async () => {

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.exactId.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.exactId.test.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DirectSessionsSource } from '@happier-dev/protocol';
+
+const trackedFs = vi.hoisted(() => ({
+  openedPaths: [] as string[],
+  mtimeMsByPath: new Map<string, number>(),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      trackedFs.openedPaths.push(String(args[0]));
+      return actual.open(...args);
+    },
+    stat: async (...args: Parameters<typeof actual.stat>) => {
+      const result = await actual.stat(...args);
+      const mtimeMs = trackedFs.mtimeMsByPath.get(String(args[0]));
+      if (mtimeMs !== undefined) {
+        Object.defineProperty(result, 'mtimeMs', { value: mtimeMs });
+      }
+      return result;
+    },
+  };
+});
+
+import { listPiSessionCandidates } from './listPiSessionCandidates';
+import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
+
+const SESSION_A = '019f4a42-4617-767a-8e7c-189b454a0352';
+const SESSION_B = '019f53a6-c8cf-7a8c-a165-61d0dc6b42e7';
+const tempAgentDirs = new Set<string>();
+
+function makeAgentDir(prefix: string): string {
+  const agentDir = mkdtempSync(join(tmpdir(), prefix));
+  tempAgentDirs.add(agentDir);
+  return agentDir;
+}
+
+function writeSession(agentDir: string, dirName: string, sessionId: string, fileName = `${sessionId}.jsonl`): string {
+  const sessionsDir = join(agentDir, 'sessions', dirName);
+  mkdirSync(sessionsDir, { recursive: true });
+  const filePath = join(sessionsDir, fileName);
+  writeFileSync(filePath, [
+    JSON.stringify({ type: 'session', id: sessionId, timestamp: '2024-12-03T14:00:00.000Z', cwd: `/${dirName}`, version: 3 }),
+    JSON.stringify({ type: 'message', id: 'm1', parentId: null, timestamp: '2024-12-03T14:00:01.000Z', message: { role: 'user', content: sessionId } }),
+  ].join('\n') + '\n');
+  return filePath;
+}
+
+describe('listPiSessionCandidates exact-id lookup', () => {
+  beforeEach(() => {
+    trackedFs.openedPaths.length = 0;
+    trackedFs.mtimeMsByPath.clear();
+  });
+
+  afterEach(() => {
+    for (const agentDir of tempAgentDirs) {
+      rmSync(agentDir, { recursive: true, force: true });
+    }
+    tempAgentDirs.clear();
+  });
+
+  it('performs only the canonical resolver scan for a bare session id', async () => {
+    const agentDir = makeAgentDir('pi-list-exact-id-');
+    writeSession(agentDir, '--proj-a--', SESSION_A);
+    writeSession(agentDir, '--proj-b--', SESSION_B);
+    const source: DirectSessionsSource = { kind: 'piAgentDir' };
+    const env = { ...process.env, PI_CODING_AGENT_DIR: agentDir };
+
+    const result = await listPiSessionCandidates({ source, env, limit: 10, searchTerm: SESSION_A });
+
+    expect(result.candidates.map((candidate) => candidate.remoteSessionId)).toEqual([SESSION_A]);
+    expect(trackedFs.openedPaths).toHaveLength(3);
+  });
+
+  it('uses full mtime precision when choosing between copied session ids', async () => {
+    const agentDir = makeAgentDir('pi-resolve-fractional-mtime-');
+    const newerPath = writeSession(agentDir, '--proj-new--', SESSION_A, 'new-copy.jsonl');
+    const olderPath = writeSession(agentDir, '--proj-old--', SESSION_A, 'old-copy.jsonl');
+    trackedFs.mtimeMsByPath.set(newerPath, 1_000.9);
+    trackedFs.mtimeMsByPath.set(olderPath, 1_000.5);
+    const source: DirectSessionsSource = { kind: 'piAgentDir' };
+    const env = { ...process.env, PI_CODING_AGENT_DIR: agentDir };
+
+    const resolved = await resolvePiDirectSessionFile({ source, env, remoteSessionId: SESSION_A });
+
+    expect(resolved).toMatchObject({
+      filePath: newerPath,
+      header: { cwd: '/--proj-new--' },
+    });
+  });
+});

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.exactId.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.exactId.test.ts
@@ -72,7 +72,7 @@ describe('listPiSessionCandidates exact-id lookup', () => {
     tempAgentDirs.clear();
   });
 
-  it('performs only the canonical resolver scan for a bare session id', async () => {
+  it('returns only the matching candidate for a bare session id', async () => {
     const agentDir = makeAgentDir('pi-list-exact-id-');
     writeSession(agentDir, '--proj-a--', SESSION_A);
     writeSession(agentDir, '--proj-b--', SESSION_B);
@@ -82,6 +82,17 @@ describe('listPiSessionCandidates exact-id lookup', () => {
     const result = await listPiSessionCandidates({ source, env, limit: 10, searchTerm: SESSION_A });
 
     expect(result.candidates.map((candidate) => candidate.remoteSessionId)).toEqual([SESSION_A]);
+  });
+
+  it('does not repeat unrelated header discovery for a bare session id', async () => {
+    const agentDir = makeAgentDir('pi-list-exact-id-scan-');
+    writeSession(agentDir, '--proj-a--', SESSION_A);
+    writeSession(agentDir, '--proj-b--', SESSION_B);
+    const source: DirectSessionsSource = { kind: 'piAgentDir' };
+    const env = { ...process.env, PI_CODING_AGENT_DIR: agentDir };
+
+    await listPiSessionCandidates({ source, env, limit: 10, searchTerm: SESSION_A });
+
     // Exact lookup may inspect the target more than once to build its title, but it must not
     // repeat the resolver's scan of unrelated headers through full candidate discovery.
     expect(trackedFs.openedPaths.filter((path) => path.endsWith(`${SESSION_B}.jsonl`))).toHaveLength(1);

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
@@ -5,7 +5,10 @@ import { describe, expect, it } from 'vitest';
 
 import type { DirectSessionsSource } from '@happier-dev/protocol';
 
-import { listPiSessionCandidates } from './listPiSessionCandidates';
+import {
+  listPiSessionCandidates,
+  resolvePiDiscoveryConcurrencyBudget,
+} from './listPiSessionCandidates';
 
 const SESSION_A = '019f4a42-4617-767a-8e7c-189b454a0352';
 const SESSION_B = '019f53a6-c8cf-7a8c-a165-61d0dc6b42e7';
@@ -31,6 +34,14 @@ function userMsg(id: string, parentId: string | null, text: string): object {
 }
 
 describe('listPiSessionCandidates', () => {
+  it('keeps nested directory and file work inside one discovery concurrency budget', () => {
+    const budget = resolvePiDiscoveryConcurrencyBudget(64);
+
+    expect(budget.directoryConcurrency).toBeGreaterThan(0);
+    expect(budget.fileConcurrency).toBeGreaterThan(0);
+    expect(budget.directoryConcurrency * budget.fileConcurrency).toBeLessThanOrEqual(64);
+  });
+
   it('discovers sessions across cwd-encoded directories, sorted by mtime descending', async () => {
     const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-'));
     writeSession(agentDir, '--proj-a--', `2024-12-03T14-00-00-000Z_${SESSION_A}.jsonl`, [header(SESSION_A, '/proj-a'), userMsg('m1', null, 'task in proj-a')], 1_700_000_100);
@@ -71,6 +82,10 @@ describe('listPiSessionCandidates', () => {
     const result = await listPiSessionCandidates({ source, env, limit: 10, searchTerm: SESSION_A });
     expect(result.candidates.map((c) => c.remoteSessionId)).toEqual([SESSION_A]);
     expect(result.candidates[0]!.title).toBe('find me');
+    expect(result.candidates[0]!.details).toEqual({
+      cwd: '/proj-a',
+      sessionDirName: '--proj-a--',
+    });
   });
 
   it('uses the header id when a valid session file has been renamed', async () => {

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import type { DirectSessionsSource } from '@happier-dev/protocol';
+
+import { listPiSessionCandidates } from './listPiSessionCandidates';
+
+const SESSION_A = '019f4a42-4617-767a-8e7c-189b454a0352';
+const SESSION_B = '019f53a6-c8cf-7a8c-a165-61d0dc6b42e7';
+
+function writeSession(agentDir: string, dirName: string, fileName: string, lines: readonly object[], mtimeSeconds: number): void {
+  const sessionsDir = join(agentDir, 'sessions', dirName);
+  mkdirSync(sessionsDir, { recursive: true });
+  const filePath = join(sessionsDir, fileName);
+  writeFileSync(filePath, lines.map((line) => JSON.stringify(line)).join('\n') + '\n');
+  utimesSync(filePath, mtimeSeconds, mtimeSeconds);
+}
+
+function sourceEnv(agentDir: string): { source: DirectSessionsSource; env: NodeJS.ProcessEnv } {
+  return { source: { kind: 'piAgentDir' }, env: { ...process.env, PI_CODING_AGENT_DIR: agentDir } };
+}
+
+function header(id: string, cwd: string): object {
+  return { type: 'session', id, timestamp: '2024-12-03T14:00:00.000Z', cwd, version: 3 };
+}
+
+function userMsg(id: string, parentId: string | null, text: string): object {
+  return { type: 'message', id, parentId, timestamp: '2024-12-03T14:00:01.000Z', message: { role: 'user', content: text } };
+}
+
+describe('listPiSessionCandidates', () => {
+  it('discovers sessions across cwd-encoded directories, sorted by mtime descending', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-'));
+    writeSession(agentDir, '--proj-a--', `2024-12-03T14-00-00-000Z_${SESSION_A}.jsonl`, [header(SESSION_A, '/proj-a'), userMsg('m1', null, 'task in proj-a')], 1_700_000_100);
+    writeSession(agentDir, '--proj-b--', `2024-12-04T09-00-00-000Z_${SESSION_B}.jsonl`, [header(SESSION_B, '/proj-b'), userMsg('n1', null, 'task in proj-b')], 1_700_000_200);
+
+    const { source, env } = sourceEnv(agentDir);
+    const result = await listPiSessionCandidates({ source, env, limit: 10 });
+
+    expect(result.candidates.map((c) => c.remoteSessionId)).toEqual([SESSION_B, SESSION_A]);
+    expect(result.nextCursor).toBeNull();
+    // title + cwd enriched from header/title scan
+    const candidateA = result.candidates.find((c) => c.remoteSessionId === SESSION_A)!;
+    expect(candidateA.title).toBe('task in proj-a');
+    expect((candidateA.details as { cwd: string }).cwd).toBe('/proj-a');
+  });
+
+  it('paginates with an index cursor', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-page-'));
+    writeSession(agentDir, '--proj-a--', `2024-12-03T14-00-00-000Z_${SESSION_A}.jsonl`, [header(SESSION_A, '/proj-a'), userMsg('m1', null, 'older')], 1_700_000_100);
+    writeSession(agentDir, '--proj-b--', `2024-12-04T09-00-00-000Z_${SESSION_B}.jsonl`, [header(SESSION_B, '/proj-b'), userMsg('n1', null, 'newer')], 1_700_000_200);
+
+    const { source, env } = sourceEnv(agentDir);
+    const first = await listPiSessionCandidates({ source, env, limit: 1 });
+    expect(first.candidates.map((c) => c.remoteSessionId)).toEqual([SESSION_B]);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await listPiSessionCandidates({ source, env, limit: 1, cursor: first.nextCursor! });
+    expect(second.candidates.map((c) => c.remoteSessionId)).toEqual([SESSION_A]);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  it('exact-id search resolves directly to the session regardless of scan order', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-search-'));
+    writeSession(agentDir, '--proj-a--', `2024-12-03T14-00-00-000Z_${SESSION_A}.jsonl`, [header(SESSION_A, '/proj-a'), userMsg('m1', null, 'find me')], 1_700_000_100);
+    writeSession(agentDir, '--proj-b--', `2024-12-04T09-00-00-000Z_${SESSION_B}.jsonl`, [header(SESSION_B, '/proj-b'), userMsg('n1', null, 'other')], 1_700_000_200);
+
+    const { source, env } = sourceEnv(agentDir);
+    const result = await listPiSessionCandidates({ source, env, limit: 10, searchTerm: SESSION_A });
+    expect(result.candidates.map((c) => c.remoteSessionId)).toEqual([SESSION_A]);
+    expect(result.candidates[0]!.title).toBe('find me');
+  });
+
+  it('returns an empty candidate list when the agent dir has no sessions', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-empty-'));
+    const { source, env } = sourceEnv(agentDir);
+    const result = await listPiSessionCandidates({ source, env, limit: 10 });
+    expect(result.candidates).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+  });
+});

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
@@ -73,6 +73,28 @@ describe('listPiSessionCandidates', () => {
     expect(result.candidates[0]!.title).toBe('find me');
   });
 
+  it('uses the header id when a valid session file has been renamed', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-renamed-'));
+    writeSession(agentDir, '--proj-a--', 'copied-session.jsonl', [header(SESSION_A, '/proj-a'), userMsg('m1', null, 'renamed')], 1_700_000_100);
+
+    const { source, env } = sourceEnv(agentDir);
+    const listed = await listPiSessionCandidates({ source, env, limit: 10 });
+    expect(listed.candidates.map((candidate) => candidate.remoteSessionId)).toEqual([SESSION_A]);
+
+    const exact = await listPiSessionCandidates({ source, env, limit: 10, searchTerm: SESSION_A });
+    expect(exact.candidates.map((candidate) => candidate.remoteSessionId)).toEqual([SESSION_A]);
+  });
+
+  it('terminates full search pagination when no candidates match', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-no-match-'));
+    writeSession(agentDir, '--proj-a--', `2024-12-03T14-00-00-000Z_${SESSION_A}.jsonl`, [header(SESSION_A, '/proj-a'), userMsg('m1', null, 'alpha')], 1_700_000_100);
+
+    const { source, env } = sourceEnv(agentDir);
+    const result = await listPiSessionCandidates({ source, env, limit: 10, searchTerm: 'does-not-exist', searchMode: 'full' });
+    expect(result.candidates).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+  });
+
   it('returns an empty candidate list when the agent dir has no sessions', async () => {
     const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-empty-'));
     const { source, env } = sourceEnv(agentDir);

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
@@ -100,6 +100,18 @@ describe('listPiSessionCandidates', () => {
     expect(exact.candidates.map((candidate) => candidate.remoteSessionId)).toEqual([SESSION_A]);
   });
 
+  it('does not list files without a valid canonical session header', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-invalid-header-'));
+    writeSession(agentDir, '--proj-a--', `2024-12-03T14-00-00-000Z_${SESSION_A}.jsonl`, [
+      userMsg('m1', null, 'missing header'),
+    ], 1_700_000_100);
+
+    const { source, env } = sourceEnv(agentDir);
+    const listed = await listPiSessionCandidates({ source, env, limit: 10 });
+
+    expect(listed.candidates).toEqual([]);
+  });
+
   it('consolidates copied files with the same header id onto the newest resolvable session', async () => {
     const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-copied-'));
     writeSession(agentDir, '--proj-old--', 'old-copy.jsonl', [

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.test.ts
@@ -85,6 +85,28 @@ describe('listPiSessionCandidates', () => {
     expect(exact.candidates.map((candidate) => candidate.remoteSessionId)).toEqual([SESSION_A]);
   });
 
+  it('consolidates copied files with the same header id onto the newest resolvable session', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-copied-'));
+    writeSession(agentDir, '--proj-old--', 'old-copy.jsonl', [
+      header(SESSION_A, '/proj-old'),
+      userMsg('m1', null, 'older copy'),
+    ], 1_700_000_100);
+    writeSession(agentDir, '--proj-new--', 'new-copy.jsonl', [
+      header(SESSION_A, '/proj-new'),
+      userMsg('n1', null, 'newer copy'),
+    ], 1_700_000_200);
+
+    const { source, env } = sourceEnv(agentDir);
+    const listed = await listPiSessionCandidates({ source, env, limit: 10 });
+
+    expect(listed.candidates).toHaveLength(1);
+    expect(listed.candidates[0]).toMatchObject({
+      remoteSessionId: SESSION_A,
+      title: 'newer copy',
+      details: { cwd: '/proj-new', sessionDirName: '--proj-new--' },
+    });
+  });
+
   it('terminates full search pagination when no candidates match', async () => {
     const agentDir = mkdtempSync(join(tmpdir(), 'pi-list-no-match-'));
     writeSession(agentDir, '--proj-a--', `2024-12-03T14-00-00-000Z_${SESSION_A}.jsonl`, [header(SESSION_A, '/proj-a'), userMsg('m1', null, 'alpha')], 1_700_000_100);

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
@@ -10,7 +10,11 @@ import { logger } from '@/utils/logger';
 
 import { readPiSessionHeader } from './readPiSessionHeader';
 import { readPiSessionTitle } from './readPiSessionTitle';
-import { extractPiSessionIdFromFilename, resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
+import {
+  comparePiSessionFilePreference,
+  extractPiSessionIdFromFilename,
+  resolvePiDirectSessionFile,
+} from './resolvePiDirectSessionFile';
 import { resolvePiAgentDir } from './resolvePiAgentDir';
 
 type IndexCursorV1 = Readonly<{ v: 1; kind: 'index'; offset: number }>;
@@ -68,6 +72,8 @@ function resolvePiSearchCandidateLimit(env: NodeJS.ProcessEnv): number {
 
 type DiscoveredPiSession = Readonly<{
   id: string;
+  remoteSessionId: string;
+  cwd: string | null;
   dirName: string;
   fileName: string;
   filePath: string;
@@ -78,22 +84,15 @@ async function buildPiCandidate(params: Readonly<{
   session: DiscoveredPiSession;
   env: NodeJS.ProcessEnv;
 }>): Promise<DirectSessionCandidateV1> {
-  const [header, title] = await Promise.all([
-    readPiSessionHeader(params.session.filePath).catch(() => null),
-    readPiSessionTitle(params.session.filePath).catch(() => null),
-  ]);
-
-  // Prefer the authoritative header id; fall back to the filename UUID when the header is unreadable.
-  const remoteSessionId = header?.id?.trim() || params.session.id;
-  const cwd = header?.cwd?.trim() || null;
+  const title = await readPiSessionTitle(params.session.filePath).catch(() => null);
 
   return {
-    remoteSessionId,
+    remoteSessionId: params.session.remoteSessionId,
     ...(title ? { title } : {}),
     updatedAtMs: params.session.mtimeMs,
     activity: deriveDirectSessionActivityFromTimestamp({ updatedAtMs: params.session.mtimeMs, env: params.env }),
     details: {
-      ...(cwd ? { cwd } : {}),
+      ...(params.session.cwd ? { cwd: params.session.cwd } : {}),
       sessionDirName: params.session.dirName,
     },
   };
@@ -125,8 +124,8 @@ export async function listPiSessionCandidates(params: Readonly<{
     dirEntries = [];
   }
 
-  // Phase 1: stat every session file. The session id is the filename UUID, so no header read is
-  // needed for discovery — headers/titles are read only for the page slice (Phase 2).
+  // Phase 1: stat and identify every session file. Pi files can be renamed or copied, so the
+  // header id is the canonical identity used to consolidate duplicate files before pagination.
   const discoveredSessions = (
     await mapWithConcurrency(dirEntries, concurrency, async (dirEntry): Promise<DiscoveredPiSession[]> => {
       if (!dirEntry.isDirectory()) return [];
@@ -151,7 +150,16 @@ export async function listPiSessionCandidates(params: Readonly<{
         try {
           const s = await stat(filePath);
           if (!s.isFile()) return null;
-          return { id, dirName, fileName, filePath, mtimeMs: Math.trunc(s.mtimeMs) };
+          const header = await readPiSessionHeader(filePath).catch(() => null);
+          return {
+            id,
+            remoteSessionId: header?.id?.trim() || id,
+            cwd: header?.cwd?.trim() || null,
+            dirName,
+            fileName,
+            filePath,
+            mtimeMs: Math.trunc(s.mtimeMs),
+          };
         } catch {
           return null;
         }
@@ -161,9 +169,14 @@ export async function listPiSessionCandidates(params: Readonly<{
     })
   ).flat();
 
-  const sortedSessions = discoveredSessions.sort(
-    (a, b) => b.mtimeMs - a.mtimeMs || String(a.id).localeCompare(String(b.id)),
-  );
+  const seenRemoteSessionIds = new Set<string>();
+  const sortedSessions = discoveredSessions
+    .sort(comparePiSessionFilePreference)
+    .filter((session) => {
+      if (seenRemoteSessionIds.has(session.remoteSessionId)) return false;
+      seenRemoteSessionIds.add(session.remoteSessionId);
+      return true;
+    });
 
   // Exact-id fast path: when the search term is a bare session id, resolve straight to that file
   // (authoritative, no scan-order dependence).
@@ -181,9 +194,12 @@ export async function listPiSessionCandidates(params: Readonly<{
         if (pageOffset > 0) {
           return { candidates: [], nextCursor: null };
         }
+        const exactHeader = await readPiSessionHeader(resolved.filePath).catch(() => null);
         const candidate = await buildPiCandidate({
           session: {
             id: rawSearchTerm,
+            remoteSessionId: exactHeader?.id?.trim() || rawSearchTerm,
+            cwd: exactHeader?.cwd?.trim() || null,
             dirName: '',
             fileName: '',
             filePath: resolved.filePath,
@@ -204,7 +220,7 @@ export async function listPiSessionCandidates(params: Readonly<{
     if (params.searchMode === 'fast') {
       searchIncomplete = true;
       const metadataMatches = sortedSessions.filter((session) => {
-        const haystack = `${session.id} ${session.dirName}`.toLowerCase();
+        const haystack = `${session.remoteSessionId} ${session.id} ${session.dirName}`.toLowerCase();
         return haystack.includes(searchTerm);
       });
       searchedTotalCount = metadataMatches.length;

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
@@ -1,0 +1,250 @@
+import { type Dirent } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { DirectSessionCandidateV1, DirectSessionsSource } from '@happier-dev/protocol';
+
+import { deriveDirectSessionActivityFromTimestamp } from '@/api/directSessions/activity/deriveDirectSessionActivityFromTimestamp';
+import { mapWithConcurrency } from '@/api/directSessions/discovery/mapWithConcurrency';
+import { logger } from '@/utils/logger';
+
+import { readPiSessionHeader } from './readPiSessionHeader';
+import { readPiSessionTitle } from './readPiSessionTitle';
+import { extractPiSessionIdFromFilename, resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
+import { resolvePiAgentDir } from './resolvePiAgentDir';
+
+type IndexCursorV1 = Readonly<{ v: 1; kind: 'index'; offset: number }>;
+
+function encodeIndexCursor(offset: number): string {
+  const cursor: IndexCursorV1 = { v: 1, kind: 'index', offset: Math.max(0, Math.trunc(offset)) };
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeIndexCursor(raw: string | undefined): number {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return 0;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') return 0;
+    const value = parsed as Record<string, unknown>;
+    if (value.v !== 1 || value.kind !== 'index') return 0;
+    const offset = typeof value.offset === 'number' && Number.isFinite(value.offset) ? value.offset : 0;
+    return Math.max(0, Math.trunc(offset));
+  } catch {
+    return 0;
+  }
+}
+
+function parsePositiveIntEnv(params: Readonly<{
+  env: NodeJS.ProcessEnv;
+  key: string;
+  defaultValue: number;
+  min: number;
+  max: number;
+}>): number {
+  const raw = Number.parseInt(String(params.env[params.key] ?? ''), 10);
+  const configured = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : params.defaultValue;
+  return Math.max(params.min, Math.min(params.max, configured));
+}
+
+function resolvePiDiscoveryConcurrency(env: NodeJS.ProcessEnv): number {
+  return parsePositiveIntEnv({
+    env,
+    key: 'HAPPIER_DIRECT_SESSIONS_PI_DISCOVERY_CONCURRENCY',
+    defaultValue: 64,
+    min: 1,
+    max: 512,
+  });
+}
+
+function resolvePiSearchCandidateLimit(env: NodeJS.ProcessEnv): number {
+  return parsePositiveIntEnv({
+    env,
+    key: 'HAPPIER_DIRECT_SESSIONS_PI_SEARCH_CANDIDATE_LIMIT',
+    defaultValue: 2000,
+    min: 1,
+    max: 50_000,
+  });
+}
+
+type DiscoveredPiSession = Readonly<{
+  id: string;
+  dirName: string;
+  fileName: string;
+  filePath: string;
+  mtimeMs: number;
+}>;
+
+async function buildPiCandidate(params: Readonly<{
+  session: DiscoveredPiSession;
+  env: NodeJS.ProcessEnv;
+}>): Promise<DirectSessionCandidateV1> {
+  const [header, title] = await Promise.all([
+    readPiSessionHeader(params.session.filePath).catch(() => null),
+    readPiSessionTitle(params.session.filePath).catch(() => null),
+  ]);
+
+  // Prefer the authoritative header id; fall back to the filename UUID when the header is unreadable.
+  const remoteSessionId = header?.id?.trim() || params.session.id;
+  const cwd = header?.cwd?.trim() || null;
+
+  return {
+    remoteSessionId,
+    ...(title ? { title } : {}),
+    updatedAtMs: params.session.mtimeMs,
+    activity: deriveDirectSessionActivityFromTimestamp({ updatedAtMs: params.session.mtimeMs, env: params.env }),
+    details: {
+      ...(cwd ? { cwd } : {}),
+      sessionDirName: params.session.dirName,
+    },
+  };
+}
+
+export async function listPiSessionCandidates(params: Readonly<{
+  source: DirectSessionsSource;
+  env?: NodeJS.ProcessEnv;
+  cursor?: string;
+  limit: number;
+  searchTerm?: string;
+  searchMode?: 'fast' | 'full';
+}>): Promise<Readonly<{ candidates: DirectSessionCandidateV1[]; nextCursor: string | null; searchIncomplete?: boolean }>> {
+  const env = params.env ?? process.env;
+  const startedAtMs = Date.now();
+  const agentDir = resolvePiAgentDir({ source: params.source, env });
+  const sessionsDir = join(agentDir, 'sessions');
+  const concurrency = resolvePiDiscoveryConcurrency(env);
+  const limit = Math.max(1, Math.trunc(params.limit));
+  const offset = decodeIndexCursor(params.cursor);
+
+  const rawSearchTerm = typeof params.searchTerm === 'string' ? params.searchTerm.trim() : '';
+  const searchTerm = rawSearchTerm.toLowerCase();
+
+  let dirEntries: Dirent<string>[];
+  try {
+    dirEntries = await readdir(sessionsDir, { withFileTypes: true });
+  } catch {
+    dirEntries = [];
+  }
+
+  // Phase 1: stat every session file. The session id is the filename UUID, so no header read is
+  // needed for discovery — headers/titles are read only for the page slice (Phase 2).
+  const discoveredSessions = (
+    await mapWithConcurrency(dirEntries, concurrency, async (dirEntry): Promise<DiscoveredPiSession[]> => {
+      if (!dirEntry.isDirectory()) return [];
+      if (dirEntry.isSymbolicLink()) return [];
+      const dirName = typeof dirEntry.name === 'string' ? dirEntry.name : String(dirEntry.name);
+      if (!dirName || dirName.includes('/') || dirName.includes('\\')) return [];
+
+      let fileEntries: Dirent<string>[];
+      try {
+        fileEntries = await readdir(join(sessionsDir, dirName), { withFileTypes: true });
+      } catch {
+        return [];
+      }
+
+      const sessions = await mapWithConcurrency(fileEntries, concurrency, async (fe): Promise<DiscoveredPiSession | null> => {
+        if (!fe.isFile()) return null;
+        if (fe.isSymbolicLink()) return null;
+        const fileName = typeof fe.name === 'string' ? fe.name : String(fe.name);
+        const id = extractPiSessionIdFromFilename(fileName);
+        if (!id) return null;
+        const filePath = join(sessionsDir, dirName, fileName);
+        try {
+          const s = await stat(filePath);
+          if (!s.isFile()) return null;
+          return { id, dirName, fileName, filePath, mtimeMs: Math.trunc(s.mtimeMs) };
+        } catch {
+          return null;
+        }
+      });
+
+      return sessions.filter((session): session is DiscoveredPiSession => session !== null);
+    })
+  ).flat();
+
+  const sortedSessions = discoveredSessions.sort(
+    (a, b) => b.mtimeMs - a.mtimeMs || String(a.id).localeCompare(String(b.id)),
+  );
+
+  // Exact-id fast path: when the search term is a bare session id, resolve straight to that file
+  // (authoritative, no scan-order dependence).
+  if (searchTerm && !rawSearchTerm.includes('/')) {
+    const resolved = await resolvePiDirectSessionFile({ source: params.source, env, remoteSessionId: rawSearchTerm }).catch(() => null);
+    if (resolved) {
+      let exactStat: Awaited<ReturnType<typeof stat>> | null = null;
+      try {
+        exactStat = await stat(resolved.filePath);
+      } catch {
+        exactStat = null;
+      }
+      if (exactStat?.isFile()) {
+        const pageOffset = Math.min(offset, 1);
+        if (pageOffset > 0) {
+          return { candidates: [], nextCursor: null };
+        }
+        const candidate = await buildPiCandidate({
+          session: {
+            id: rawSearchTerm,
+            dirName: '',
+            fileName: '',
+            filePath: resolved.filePath,
+            mtimeMs: Math.trunc(exactStat.mtimeMs),
+          },
+          env,
+        });
+        return { candidates: [candidate], nextCursor: null };
+      }
+    }
+  }
+
+  let searchIncomplete = false;
+  let searchedPage: DirectSessionCandidateV1[] | null = null;
+
+  if (searchTerm) {
+    if (params.searchMode === 'fast') {
+      searchIncomplete = true;
+      const metadataMatches = sortedSessions.filter((session) => {
+        const haystack = `${session.id} ${session.dirName}`.toLowerCase();
+        return haystack.includes(searchTerm);
+      });
+      const page = metadataMatches.slice(offset, offset + limit);
+      searchedPage = await mapWithConcurrency(page, concurrency, (session) => buildPiCandidate({ session, env }));
+    } else {
+      const searchCandidateLimit = resolvePiSearchCandidateLimit(env);
+      const sessionsToSearch = sortedSessions.slice(0, searchCandidateLimit);
+      searchIncomplete = sessionsToSearch.length < sortedSessions.length;
+      const withTitles = await mapWithConcurrency(sessionsToSearch, concurrency, async (session): Promise<DirectSessionCandidateV1 | null> => {
+        const candidate = await buildPiCandidate({ session, env });
+        const haystack = `${candidate.remoteSessionId} ${session.dirName}${candidate.title ? ` ${candidate.title}` : ''}`.toLowerCase();
+        return haystack.includes(searchTerm) ? candidate : null;
+      });
+      const filtered = withTitles.filter((candidate): candidate is DirectSessionCandidateV1 => candidate !== null);
+      searchedPage = filtered.slice(offset, offset + limit);
+    }
+  }
+
+  const page =
+    searchedPage
+    ?? await mapWithConcurrency(sortedSessions.slice(offset, offset + limit), concurrency, (session) => buildPiCandidate({ session, env }));
+
+  const filteredCount = searchTerm
+    ? (searchedPage ? Math.max(sortedSessions.length, offset + page.length) : sortedSessions.length)
+    : sortedSessions.length;
+  const nextOffset = offset + page.length;
+  const nextCursor = nextOffset < filteredCount ? encodeIndexCursor(nextOffset) : null;
+
+  logger.debug('[directSessions.pi.candidates] list finished', {
+    elapsedMs: Date.now() - startedAtMs,
+    searchTermLength: rawSearchTerm.length,
+    searchMode: params.searchMode ?? 'default',
+    discoveredSessions: sortedSessions.length,
+    returnedCandidates: page.length,
+    hasNextCursor: Boolean(nextCursor),
+    searchIncomplete,
+  });
+
+  return {
+    candidates: page,
+    nextCursor,
+    ...(searchIncomplete ? { searchIncomplete: true } : {}),
+  };
+}

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
@@ -131,6 +131,40 @@ export async function listPiSessionCandidates(params: Readonly<{
   const rawSearchTerm = typeof params.searchTerm === 'string' ? params.searchTerm.trim() : '';
   const searchTerm = rawSearchTerm.toLowerCase();
 
+  // Exact-id fast path: when the search term is a bare session id, resolve straight to that file
+  // without first performing the same repository-wide header scan through discovery.
+  if (searchTerm && !rawSearchTerm.includes('/')) {
+    const resolved = await resolvePiDirectSessionFile({ source: params.source, env, remoteSessionId: rawSearchTerm }).catch(() => null);
+    if (resolved) {
+      let exactStat: Awaited<ReturnType<typeof stat>> | null = null;
+      try {
+        exactStat = await stat(resolved.filePath);
+      } catch {
+        exactStat = null;
+      }
+      if (exactStat?.isFile()) {
+        const pageOffset = Math.min(offset, 1);
+        if (pageOffset > 0) {
+          return { candidates: [], nextCursor: null };
+        }
+        const relSegments = resolved.fileRelPath.split('/');
+        const candidate = await buildPiCandidate({
+          session: {
+            id: rawSearchTerm,
+            remoteSessionId: resolved.header.id.trim() || rawSearchTerm,
+            cwd: resolved.header.cwd.trim() || null,
+            dirName: relSegments.at(-2) ?? '',
+            fileName: relSegments.at(-1) ?? '',
+            filePath: resolved.filePath,
+            mtimeMs: exactStat.mtimeMs,
+          },
+          env,
+        });
+        return { candidates: [candidate], nextCursor: null };
+      }
+    }
+  }
+
   let dirEntries: Dirent<string>[];
   try {
     dirEntries = await readdir(sessionsDir, { withFileTypes: true });
@@ -165,14 +199,17 @@ export async function listPiSessionCandidates(params: Readonly<{
           const s = await stat(filePath);
           if (!s.isFile()) return null;
           const header = await readPiSessionHeader(filePath).catch(() => null);
+          if (!header) return null;
+          const remoteSessionId = header.id.trim();
+          if (!remoteSessionId) return null;
           return {
             id,
-            remoteSessionId: header?.id?.trim() || id,
-            cwd: header?.cwd?.trim() || null,
+            remoteSessionId,
+            cwd: header.cwd.trim() || null,
             dirName,
             fileName,
             filePath,
-            mtimeMs: Math.trunc(s.mtimeMs),
+            mtimeMs: s.mtimeMs,
           };
         } catch {
           return null;
@@ -191,40 +228,6 @@ export async function listPiSessionCandidates(params: Readonly<{
       seenRemoteSessionIds.add(session.remoteSessionId);
       return true;
     });
-
-  // Exact-id fast path: when the search term is a bare session id, resolve straight to that file
-  // (authoritative, no scan-order dependence).
-  if (searchTerm && !rawSearchTerm.includes('/')) {
-    const resolved = await resolvePiDirectSessionFile({ source: params.source, env, remoteSessionId: rawSearchTerm }).catch(() => null);
-    if (resolved) {
-      let exactStat: Awaited<ReturnType<typeof stat>> | null = null;
-      try {
-        exactStat = await stat(resolved.filePath);
-      } catch {
-        exactStat = null;
-      }
-      if (exactStat?.isFile()) {
-        const pageOffset = Math.min(offset, 1);
-        if (pageOffset > 0) {
-          return { candidates: [], nextCursor: null };
-        }
-        const relSegments = resolved.fileRelPath.split('/');
-        const candidate = await buildPiCandidate({
-          session: {
-            id: rawSearchTerm,
-            remoteSessionId: resolved.header.id.trim() || rawSearchTerm,
-            cwd: resolved.header.cwd.trim() || null,
-            dirName: relSegments.at(-2) ?? '',
-            fileName: relSegments.at(-1) ?? '',
-            filePath: resolved.filePath,
-            mtimeMs: Math.trunc(exactStat.mtimeMs),
-          },
-          env,
-        });
-        return { candidates: [candidate], nextCursor: null };
-      }
-    }
-  }
 
   let searchIncomplete = false;
   let searchedPage: DirectSessionCandidateV1[] | null = null;

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
@@ -60,6 +60,18 @@ function resolvePiDiscoveryConcurrency(env: NodeJS.ProcessEnv): number {
   });
 }
 
+export function resolvePiDiscoveryConcurrencyBudget(totalConcurrency: number): Readonly<{
+  directoryConcurrency: number;
+  fileConcurrency: number;
+}> {
+  const total = Math.max(1, Math.trunc(totalConcurrency));
+  const directoryConcurrency = Math.max(1, Math.trunc(Math.sqrt(total)));
+  return {
+    directoryConcurrency,
+    fileConcurrency: Math.max(1, Math.trunc(total / directoryConcurrency)),
+  };
+}
+
 function resolvePiSearchCandidateLimit(env: NodeJS.ProcessEnv): number {
   return parsePositiveIntEnv({
     env,
@@ -111,6 +123,8 @@ export async function listPiSessionCandidates(params: Readonly<{
   const agentDir = resolvePiAgentDir({ source: params.source, env });
   const sessionsDir = join(agentDir, 'sessions');
   const concurrency = resolvePiDiscoveryConcurrency(env);
+  const { directoryConcurrency, fileConcurrency } =
+    resolvePiDiscoveryConcurrencyBudget(concurrency);
   const limit = Math.max(1, Math.trunc(params.limit));
   const offset = decodeIndexCursor(params.cursor);
 
@@ -127,7 +141,7 @@ export async function listPiSessionCandidates(params: Readonly<{
   // Phase 1: stat and identify every session file. Pi files can be renamed or copied, so the
   // header id is the canonical identity used to consolidate duplicate files before pagination.
   const discoveredSessions = (
-    await mapWithConcurrency(dirEntries, concurrency, async (dirEntry): Promise<DiscoveredPiSession[]> => {
+    await mapWithConcurrency(dirEntries, directoryConcurrency, async (dirEntry): Promise<DiscoveredPiSession[]> => {
       if (!dirEntry.isDirectory()) return [];
       if (dirEntry.isSymbolicLink()) return [];
       const dirName = typeof dirEntry.name === 'string' ? dirEntry.name : String(dirEntry.name);
@@ -140,7 +154,7 @@ export async function listPiSessionCandidates(params: Readonly<{
         return [];
       }
 
-      const sessions = await mapWithConcurrency(fileEntries, concurrency, async (fe): Promise<DiscoveredPiSession | null> => {
+      const sessions = await mapWithConcurrency(fileEntries, fileConcurrency, async (fe): Promise<DiscoveredPiSession | null> => {
         if (!fe.isFile()) return null;
         if (fe.isSymbolicLink()) return null;
         const fileName = typeof fe.name === 'string' ? fe.name : String(fe.name);
@@ -194,14 +208,14 @@ export async function listPiSessionCandidates(params: Readonly<{
         if (pageOffset > 0) {
           return { candidates: [], nextCursor: null };
         }
-        const exactHeader = await readPiSessionHeader(resolved.filePath).catch(() => null);
+        const relSegments = resolved.fileRelPath.split('/');
         const candidate = await buildPiCandidate({
           session: {
             id: rawSearchTerm,
-            remoteSessionId: exactHeader?.id?.trim() || rawSearchTerm,
-            cwd: exactHeader?.cwd?.trim() || null,
-            dirName: '',
-            fileName: '',
+            remoteSessionId: resolved.header.id.trim() || rawSearchTerm,
+            cwd: resolved.header.cwd.trim() || null,
+            dirName: relSegments.at(-2) ?? '',
+            fileName: relSegments.at(-1) ?? '',
             filePath: resolved.filePath,
             mtimeMs: Math.trunc(exactStat.mtimeMs),
           },

--- a/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
+++ b/apps/cli/src/backends/pi/directSessions/listPiSessionCandidates.ts
@@ -198,6 +198,7 @@ export async function listPiSessionCandidates(params: Readonly<{
 
   let searchIncomplete = false;
   let searchedPage: DirectSessionCandidateV1[] | null = null;
+  let searchedTotalCount: number | null = null;
 
   if (searchTerm) {
     if (params.searchMode === 'fast') {
@@ -206,6 +207,7 @@ export async function listPiSessionCandidates(params: Readonly<{
         const haystack = `${session.id} ${session.dirName}`.toLowerCase();
         return haystack.includes(searchTerm);
       });
+      searchedTotalCount = metadataMatches.length;
       const page = metadataMatches.slice(offset, offset + limit);
       searchedPage = await mapWithConcurrency(page, concurrency, (session) => buildPiCandidate({ session, env }));
     } else {
@@ -218,6 +220,7 @@ export async function listPiSessionCandidates(params: Readonly<{
         return haystack.includes(searchTerm) ? candidate : null;
       });
       const filtered = withTitles.filter((candidate): candidate is DirectSessionCandidateV1 => candidate !== null);
+      searchedTotalCount = filtered.length;
       searchedPage = filtered.slice(offset, offset + limit);
     }
   }
@@ -226,9 +229,7 @@ export async function listPiSessionCandidates(params: Readonly<{
     searchedPage
     ?? await mapWithConcurrency(sortedSessions.slice(offset, offset + limit), concurrency, (session) => buildPiCandidate({ session, env }));
 
-  const filteredCount = searchTerm
-    ? (searchedPage ? Math.max(sortedSessions.length, offset + page.length) : sortedSessions.length)
-    : sortedSessions.length;
+  const filteredCount = searchedTotalCount ?? sortedSessions.length;
   const nextOffset = offset + page.length;
   const nextCursor = nextOffset < filteredCount ? encodeIndexCursor(nextOffset) : null;
 

--- a/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DirectTranscriptRawMessageV1 } from '@happier-dev/protocol';
+
+import type { PiSessionEntry } from './piEntryContext';
+import { mapPiSessionToDirectMessages } from './mapPiSessionToDirectMessages';
+
+function entry(partial: Partial<PiSessionEntry> & Pick<PiSessionEntry, 'type' | 'id'>): PiSessionEntry {
+  return {
+    parentId: null,
+    timestamp: '2024-12-03T14:00:00.000Z',
+    ...partial,
+  } as PiSessionEntry;
+}
+
+function user(id: string, parentId: string | null, text: string, ts = '2024-12-03T14:00:01.000Z'): PiSessionEntry {
+  return entry({ type: 'message', id, parentId, timestamp: ts, message: { role: 'user', content: text, timestamp: Date.parse(ts) } });
+}
+
+function assistant(id: string, parentId: string | null, text: string, ts = '2024-12-03T14:00:02.000Z'): PiSessionEntry {
+  return entry({
+    type: 'message',
+    id,
+    parentId,
+    timestamp: ts,
+    message: { role: 'assistant', content: [{ type: 'text', text }], provider: 'anthropic', model: 'claude', usage: {}, stopReason: 'stop', timestamp: Date.parse(ts) },
+  });
+}
+
+function toolResult(id: string, parentId: string | null, ts = '2024-12-03T14:00:03.000Z'): PiSessionEntry {
+  return entry({
+    type: 'message',
+    id,
+    parentId,
+    timestamp: ts,
+    message: { role: 'toolResult', toolCallId: 'call_1', toolName: 'bash', content: [{ type: 'text', text: 'ok' }], isError: false, timestamp: Date.parse(ts) },
+  });
+}
+
+const FILE_REL = 'projects/sample.jsonl';
+
+function ids(items: readonly DirectTranscriptRawMessageV1[]): string[] {
+  return items.map((item) => item.id);
+}
+
+function roles(items: readonly DirectTranscriptRawMessageV1[]): string[] {
+  return items.map((item) => item.messageRole ?? '');
+}
+
+describe('mapPiSessionToDirectMessages', () => {
+  it('maps a linear user -> assistant -> toolResult branch into three ordered transcript items', () => {
+    const entries = [
+      user('a1b2c3d4', null, 'hello'),
+      assistant('b2c3d4e5', 'a1b2c3d4', 'hi!'),
+      toolResult('c3d4e5f6', 'b2c3d4e5'),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+
+    expect(items).toHaveLength(3);
+    expect(ids(items)).toEqual([
+      `pi:${FILE_REL}:a1b2c3d4`,
+      `pi:${FILE_REL}:b2c3d4e5`,
+      `pi:${FILE_REL}:c3d4e5f6`,
+    ]);
+    expect(roles(items)).toEqual(['user', 'agent', 'event']);
+    expect(items[0]!.createdAtMs).toBe(Date.parse('2024-12-03T14:00:01.000Z'));
+    // user text is preserved on raw
+    expect((items[0]!.raw as any).role).toBe('user');
+    expect((items[0]!.raw as any).content).toBe('hello');
+  });
+
+  it('imports only the active (last-in-file) branch and excludes the abandoned sibling', () => {
+    // a -> b (abandoned), a -> b' (active). Only [a, b'] must surface.
+    const entries = [
+      user('aaaa0001', null, 'prompt'),
+      assistant('bbbb0001', 'aaaa0001', 'abandoned branch'),
+      assistant('bbbb0002', 'aaaa0001', 'active branch'),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+
+    expect(ids(items)).toEqual([`pi:${FILE_REL}:aaaa0001`, `pi:${FILE_REL}:bbbb0002`]);
+    expect((items[1]!.raw as any).content[0].text).toBe('active branch');
+  });
+
+  it('honors an explicit leafId to select a non-default branch', () => {
+    const entries = [
+      user('aaaa0001', null, 'prompt'),
+      assistant('bbbb0001', 'aaaa0001', 'abandoned branch'),
+      assistant('bbbb0002', 'aaaa0001', 'active branch'),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL, leafId: 'bbbb0001' });
+    expect(ids(items)).toEqual([`pi:${FILE_REL}:aaaa0001`, `pi:${FILE_REL}:bbbb0001`]);
+  });
+
+  it('drops entries summarized before the latest compaction and emits the compaction as an event', () => {
+    const entries = [
+      user('aaaa0001', null, 'old prompt'),
+      assistant('summariz', 'aaaa0001', 'summarized away'),
+      user('kept00001', 'summariz', 'kept prompt'),
+      entry({ type: 'compaction', id: 'comp00001', parentId: 'kept00001', firstKeptEntryId: 'kept00001', summary: 'earlier work', tokensBefore: 5000 }),
+      assistant('aftercmp', 'comp00001', 'after compaction'),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+
+    // [compaction, kept00001, aftercmp] — aaaa0001 and summariz are dropped
+    expect(ids(items)).toEqual([
+      `pi:${FILE_REL}:comp00001`,
+      `pi:${FILE_REL}:kept00001`,
+      `pi:${FILE_REL}:aftercmp`,
+    ]);
+    expect(items[0]!.messageRole).toBe('event');
+    expect((items[0]!.raw as any).role).toBe('compactionSummary');
+  });
+
+  it('skips non-context entries (model_change, thinking_level_change, label, custom) entirely', () => {
+    const entries = [
+      user('aaaa0001', null, 'prompt'),
+      entry({ type: 'model_change', id: 'mchn0001', parentId: 'aaaa0001', provider: 'openai', modelId: 'gpt-4o' }),
+      entry({ type: 'thinking_level_change', id: 'tlnk0001', parentId: 'mchn0001', thinkingLevel: 'high' }),
+      entry({ type: 'label', id: 'lbl00001', parentId: 'tlnk0001', targetId: 'aaaa0001', label: 'checkpoint' }),
+      entry({ type: 'custom', id: 'cst00001', parentId: 'lbl00001', customType: 'ext', data: { x: 1 } }),
+      assistant('bbbb0001', 'cst00001', 'reply'),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+
+    // only the two message entries surface; the path-walk includes the metadata entries but
+    // projection drops them
+    expect(ids(items)).toEqual([`pi:${FILE_REL}:aaaa0001`, `pi:${FILE_REL}:bbbb0001`]);
+  });
+
+  it('classifies bashExecution tool output as an event', () => {
+    const entries = [
+      user('aaaa0001', null, 'run ls'),
+      entry({
+        type: 'message',
+        id: 'bbbb0001',
+        parentId: 'aaaa0001',
+        message: { role: 'bashExecution', command: 'ls', output: 'a\nb', exitCode: 0, cancelled: false, truncated: false, timestamp: 1 },
+      }),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+    expect(roles(items)).toEqual(['user', 'event']);
+  });
+
+  it('returns [] for an empty session', () => {
+    expect(mapPiSessionToDirectMessages({ entries: [], fileRelPath: FILE_REL })).toEqual([]);
+  });
+
+  it('treats a message with null content as an empty-content message rather than dropping it', () => {
+    const entries = [
+      entry({ type: 'message', id: 'aaaa0001', parentId: null, message: { role: 'assistant', content: null } }),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+    expect(items).toHaveLength(1);
+    expect((items[0]!.raw as any).content).toEqual([]);
+  });
+});

--- a/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.test.ts
@@ -92,7 +92,7 @@ describe('mapPiSessionToDirectMessages', () => {
     expect(ids(items)).toEqual([`pi:${FILE_REL}:aaaa0001`, `pi:${FILE_REL}:bbbb0001`]);
   });
 
-  it('drops entries summarized before the latest compaction and emits the compaction as an event', () => {
+  it('preserves the full active-branch history around compaction and emits the compaction as an event', () => {
     const entries = [
       user('aaaa0001', null, 'old prompt'),
       assistant('summariz', 'aaaa0001', 'summarized away'),
@@ -102,16 +102,17 @@ describe('mapPiSessionToDirectMessages', () => {
     ];
     const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
 
-    // [compaction, kept00001, aftercmp] — aaaa0001 and summariz are dropped
     expect(ids(items)).toEqual([
-      `pi:${FILE_REL}:comp00001`,
+      `pi:${FILE_REL}:aaaa0001`,
+      `pi:${FILE_REL}:summariz`,
       `pi:${FILE_REL}:kept00001`,
+      `pi:${FILE_REL}:comp00001`,
       `pi:${FILE_REL}:aftercmp`,
     ]);
-    expect(items[0]!.messageRole).toBe('event');
-    expect((items[0]!.raw as any).role).toBe('agent');
-    expect((items[0]!.raw as any).content.data.type).toBe('summary');
-    expect((items[0]!.raw as any).content.data.summary).toBe('earlier work');
+    expect(items[3]!.messageRole).toBe('event');
+    expect((items[3]!.raw as any).role).toBe('agent');
+    expect((items[3]!.raw as any).content.data.type).toBe('summary');
+    expect((items[3]!.raw as any).content.data.summary).toBe('earlier work');
   });
 
   it('skips non-context entries (model_change, thinking_level_change, label, custom) entirely', () => {

--- a/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { DirectTranscriptRawMessageV1 } from '@happier-dev/protocol';
+import { TranscriptRawRecordV1Schema, type DirectTranscriptRawMessageV1 } from '@happier-dev/protocol';
 
 import type { PiSessionEntry } from './piEntryContext';
 import { mapPiSessionToDirectMessages } from './mapPiSessionToDirectMessages';
@@ -64,9 +64,9 @@ describe('mapPiSessionToDirectMessages', () => {
     ]);
     expect(roles(items)).toEqual(['user', 'agent', 'event']);
     expect(items[0]!.createdAtMs).toBe(Date.parse('2024-12-03T14:00:01.000Z'));
-    // user text is preserved on raw
+    // user text is preserved on the protocol user record
     expect((items[0]!.raw as any).role).toBe('user');
-    expect((items[0]!.raw as any).content).toBe('hello');
+    expect((items[0]!.raw as any).content.text).toBe('hello');
   });
 
   it('imports only the active (last-in-file) branch and excludes the abandoned sibling', () => {
@@ -79,7 +79,7 @@ describe('mapPiSessionToDirectMessages', () => {
     const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
 
     expect(ids(items)).toEqual([`pi:${FILE_REL}:aaaa0001`, `pi:${FILE_REL}:bbbb0002`]);
-    expect((items[1]!.raw as any).content[0].text).toBe('active branch');
+    expect((items[1]!.raw as any).content.data.message.content[0].text).toBe('active branch');
   });
 
   it('honors an explicit leafId to select a non-default branch', () => {
@@ -109,7 +109,9 @@ describe('mapPiSessionToDirectMessages', () => {
       `pi:${FILE_REL}:aftercmp`,
     ]);
     expect(items[0]!.messageRole).toBe('event');
-    expect((items[0]!.raw as any).role).toBe('compactionSummary');
+    expect((items[0]!.raw as any).role).toBe('agent');
+    expect((items[0]!.raw as any).content.data.type).toBe('summary');
+    expect((items[0]!.raw as any).content.data.summary).toBe('earlier work');
   });
 
   it('skips non-context entries (model_change, thinking_level_change, label, custom) entirely', () => {
@@ -146,12 +148,121 @@ describe('mapPiSessionToDirectMessages', () => {
     expect(mapPiSessionToDirectMessages({ entries: [], fileRelPath: FILE_REL })).toEqual([]);
   });
 
+  it('emits protocol transcript records the UI schema accepts for every projected entry kind', () => {
+    const entries = [
+      user('aaaa0001', null, 'string user prompt'),
+      entry({
+        type: 'message', id: 'aaaa0002', parentId: 'aaaa0001', timestamp: '2024-12-03T14:00:01.500Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'blocks user prompt' }], timestamp: 1 },
+      }),
+      assistant('bbbb0001', 'aaaa0002', 'assistant reply'),
+      toolResult('c3d4e5f6', 'bbbb0001'),
+      entry({
+        type: 'message', id: 'b5s000001', parentId: 'c3d4e5f6', timestamp: '2024-12-03T14:00:03.500Z',
+        message: { role: 'bashExecution', command: 'ls', output: 'a\nb', exitCode: 0, cancelled: false, truncated: false, timestamp: 1 },
+      }),
+      entry({ type: 'custom_message', id: 'c5t000001', parentId: 'b5s000001', timestamp: '2024-12-03T14:00:04.000Z', customType: 'websearch', content: [{ type: 'text', text: 'search result' }] }),
+      entry({ type: 'branch_summary', id: 's5m000001', parentId: 'c5t000001', timestamp: '2024-12-03T14:00:04.500Z', summary: 'branched from earlier work', fromId: 'aaaa0001' }),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+
+    expect(items.length).toBeGreaterThan(0);
+    const failures: string[] = [];
+    for (const item of items) {
+      const parsed = TranscriptRawRecordV1Schema.safeParse(item.raw);
+      if (!parsed.success) failures.push(`${item.id}: ${JSON.stringify(parsed.error.issues[0])}`);
+    }
+    expect(failures).toEqual([]);
+
+    // Spot-check the projections render as the right transcript kinds.
+    const stringUser = items[0]!.raw as Record<string, any>;
+    expect(stringUser.role).toBe('user');
+    expect(stringUser.content.text).toBe('string user prompt');
+    const assistantRow = items.find((item) => item.id.endsWith('bbbb0001'))!.raw as Record<string, any>;
+    expect(assistantRow.role).toBe('agent');
+    expect(assistantRow.content.data.type).toBe('assistant');
+    expect(assistantRow.content.data.message.content[0].text).toBe('assistant reply');
+    const summaryRow = items.find((item) => item.id.endsWith('s5m000001'))!.raw as Record<string, any>;
+    expect(summaryRow.content.data.type).toBe('summary');
+    expect(summaryRow.content.data.summary).toBe('branched from earlier work');
+  });
+
+  it('projects block-array user prompts onto the protocol user record so transcript views render them as user messages', () => {
+    const entries = [
+      entry({
+        type: 'message', id: 'aaaa0001', parentId: null, timestamp: '2024-12-03T14:00:01.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'first part' }, { type: 'text', text: 'second part' }], timestamp: 1 },
+      }),
+      entry({
+        type: 'message', id: 'aaaa0002', parentId: 'aaaa0001', timestamp: '2024-12-03T14:00:01.500Z',
+        message: { role: 'user', content: [{ type: 'image', source: '…' }], timestamp: 1 },
+      }),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+
+    // Text blocks join into one protocol user text record (the semantic transcript
+    // classifier only recognizes user prompts as role:'user' + content.type:'text').
+    expect(items[0]!.messageRole).toBe('user');
+    expect((items[0]!.raw as any).role).toBe('user');
+    expect((items[0]!.raw as any).content.type).toBe('text');
+    expect((items[0]!.raw as any).content.text).toBe('first part\nsecond part');
+    // A user message with no text blocks cannot become a text record; it stays on the
+    // agent-output 'user' row (tool/attachment convention) instead of being dropped.
+    expect(items[1]!.messageRole).toBe('user');
+    expect((items[1]!.raw as any).content.data.type).toBe('user');
+  });
+
+  it('normalizes pi toolCall blocks and toolResult messages to the Claude transcript convention', () => {
+    const entries = [
+      user('aaaa0001', null, 'run a command'),
+      entry({
+        type: 'message', id: 'bbbb0001', parentId: 'aaaa0001', timestamp: '2024-12-03T14:00:02.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'pondering', thinkingSignature: 'sig' },
+            { type: 'toolCall', id: 'call_1', name: 'bash', arguments: { command: 'ls' } },
+          ],
+          timestamp: 1,
+        },
+      }),
+      entry({
+        type: 'message', id: 'c3d4e5f6', parentId: 'bbbb0001', timestamp: '2024-12-03T14:00:03.000Z',
+        message: { role: 'toolResult', toolCallId: 'call_1', toolName: 'bash', content: [{ type: 'text', text: 'ok' }], isError: false, timestamp: 1 },
+      }),
+    ];
+    const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
+
+    // The UI transcript normalizer renders Claude-convention blocks; pi writes camelCase
+    // toolCall blocks and standalone toolResult messages, so the mapper must convert.
+    const assistantRow = items[1]!.raw as Record<string, any>;
+    const blocks = assistantRow.content.data.message.content;
+    expect(blocks.find((b: any) => b.type === 'tool_use')).toEqual({
+      type: 'tool_use',
+      id: 'call_1',
+      name: 'bash',
+      input: { command: 'ls' },
+    });
+    expect(blocks.find((b: any) => b.type === 'thinking')?.thinking).toBe('pondering');
+
+    const toolResultRow = items[2]!.raw as Record<string, any>;
+    expect(toolResultRow.content.data.type).toBe('user');
+    expect(toolResultRow.content.data.message.content).toEqual([
+      {
+        type: 'tool_result',
+        tool_use_id: 'call_1',
+        content: [{ type: 'text', text: 'ok' }],
+        is_error: false,
+      },
+    ]);
+  });
+
   it('treats a message with null content as an empty-content message rather than dropping it', () => {
     const entries = [
       entry({ type: 'message', id: 'aaaa0001', parentId: null, message: { role: 'assistant', content: null } }),
     ];
     const items = mapPiSessionToDirectMessages({ entries, fileRelPath: FILE_REL });
     expect(items).toHaveLength(1);
-    expect((items[0]!.raw as any).content).toEqual([]);
+    expect((items[0]!.raw as any).content.data.message.content).toEqual([]);
   });
 });

--- a/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.ts
+++ b/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.ts
@@ -1,0 +1,110 @@
+import type { DirectTranscriptRawMessageV1, SessionMessageRole } from '@happier-dev/protocol';
+
+import { buildContextEntries, type PiSessionEntry } from './piEntryContext';
+
+/**
+ * Map a parsed pi session (full entry list) into direct-transcript items, resolving the active
+ * branch via `buildContextEntries` and projecting each context entry the same way pi's own
+ * `sessionEntryToContextMessages` does. Unlike the Claude line-by-line mapper, pi needs the whole
+ * file because the active branch is a tree walk, not a linear scan.
+ */
+export function mapPiSessionToDirectMessages(params: Readonly<{
+  entries: readonly PiSessionEntry[];
+  fileRelPath: string;
+  leafId?: string | null;
+}>): DirectTranscriptRawMessageV1[] {
+  const contextEntries = buildContextEntries(params.entries, params.leafId);
+  const items: DirectTranscriptRawMessageV1[] = [];
+
+  for (const entry of contextEntries) {
+    const message = projectPiEntryToMessage(entry);
+    if (!message) continue;
+
+    const role = typeof (message as { role?: unknown }).role === 'string'
+      ? ((message as { role: string }).role)
+      : undefined;
+    const id = `pi:${params.fileRelPath}:${entry.id}`;
+
+    items.push({
+      id,
+      localId: id,
+      createdAtMs: resolvePiEntryTimestampMs(entry, message),
+      messageRole: resolvePiMessageRole(role),
+      raw: message,
+    });
+  }
+
+  return items;
+}
+
+/**
+ * Port of pi's `sessionEntryToContextMessages`: project one selected entry into its pi AgentMessage
+ * form, or `null` when the entry does not participate in LLM context (model_change,
+ * thinking_level_change, label, plain custom). Message entries with null/missing content are
+ * normalized to an empty content array, matching pi's defensive parsing.
+ */
+function projectPiEntryToMessage(entry: PiSessionEntry): Record<string, unknown> | null {
+  if (entry.type === 'message') {
+    const message = (entry as { message?: unknown }).message;
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
+    const msg = message as Record<string, unknown> & { content?: unknown };
+    if (msg.content == null) {
+      return { ...msg, content: [] };
+    }
+    return { ...msg };
+  }
+  if (entry.type === 'custom_message') {
+    return {
+      role: 'custom',
+      customType: (entry as { customType?: unknown }).customType,
+      content: (entry as { content?: unknown }).content ?? [],
+      display: (entry as { display?: unknown }).display,
+      details: (entry as { details?: unknown }).details,
+      timestamp: entry.timestamp,
+    };
+  }
+  if (entry.type === 'branch_summary') {
+    const summary = (entry as { summary?: unknown }).summary;
+    if (!summary) return null;
+    return {
+      role: 'branchSummary',
+      summary,
+      fromId: (entry as { fromId?: unknown }).fromId,
+      timestamp: entry.timestamp,
+    };
+  }
+  if (entry.type === 'compaction') {
+    return {
+      role: 'compactionSummary',
+      summary: (entry as { summary?: unknown }).summary,
+      tokensBefore: (entry as { tokensBefore?: unknown }).tokensBefore,
+      timestamp: entry.timestamp,
+    };
+  }
+  return null;
+}
+
+function resolvePiMessageRole(role: string | undefined): SessionMessageRole {
+  if (role === 'user') return 'user';
+  if (role === 'assistant') return 'agent';
+  // toolResult, bashExecution, custom, custom_message-inferred, branchSummary, compactionSummary
+  return 'event';
+}
+
+function resolvePiEntryTimestampMs(entry: PiSessionEntry, message: Record<string, unknown>): number {
+  const fromEntry = timestampToMs(entry.timestamp);
+  if (fromEntry > 0) return fromEntry;
+  return timestampToMs(message.timestamp);
+}
+
+function timestampToMs(value: unknown): number {
+  if (typeof value === 'string' && value.trim()) {
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms) && ms >= 0) return Math.trunc(ms);
+  }
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    // Heuristic: seconds vs milliseconds (same rule as the Claude mapper).
+    return value < 1_000_000_000_000 ? Math.trunc(value * 1000) : Math.trunc(value);
+  }
+  return 0;
+}

--- a/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.ts
+++ b/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.ts
@@ -1,19 +1,18 @@
 import type { DirectTranscriptRawMessageV1, SessionMessageRole } from '@happier-dev/protocol';
 
-import { buildContextEntries, type PiSessionEntry } from './piEntryContext';
+import { buildSessionPath, type PiSessionEntry } from './piEntryContext';
 
 /**
  * Map a parsed pi session (full entry list) into direct-transcript items, resolving the active
- * branch via `buildContextEntries` and projecting each context entry the same way pi's own
- * `sessionEntryToContextMessages` does. Unlike the Claude line-by-line mapper, pi needs the whole
- * file because the active branch is a tree walk, not a linear scan.
+ * active branch and projecting its historical entries. Compaction changes the model's runtime
+ * context, but it does not delete older records from the user-visible session history.
  */
 export function mapPiSessionToDirectMessages(params: Readonly<{
   entries: readonly PiSessionEntry[];
   fileRelPath: string;
   leafId?: string | null;
 }>): DirectTranscriptRawMessageV1[] {
-  const contextEntries = buildContextEntries(params.entries, params.leafId);
+  const contextEntries = buildSessionPath(params.entries, params.leafId);
   const items: DirectTranscriptRawMessageV1[] = [];
 
   for (const entry of contextEntries) {

--- a/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.ts
+++ b/apps/cli/src/backends/pi/directSessions/mapPiSessionToDirectMessages.ts
@@ -17,19 +17,17 @@ export function mapPiSessionToDirectMessages(params: Readonly<{
   const items: DirectTranscriptRawMessageV1[] = [];
 
   for (const entry of contextEntries) {
+    const piRole = readPiEntryRole(entry);
     const message = projectPiEntryToMessage(entry);
     if (!message) continue;
 
-    const role = typeof (message as { role?: unknown }).role === 'string'
-      ? ((message as { role: string }).role)
-      : undefined;
     const id = `pi:${params.fileRelPath}:${entry.id}`;
 
     items.push({
       id,
       localId: id,
       createdAtMs: resolvePiEntryTimestampMs(entry, message),
-      messageRole: resolvePiMessageRole(role),
+      messageRole: resolvePiMessageRole(piRole),
       raw: message,
     });
   }
@@ -38,50 +36,172 @@ export function mapPiSessionToDirectMessages(params: Readonly<{
 }
 
 /**
- * Port of pi's `sessionEntryToContextMessages`: project one selected entry into its pi AgentMessage
- * form, or `null` when the entry does not participate in LLM context (model_change,
- * thinking_level_change, label, plain custom). Message entries with null/missing content are
- * normalized to an empty content array, matching pi's defensive parsing.
+ * Port of pi's `sessionEntryToContextMessages`, projected into the protocol transcript envelope
+ * (`role: 'agent' | 'user'`, mirroring the Claude direct-session mapper) so the UI's
+ * `TranscriptRawRecordV1` schema accepts every emitted record. Message entries with
+ * null/missing content are normalized to an empty content array, matching pi's defensive
+ * parsing. Non-assistant pi roles (user-with-blocks, toolResult, bashExecution) ride `user`
+ * rows, the claude convention for non-assistant content.
  */
 function projectPiEntryToMessage(entry: PiSessionEntry): Record<string, unknown> | null {
   if (entry.type === 'message') {
     const message = (entry as { message?: unknown }).message;
     if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
     const msg = message as Record<string, unknown> & { content?: unknown };
-    if (msg.content == null) {
-      return { ...msg, content: [] };
+    const content = msg.content == null ? [] : msg.content;
+    if (msg.role === 'user') {
+      const text = typeof content === 'string' ? content : joinPiTextBlocks(content);
+      // The semantic transcript classifier only recognizes user prompts as protocol
+      // user text records (role:'user' + content.type:'text'); real pi sessions store
+      // user prompts as content block arrays, so join their text blocks. User messages
+      // without text blocks fall through to the agent-output 'user' row (attachment /
+      // tool convention) instead of being dropped.
+      if (text !== null) {
+        return { role: 'user', content: { type: 'text', text } };
+      }
     }
-    return { ...msg };
+    if (msg.role === 'assistant') {
+      return {
+        role: 'agent',
+        content: {
+          type: 'output',
+          data: {
+            type: 'assistant',
+            message: {
+              role: 'assistant',
+              ...(typeof msg.model === 'string' ? { model: msg.model } : {}),
+              ...(msg.usage && typeof msg.usage === 'object' ? { usage: msg.usage } : {}),
+              content: normalizePiAssistantContentBlocks(content),
+            },
+          },
+        },
+      };
+    }
+    if (msg.role === 'toolResult') {
+      // The UI transcript normalizer renders Claude-convention tool_result blocks; pi stores
+      // standalone toolResult messages, so project the whole message as one tool_result block.
+      return {
+        role: 'agent',
+        content: {
+          type: 'output',
+          data: {
+            type: 'user',
+            message: {
+              role: 'user',
+              content: [{
+                type: 'tool_result',
+                tool_use_id: typeof (msg as { toolCallId?: unknown }).toolCallId === 'string'
+                  ? (msg as { toolCallId: string }).toolCallId
+                  : '',
+                content,
+                is_error: (msg as { isError?: unknown }).isError === true,
+              }],
+            },
+          },
+        },
+      };
+    }
+    return {
+      role: 'agent',
+      content: {
+        type: 'output',
+        data: {
+          type: 'user',
+          message: {
+            role: 'user',
+            ...(typeof (msg as { toolCallId?: unknown }).toolCallId === 'string'
+              ? { toolCallId: (msg as { toolCallId: string }).toolCallId }
+              : {}),
+            content,
+          },
+        },
+      },
+    };
   }
   if (entry.type === 'custom_message') {
     return {
-      role: 'custom',
-      customType: (entry as { customType?: unknown }).customType,
-      content: (entry as { content?: unknown }).content ?? [],
-      display: (entry as { display?: unknown }).display,
-      details: (entry as { details?: unknown }).details,
-      timestamp: entry.timestamp,
+      role: 'agent',
+      content: {
+        type: 'output',
+        data: {
+          type: 'piCustomMessage',
+          customType: (entry as { customType?: unknown }).customType,
+          content: (entry as { content?: unknown }).content ?? [],
+          display: (entry as { display?: unknown }).display,
+          details: (entry as { details?: unknown }).details,
+        },
+      },
     };
   }
   if (entry.type === 'branch_summary') {
     const summary = (entry as { summary?: unknown }).summary;
     if (!summary) return null;
     return {
-      role: 'branchSummary',
-      summary,
-      fromId: (entry as { fromId?: unknown }).fromId,
-      timestamp: entry.timestamp,
+      role: 'agent',
+      content: { type: 'output', data: { type: 'summary', summary: String(summary) } },
     };
   }
   if (entry.type === 'compaction') {
     return {
-      role: 'compactionSummary',
-      summary: (entry as { summary?: unknown }).summary,
-      tokensBefore: (entry as { tokensBefore?: unknown }).tokensBefore,
-      timestamp: entry.timestamp,
+      role: 'agent',
+      content: {
+        type: 'output',
+        data: {
+          type: 'summary',
+          summary: String((entry as { summary?: unknown }).summary ?? ''),
+          tokensBefore: (entry as { tokensBefore?: unknown }).tokensBefore,
+        },
+      },
     };
   }
   return null;
+}
+
+/**
+ * Normalize pi assistant content blocks to the Claude transcript convention the UI renders:
+ * `{ type: 'toolCall', id, name, arguments }` -> `{ type: 'tool_use', id, name, input }`.
+ * All other block shapes (text, thinking, …) pass through unchanged.
+ */
+function normalizePiAssistantContentBlocks(content: unknown): unknown {
+  if (!Array.isArray(content)) return content;
+  return content.map((block) => {
+    if (!block || typeof block !== 'object' || Array.isArray(block)) return block;
+    const record = block as Record<string, unknown>;
+    if (record.type !== 'toolCall') return block;
+    return {
+      type: 'tool_use',
+      id: record.id,
+      name: record.name,
+      input: record.arguments,
+    };
+  });
+}
+
+/**
+ * Join the `{ type: 'text' }` blocks of a pi content block array into one string.
+ * Returns null for non-arrays and for arrays without any non-empty text blocks.
+ */
+function joinPiTextBlocks(content: unknown): string | null {
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object' || Array.isArray(block)) continue;
+    const record = block as Record<string, unknown>;
+    if (record.type !== 'text' || typeof record.text !== 'string') continue;
+    if (record.text.length > 0) parts.push(record.text);
+  }
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+function readPiEntryRole(entry: PiSessionEntry): string | undefined {
+  if (entry.type === 'message') {
+    const role = (entry as { message?: { role?: unknown } }).message?.role;
+    return typeof role === 'string' ? role : undefined;
+  }
+  if (entry.type === 'custom_message') return 'custom';
+  if (entry.type === 'branch_summary') return 'branchSummary';
+  if (entry.type === 'compaction') return 'compactionSummary';
+  return undefined;
 }
 
 function resolvePiMessageRole(role: string | undefined): SessionMessageRole {

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
@@ -124,4 +124,30 @@ describe('pagePiTranscript', () => {
       Date.parse('2024-12-03T14:00:05.000Z'),
     ]);
   });
+
+  it('reconstructs chronologically with no duplicates or gaps when maxBytes truncates pages below maxItems', async () => {
+    // Regression: byte-truncation must not overlap the next page's window. With small maxBytes each
+    // page delivers fewer items than maxItems; the reconstruction must still be chronological,
+    // gap-free, and duplicate-free across the whole active branch.
+    const agentDir = freshAgentDir();
+    const { source, env } = writeSession(agentDir, [
+      header,
+      msg('m1', null, 'user', 'message one', '2024-12-03T14:00:01.000Z'),
+      msg('m2', 'm1', 'assistant', 'message two', '2024-12-03T14:00:02.000Z'),
+      msg('m3', 'm2', 'user', 'message three', '2024-12-03T14:00:03.000Z'),
+      msg('m4', 'm3', 'assistant', 'message four', '2024-12-03T14:00:04.000Z'),
+      msg('m5', 'm4', 'user', 'message five', '2024-12-03T14:00:05.000Z'),
+      msg('m6', 'm5', 'assistant', 'message six', '2024-12-03T14:00:06.000Z'),
+    ]);
+
+    const ordered = await importAll(source, env, { maxBytes: 512, maxItems: 10 });
+    // all six, no duplicates
+    expect(ordered).toHaveLength(6);
+    expect(new Set(ordered.map((i) => i.id)).size).toBe(6);
+    // strictly chronological
+    for (let i = 1; i < ordered.length; i += 1) {
+      expect(ordered[i]!.createdAtMs).toBeGreaterThanOrEqual(ordered[i - 1]!.createdAtMs);
+    }
+    expect(ordered.map((i) => i.id).map((id) => id.slice(-2))).toEqual(['m1', 'm2', 'm3', 'm4', 'm5', 'm6']);
+  });
 });

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
@@ -81,7 +81,7 @@ describe('pagePiTranscript', () => {
     const ordered = await importAll(source, env, { maxBytes: 1024 * 1024, maxItems: 10 });
     // only m1 + m3 (active leaf = m3, the last in file)
     expect(ordered.map((i) => i.id)).toHaveLength(2);
-    expect((ordered[1]!.raw as { content: Array<{ text: string }> }).content[0]!.text).toBe('active branch');
+    expect((ordered[1]!.raw as { content: { data: { message: { content: Array<{ text: string }> } } } }).content.data.message.content[0]!.text).toBe('active branch');
   });
 
   it('returns empty and no cursor for a missing session', async () => {

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
@@ -69,6 +69,30 @@ describe('pagePiTranscript', () => {
     ]);
   });
 
+  it('reads legacy v1 linear sessions without dropping all but the final entry', async () => {
+    const agentDir = freshAgentDir();
+    const legacyHeader = { type: 'session', id: SESSION_ID, timestamp: '2024-12-03T14:00:00.000Z', cwd: '/proj' };
+    const legacyMessage = (role: string, text: string, ts: string) => ({
+      type: 'message',
+      timestamp: ts,
+      message: { role, content: [{ type: 'text', text }], timestamp: Date.parse(ts) },
+    });
+    const { source, env } = writeSession(agentDir, [
+      legacyHeader,
+      legacyMessage('user', 'one', '2024-12-03T14:00:01.000Z'),
+      legacyMessage('assistant', 'two', '2024-12-03T14:00:02.000Z'),
+      legacyMessage('user', 'three', '2024-12-03T14:00:03.000Z'),
+    ]);
+
+    const ordered = await importAll(source, env, { maxBytes: 1024 * 1024, maxItems: 10 });
+    expect(ordered).toHaveLength(3);
+    expect(ordered.map((item) => item.createdAtMs)).toEqual([
+      Date.parse('2024-12-03T14:00:01.000Z'),
+      Date.parse('2024-12-03T14:00:02.000Z'),
+      Date.parse('2024-12-03T14:00:03.000Z'),
+    ]);
+  });
+
   it('pages only the active branch, excluding the abandoned sibling', async () => {
     const agentDir = freshAgentDir();
     const { source, env } = writeSession(agentDir, [

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import type { DirectSessionsSource, DirectTranscriptRawMessageV1 } from '@happier-dev/protocol';
+
+import { pagePiTranscript } from './pagePiTranscript';
+
+const SESSION_ID = '019f4a42-4617-767a-8e7c-189b454a0352';
+
+function writeSession(agentDir: string, lines: readonly object[]): { source: DirectSessionsSource; env: NodeJS.ProcessEnv } {
+  const sessionsDir = join(agentDir, 'sessions', '--proj--');
+  mkdirSync(sessionsDir, { recursive: true });
+  const filePath = join(sessionsDir, `2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl`);
+  writeFileSync(filePath, lines.map((line) => JSON.stringify(line)).join('\n') + '\n');
+  return { source: { kind: 'piAgentDir' }, env: { ...process.env, PI_CODING_AGENT_DIR: agentDir } };
+}
+
+function freshAgentDir(): string {
+  return mkdtempSync(join(tmpdir(), 'pi-page-'));
+}
+
+const header = { type: 'session', id: SESSION_ID, timestamp: '2024-12-03T14:00:00.000Z', cwd: '/proj', version: 3 };
+
+function msg(id: string, parentId: string | null, role: string, text: string, ts: string): object {
+  return { type: 'message', id, parentId, timestamp: ts, message: { role, content: [{ type: 'text', text }], timestamp: Date.parse(ts) } };
+}
+
+/** Mirror importDirectSessionTranscript's accumulation: collect older pages, reverse, flatten. */
+async function importAll(source: DirectSessionsSource, env: NodeJS.ProcessEnv, opts: { maxBytes: number; maxItems: number }): Promise<DirectTranscriptRawMessageV1[]> {
+  const pages: DirectTranscriptRawMessageV1[][] = [];
+  let cursor: string | undefined;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const page = await pagePiTranscript({ source, env, remoteSessionId: SESSION_ID, direction: 'older', cursor, ...opts });
+    if (page.items.length > 0) pages.push(page.items.slice());
+    if (!page.hasMore || !page.nextCursor) break;
+    cursor = page.nextCursor;
+  }
+  const ordered: DirectTranscriptRawMessageV1[] = [];
+  for (let i = pages.length - 1; i >= 0; i -= 1) ordered.push(...pages[i]!);
+  return ordered;
+}
+
+describe('pagePiTranscript', () => {
+  it('walks a linear session to completion in chronological order', async () => {
+    const agentDir = freshAgentDir();
+    const { source, env } = writeSession(agentDir, [
+      header,
+      msg('m1', null, 'user', 'one', '2024-12-03T14:00:01.000Z'),
+      msg('m2', 'm1', 'assistant', 'two', '2024-12-03T14:00:02.000Z'),
+      msg('m3', 'm2', 'user', 'three', '2024-12-03T14:00:03.000Z'),
+      msg('m4', 'm3', 'assistant', 'four', '2024-12-03T14:00:04.000Z'),
+    ]);
+
+    const ordered = await importAll(source, env, { maxBytes: 1024 * 1024, maxItems: 2 });
+    expect(ordered.map((i) => i.id)).toEqual([
+      `pi:sessions/--proj--/2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl:m1`,
+      `pi:sessions/--proj--/2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl:m2`,
+      `pi:sessions/--proj--/2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl:m3`,
+      `pi:sessions/--proj--/2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl:m4`,
+    ]);
+    expect(ordered.map((i) => i.createdAtMs)).toEqual([
+      Date.parse('2024-12-03T14:00:01.000Z'),
+      Date.parse('2024-12-03T14:00:02.000Z'),
+      Date.parse('2024-12-03T14:00:03.000Z'),
+      Date.parse('2024-12-03T14:00:04.000Z'),
+    ]);
+  });
+
+  it('pages only the active branch, excluding the abandoned sibling', async () => {
+    const agentDir = freshAgentDir();
+    const { source, env } = writeSession(agentDir, [
+      header,
+      msg('m1', null, 'user', 'prompt', '2024-12-03T14:00:01.000Z'),
+      msg('m2', 'm1', 'assistant', 'abandoned branch', '2024-12-03T14:00:02.000Z'),
+      msg('m3', 'm1', 'assistant', 'active branch', '2024-12-03T14:00:03.000Z'),
+    ]);
+
+    const ordered = await importAll(source, env, { maxBytes: 1024 * 1024, maxItems: 10 });
+    // only m1 + m3 (active leaf = m3, the last in file)
+    expect(ordered.map((i) => i.id)).toHaveLength(2);
+    expect((ordered[1]!.raw as { content: Array<{ text: string }> }).content[0]!.text).toBe('active branch');
+  });
+
+  it('returns empty and no cursor for a missing session', async () => {
+    const agentDir = freshAgentDir();
+    // empty agent dir (no sessions)
+    const source: DirectSessionsSource = { kind: 'piAgentDir' };
+    const env = { ...process.env, PI_CODING_AGENT_DIR: agentDir };
+    const page = await pagePiTranscript({ source, env, remoteSessionId: SESSION_ID, direction: 'older', maxBytes: 1024, maxItems: 10 });
+    expect(page.items).toEqual([]);
+    expect(page.nextCursor).toBeNull();
+    expect(page.hasMore).toBe(false);
+  });
+
+  it('returns empty for the newer direction (v1 uses readAfter for tail)', async () => {
+    const agentDir = freshAgentDir();
+    const { source, env } = writeSession(agentDir, [header, msg('m1', null, 'user', 'one', '2024-12-03T14:00:01.000Z')]);
+    const page = await pagePiTranscript({ source, env, remoteSessionId: SESSION_ID, direction: 'newer', maxBytes: 1024, maxItems: 10 });
+    expect(page.items).toEqual([]);
+    expect(page.hasMore).toBe(false);
+  });
+
+  it('honors maxItems by splitting across pages without losing items', async () => {
+    const agentDir = freshAgentDir();
+    const { source, env } = writeSession(agentDir, [
+      header,
+      msg('m1', null, 'user', '1', '2024-12-03T14:00:01.000Z'),
+      msg('m2', 'm1', 'assistant', '2', '2024-12-03T14:00:02.000Z'),
+      msg('m3', 'm2', 'user', '3', '2024-12-03T14:00:03.000Z'),
+      msg('m4', 'm3', 'assistant', '4', '2024-12-03T14:00:04.000Z'),
+      msg('m5', 'm4', 'user', '5', '2024-12-03T14:00:05.000Z'),
+    ]);
+
+    const ordered = await importAll(source, env, { maxBytes: 1024 * 1024, maxItems: 2 });
+    expect(ordered).toHaveLength(5);
+    expect(ordered.map((i) => i.createdAtMs)).toEqual([
+      Date.parse('2024-12-03T14:00:01.000Z'),
+      Date.parse('2024-12-03T14:00:02.000Z'),
+      Date.parse('2024-12-03T14:00:03.000Z'),
+      Date.parse('2024-12-03T14:00:04.000Z'),
+      Date.parse('2024-12-03T14:00:05.000Z'),
+    ]);
+  });
+});

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { DirectSessionsSource, DirectTranscriptRawMessageV1 } from '@happier-dev/protocol';
 
-import { pagePiTranscript } from './pagePiTranscript';
+import { loadPiSessionEntries, pagePiTranscript } from './pagePiTranscript';
 
 const SESSION_ID = '019f4a42-4617-767a-8e7c-189b454a0352';
 
@@ -91,6 +91,33 @@ describe('pagePiTranscript', () => {
       Date.parse('2024-12-03T14:00:02.000Z'),
       Date.parse('2024-12-03T14:00:03.000Z'),
     ]);
+  });
+
+  it('preserves modern tree links when a valid header has no version', async () => {
+    const agentDir = freshAgentDir();
+    const versionlessHeader = {
+      type: 'session',
+      id: SESSION_ID,
+      timestamp: '2024-12-03T14:00:00.000Z',
+      cwd: '/proj',
+    };
+    const { source, env } = writeSession(agentDir, [
+      versionlessHeader,
+      msg('m1', null, 'user', 'prompt', '2024-12-03T14:00:01.000Z'),
+      msg('m2', 'm1', 'assistant', 'abandoned', '2024-12-03T14:00:02.000Z'),
+      msg('m3', 'm1', 'assistant', 'active', '2024-12-03T14:00:03.000Z'),
+    ]);
+
+    const ordered = await importAll(source, env, { maxBytes: 1024 * 1024, maxItems: 10 });
+    expect(ordered.map((item) => item.id)).toEqual([
+      `pi:sessions/--proj--/2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl:m1`,
+      `pi:sessions/--proj--/2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl:m3`,
+    ]);
+  });
+
+  it('does not reinterpret non-missing filesystem failures as an empty session', async () => {
+    const directory = freshAgentDir();
+    await expect(loadPiSessionEntries(directory)).rejects.toMatchObject({ code: 'EISDIR' });
   });
 
   it('pages only the active branch, excluding the abandoned sibling', async () => {

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.ts
@@ -60,8 +60,19 @@ export function decodePiForwardCursor(raw: string | undefined): PiForwardCursorV
 
 function normalizeLegacyPiEntries(records: readonly Record<string, unknown>[]): PiSessionEntry[] {
   const header = records.find((record) => record.type === 'session');
-  const version = typeof header?.version === 'number' ? header.version : 1;
-  if (version >= 2) return records.map((record) => record as PiSessionEntry);
+  const version = typeof header?.version === 'number' ? header.version : null;
+  if (version !== null && version >= 2) {
+    return records.map((record) => record as PiSessionEntry);
+  }
+  const nonHeaderRecords = records.filter((record) => record.type !== 'session');
+  const hasCompleteTreeLinks = nonHeaderRecords.length > 0 && nonHeaderRecords.every(
+    (record) => typeof record.id === 'string'
+      && record.id.trim().length > 0
+      && Object.hasOwn(record, 'parentId'),
+  );
+  if (version === null && hasCompleteTreeLinks) {
+    return records.map((record) => record as PiSessionEntry);
+  }
 
   const ids = records.map((record, index) => {
     if (record.type === 'session') return null;
@@ -83,7 +94,20 @@ function normalizeLegacyPiEntries(records: readonly Record<string, unknown>[]): 
  * branch cannot be resolved incrementally; the full entry list is required for the tree walk.
  */
 export async function loadPiSessionEntries(filePath: string): Promise<PiSessionEntry[]> {
-  const content = await readFile(filePath, 'utf8').catch(() => '');
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf8');
+  } catch (error) {
+    if (
+      error
+      && typeof error === 'object'
+      && 'code' in error
+      && error.code === 'ENOENT'
+    ) {
+      return [];
+    }
+    throw error;
+  }
   const entries: Record<string, unknown>[] = [];
   for (const line of content.split('\n')) {
     const trimmed = line.trim();
@@ -108,7 +132,7 @@ async function loadMappedItems(
   return mapPiSessionToDirectMessages({ entries, fileRelPath });
 }
 
-function itemByteSize(item: DirectTranscriptRawMessageV1): number {
+export function itemByteSize(item: DirectTranscriptRawMessageV1): number {
   try {
     return Buffer.byteLength(JSON.stringify(item.raw), 'utf8');
   } catch {

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.ts
@@ -6,24 +6,25 @@ import type { PiSessionEntry } from './piEntryContext';
 import { mapPiSessionToDirectMessages } from './mapPiSessionToDirectMessages';
 import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
 
-type PiBackwardCursorV1 = Readonly<{ v: 1; kind: 'piBackward'; consumed: number }>;
+type PiBackwardCursorV1 = Readonly<{ v: 1; kind: 'piBackward'; endExclusive: number }>;
 type PiForwardCursorV1 = Readonly<{ v: 1; kind: 'piForward'; delivered: number }>;
 
 function encodeBackwardCursor(value: PiBackwardCursorV1): string {
   return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
 }
 
-function decodeBackwardCursor(raw: string | undefined): number {
-  if (typeof raw !== 'string' || raw.trim().length === 0) return 0;
+function decodeBackwardCursor(raw: string | undefined): number | null {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return null;
   try {
     const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as unknown;
-    if (!parsed || typeof parsed !== 'object') return 0;
+    if (!parsed || typeof parsed !== 'object') return null;
     const value = parsed as Record<string, unknown>;
-    if (value.v !== 1 || value.kind !== 'piBackward') return 0;
-    const consumed = typeof value.consumed === 'number' && Number.isFinite(value.consumed) ? value.consumed : 0;
-    return Math.max(0, Math.trunc(consumed));
+    if (value.v !== 1 || value.kind !== 'piBackward') return null;
+    const endExclusive = typeof value.endExclusive === 'number' && Number.isFinite(value.endExclusive) ? value.endExclusive : NaN;
+    if (!Number.isFinite(endExclusive) || endExclusive < 0) return null;
+    return Math.trunc(endExclusive);
   } catch {
-    return 0;
+    return null;
   }
 }
 
@@ -120,34 +121,35 @@ export async function pagePiTranscript(params: Readonly<{
 
   const items = await loadMappedItems(resolved.filePath, resolved.fileRelPath);
   const total = items.length;
-  const consumed = decodeBackwardCursor(params.cursor);
+  const maxItems = Math.max(1, Math.trunc(params.maxItems));
+  const maxBytes = Math.max(1, Math.trunc(params.maxBytes));
   const tailCursor = encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: total });
 
-  const remaining = total - consumed;
-  if (remaining <= 0) {
+  // Backward paging uses an `endExclusive` cursor: each page delivers a contiguous block ending at
+  // endExclusive, collected newest-first so byte-limit truncation cuts the OLDER end and the next
+  // page's window begins exactly where this one stopped. This keeps pages gap-free, overlap-free,
+  // and reconstructable into full chronological order even when maxBytes truncates below maxItems.
+  const decoded = decodeBackwardCursor(params.cursor);
+  const endExclusive = decoded === null ? total : Math.min(Math.max(0, decoded), total);
+  if (endExclusive <= 0) {
     return { items: [], nextCursor: null, tailCursor, hasMore: false };
   }
 
-  const maxItems = Math.max(1, Math.trunc(params.maxItems));
-  const maxBytes = Math.max(1, Math.trunc(params.maxBytes));
-
-  const pageStart = Math.max(0, total - consumed - maxItems);
-  const pageEndExclusive = total - consumed;
-
-  const pageItems: DirectTranscriptRawMessageV1[] = [];
+  const windowStart = Math.max(0, endExclusive - maxItems);
+  const collected: DirectTranscriptRawMessageV1[] = [];
   let bytesUsed = 0;
-  for (let i = pageStart; i < pageEndExclusive; i += 1) {
+  for (let i = endExclusive - 1; i >= windowStart && collected.length < maxItems; i -= 1) {
     const item = items[i]!;
-    if (pageItems.length >= maxItems) break;
     const size = itemByteSize(item);
-    if (pageItems.length > 0 && bytesUsed + size > maxBytes) break;
-    pageItems.push(item);
+    if (collected.length > 0 && bytesUsed + size > maxBytes) break;
+    collected.push(item);
     bytesUsed += size;
   }
+  collected.reverse(); // newest-first collection → chronological intra-page order
 
-  const newConsumed = consumed + pageItems.length;
-  const hasMore = newConsumed < total;
-  const nextCursor = hasMore ? encodeBackwardCursor({ v: 1, kind: 'piBackward', consumed: newConsumed }) : null;
+  const newEndExclusive = endExclusive - collected.length;
+  const hasMore = newEndExclusive > 0;
+  const nextCursor = hasMore ? encodeBackwardCursor({ v: 1, kind: 'piBackward', endExclusive: newEndExclusive }) : null;
 
-  return { items: pageItems, nextCursor, tailCursor, hasMore };
+  return { items: collected, nextCursor, tailCursor, hasMore };
 }

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.ts
@@ -7,7 +7,12 @@ import { mapPiSessionToDirectMessages } from './mapPiSessionToDirectMessages';
 import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
 
 type PiBackwardCursorV1 = Readonly<{ v: 1; kind: 'piBackward'; endExclusive: number }>;
-type PiForwardCursorV1 = Readonly<{ v: 1; kind: 'piForward'; delivered: number }>;
+export type PiForwardCursorV1 = Readonly<{
+  v: 1;
+  kind: 'piForward';
+  delivered: number;
+  anchorItemId?: string | null;
+}>;
 
 function encodeBackwardCursor(value: PiBackwardCursorV1): string {
   return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
@@ -32,18 +37,45 @@ export function encodePiForwardCursor(value: PiForwardCursorV1): string {
   return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
 }
 
-export function decodePiForwardCursor(raw: string | undefined): number {
-  if (typeof raw !== 'string' || raw.trim().length === 0) return 0;
+export function decodePiForwardCursor(raw: string | undefined): PiForwardCursorV1 | null {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return null;
   try {
     const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as unknown;
-    if (!parsed || typeof parsed !== 'object') return 0;
+    if (!parsed || typeof parsed !== 'object') return null;
     const value = parsed as Record<string, unknown>;
-    if (value.v !== 1 || value.kind !== 'piForward') return 0;
-    const delivered = typeof value.delivered === 'number' && Number.isFinite(value.delivered) ? value.delivered : 0;
-    return Math.max(0, Math.trunc(delivered));
+    if (value.v !== 1 || value.kind !== 'piForward') return null;
+    if (typeof value.delivered !== 'number' || !Number.isFinite(value.delivered) || value.delivered < 0) return null;
+    return {
+      v: 1,
+      kind: 'piForward',
+      delivered: Math.trunc(value.delivered),
+      ...(typeof value.anchorItemId === 'string' || value.anchorItemId === null
+        ? { anchorItemId: value.anchorItemId }
+        : {}),
+    };
   } catch {
-    return 0;
+    return null;
   }
+}
+
+function normalizeLegacyPiEntries(records: readonly Record<string, unknown>[]): PiSessionEntry[] {
+  const header = records.find((record) => record.type === 'session');
+  const version = typeof header?.version === 'number' ? header.version : 1;
+  if (version >= 2) return records.map((record) => record as PiSessionEntry);
+
+  const ids = records.map((record, index) => {
+    if (record.type === 'session') return null;
+    const existingId = typeof record.id === 'string' ? record.id.trim() : '';
+    return existingId || `legacy-${index}`;
+  });
+  let previousId: string | null = null;
+  return records.map((record, index) => {
+    if (record.type === 'session') return record as PiSessionEntry;
+    const id = ids[index]!;
+    const normalized: Record<string, unknown> = { ...record, id, parentId: previousId };
+    previousId = id;
+    return normalized as PiSessionEntry;
+  });
 }
 
 /**
@@ -52,20 +84,20 @@ export function decodePiForwardCursor(raw: string | undefined): number {
  */
 export async function loadPiSessionEntries(filePath: string): Promise<PiSessionEntry[]> {
   const content = await readFile(filePath, 'utf8').catch(() => '');
-  const entries: PiSessionEntry[] = [];
+  const entries: Record<string, unknown>[] = [];
   for (const line of content.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
       const parsed = JSON.parse(trimmed) as unknown;
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        entries.push(parsed as PiSessionEntry);
+        entries.push(parsed as Record<string, unknown>);
       }
     } catch {
       // Skip malformed lines (matches pi's own parseSessionEntryLine).
     }
   }
-  return entries;
+  return normalizeLegacyPiEntries(entries);
 }
 
 async function loadMappedItems(
@@ -123,7 +155,12 @@ export async function pagePiTranscript(params: Readonly<{
   const total = items.length;
   const maxItems = Math.max(1, Math.trunc(params.maxItems));
   const maxBytes = Math.max(1, Math.trunc(params.maxBytes));
-  const tailCursor = encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: total });
+  const tailCursor = encodePiForwardCursor({
+    v: 1,
+    kind: 'piForward',
+    delivered: total,
+    anchorItemId: items.at(-1)?.id ?? null,
+  });
 
   // Backward paging uses an `endExclusive` cursor: each page delivers a contiguous block ending at
   // endExclusive, collected newest-first so byte-limit truncation cuts the OLDER end and the next

--- a/apps/cli/src/backends/pi/directSessions/pagePiTranscript.ts
+++ b/apps/cli/src/backends/pi/directSessions/pagePiTranscript.ts
@@ -1,0 +1,153 @@
+import { readFile } from 'node:fs/promises';
+
+import type { DirectSessionsSource, DirectTranscriptRawMessageV1 } from '@happier-dev/protocol';
+
+import type { PiSessionEntry } from './piEntryContext';
+import { mapPiSessionToDirectMessages } from './mapPiSessionToDirectMessages';
+import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
+
+type PiBackwardCursorV1 = Readonly<{ v: 1; kind: 'piBackward'; consumed: number }>;
+type PiForwardCursorV1 = Readonly<{ v: 1; kind: 'piForward'; delivered: number }>;
+
+function encodeBackwardCursor(value: PiBackwardCursorV1): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+function decodeBackwardCursor(raw: string | undefined): number {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return 0;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') return 0;
+    const value = parsed as Record<string, unknown>;
+    if (value.v !== 1 || value.kind !== 'piBackward') return 0;
+    const consumed = typeof value.consumed === 'number' && Number.isFinite(value.consumed) ? value.consumed : 0;
+    return Math.max(0, Math.trunc(consumed));
+  } catch {
+    return 0;
+  }
+}
+
+export function encodePiForwardCursor(value: PiForwardCursorV1): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+export function decodePiForwardCursor(raw: string | undefined): number {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return 0;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') return 0;
+    const value = parsed as Record<string, unknown>;
+    if (value.v !== 1 || value.kind !== 'piForward') return 0;
+    const delivered = typeof value.delivered === 'number' && Number.isFinite(value.delivered) ? value.delivered : 0;
+    return Math.max(0, Math.trunc(delivered));
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Parse a whole pi session JSONL file into its raw entries. Pi sessions are trees, so the active
+ * branch cannot be resolved incrementally; the full entry list is required for the tree walk.
+ */
+export async function loadPiSessionEntries(filePath: string): Promise<PiSessionEntry[]> {
+  const content = await readFile(filePath, 'utf8').catch(() => '');
+  const entries: PiSessionEntry[] = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        entries.push(parsed as PiSessionEntry);
+      }
+    } catch {
+      // Skip malformed lines (matches pi's own parseSessionEntryLine).
+    }
+  }
+  return entries;
+}
+
+async function loadMappedItems(
+  filePath: string,
+  fileRelPath: string,
+): Promise<DirectTranscriptRawMessageV1[]> {
+  const entries = await loadPiSessionEntries(filePath);
+  return mapPiSessionToDirectMessages({ entries, fileRelPath });
+}
+
+function itemByteSize(item: DirectTranscriptRawMessageV1): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(item.raw), 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Page a pi direct-session transcript. Pi pages the projected active-branch item list rather than
+ * raw file bytes: the `older` direction walks backward from the newest item (the import flow),
+ * returning each page in chronological order so the caller's page-reversal reconstructs full
+ * chronological order. `consumed` counts items already delivered from the end.
+ */
+export async function pagePiTranscript(params: Readonly<{
+  source: DirectSessionsSource;
+  env?: NodeJS.ProcessEnv;
+  remoteSessionId: string;
+  direction: 'older' | 'newer';
+  cursor?: string;
+  maxBytes: number;
+  maxItems: number;
+}>): Promise<Readonly<{
+  items: DirectTranscriptRawMessageV1[];
+  nextCursor: string | null;
+  tailCursor: string | null;
+  hasMore: boolean;
+  truncated?: boolean;
+}>> {
+  const resolved = await resolvePiDirectSessionFile({
+    source: params.source,
+    env: params.env,
+    remoteSessionId: params.remoteSessionId,
+  });
+  if (!resolved) {
+    return { items: [], nextCursor: null, tailCursor: null, hasMore: false };
+  }
+
+  // Forward paging is not required for v1 UI flows (tail uses readAfter).
+  if (params.direction !== 'older') {
+    return { items: [], nextCursor: null, tailCursor: null, hasMore: false };
+  }
+
+  const items = await loadMappedItems(resolved.filePath, resolved.fileRelPath);
+  const total = items.length;
+  const consumed = decodeBackwardCursor(params.cursor);
+  const tailCursor = encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: total });
+
+  const remaining = total - consumed;
+  if (remaining <= 0) {
+    return { items: [], nextCursor: null, tailCursor, hasMore: false };
+  }
+
+  const maxItems = Math.max(1, Math.trunc(params.maxItems));
+  const maxBytes = Math.max(1, Math.trunc(params.maxBytes));
+
+  const pageStart = Math.max(0, total - consumed - maxItems);
+  const pageEndExclusive = total - consumed;
+
+  const pageItems: DirectTranscriptRawMessageV1[] = [];
+  let bytesUsed = 0;
+  for (let i = pageStart; i < pageEndExclusive; i += 1) {
+    const item = items[i]!;
+    if (pageItems.length >= maxItems) break;
+    const size = itemByteSize(item);
+    if (pageItems.length > 0 && bytesUsed + size > maxBytes) break;
+    pageItems.push(item);
+    bytesUsed += size;
+  }
+
+  const newConsumed = consumed + pageItems.length;
+  const hasMore = newConsumed < total;
+  const nextCursor = hasMore ? encodeBackwardCursor({ v: 1, kind: 'piBackward', consumed: newConsumed }) : null;
+
+  return { items: pageItems, nextCursor, tailCursor, hasMore };
+}

--- a/apps/cli/src/backends/pi/directSessions/piEntryContext.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/piEntryContext.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  buildContextEntries,
   buildSessionPath,
   resolveActiveLeafId,
   type PiSessionEntry,
@@ -76,39 +75,15 @@ describe('piEntryContext', () => {
       const entries: PiSessionEntry[] = [entry({ type: 'message', id: 'a1b2c3d4', parentId: null })];
       expect(buildSessionPath(entries, null)).toEqual([]);
     });
-  });
 
-  describe('buildContextEntries', () => {
-    it('returns the full path when there is no compaction', () => {
+    it('terminates when malformed parent links contain a cycle', () => {
       const entries: PiSessionEntry[] = [
-        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
-        entry({ type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4' }),
+        entry({ type: 'message', id: 'cycle-a', parentId: 'cycle-b' }),
+        entry({ type: 'message', id: 'cycle-b', parentId: 'cycle-a' }),
       ];
-      expect(buildContextEntries(entries).map((e) => e.id)).toEqual(['a1b2c3d4', 'b2c3d4e5']);
-    });
 
-    it('drops entries before the latest compaction firstKeptEntryId, keeps compaction + kept tail + post-compaction', () => {
-      const entries: PiSessionEntry[] = [
-        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
-        entry({ type: 'message', id: 'summarized1', parentId: 'a1b2c3d4' }),
-        entry({ type: 'message', id: 'keptstart', parentId: 'summarized1' }),
-        entry({ type: 'message', id: 'keptnext', parentId: 'keptstart' }),
-        entry({ type: 'compaction', id: 'comp12345', parentId: 'keptnext', firstKeptEntryId: 'keptstart', summary: '...' }),
-        entry({ type: 'message', id: 'aftercmp', parentId: 'comp12345' }),
-      ];
-      expect(buildContextEntries(entries).map((e) => e.id)).toEqual(['comp12345', 'keptstart', 'keptnext', 'aftercmp']);
-    });
-
-    it('uses the latest compaction when multiple are on the path', () => {
-      const entries: PiSessionEntry[] = [
-        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
-        entry({ type: 'compaction', id: 'oldcomp12', parentId: 'a1b2c3d4', firstKeptEntryId: 'a1b2c3d4', summary: 'old' }),
-        entry({ type: 'message', id: 'midmsg12', parentId: 'oldcomp12' }),
-        entry({ type: 'compaction', id: 'newcomp12', parentId: 'midmsg12', firstKeptEntryId: 'midmsg12', summary: 'new' }),
-        entry({ type: 'message', id: 'afternew', parentId: 'newcomp12' }),
-      ];
-      // latest compaction wins: [newcomp, midmsg, afternew]
-      expect(buildContextEntries(entries).map((e) => e.id)).toEqual(['newcomp12', 'midmsg12', 'afternew']);
+      expect(buildSessionPath(entries).map((item) => item.id)).toEqual(['cycle-a', 'cycle-b']);
     });
   });
+
 });

--- a/apps/cli/src/backends/pi/directSessions/piEntryContext.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/piEntryContext.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildContextEntries,
+  buildSessionPath,
+  resolveActiveLeafId,
+  type PiSessionEntry,
+} from './piEntryContext';
+
+// Minimal entry factory. Timestamps are ISO strings on real pi entries.
+function entry(partial: Partial<PiSessionEntry> & Pick<PiSessionEntry, 'type' | 'id'>): PiSessionEntry {
+  return {
+    parentId: null,
+    timestamp: '2024-12-03T14:00:00.000Z',
+    ...partial,
+  } as PiSessionEntry;
+}
+
+const header = { type: 'session', id: 'root-uuid', timestamp: '2024-12-03T14:00:00.000Z', version: 3, cwd: '/proj' };
+
+describe('piEntryContext', () => {
+  describe('resolveActiveLeafId', () => {
+    it('returns the last non-header entry id (mirrors pi _buildIndex)', () => {
+      const entries: PiSessionEntry[] = [
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4' }),
+      ];
+      expect(resolveActiveLeafId(entries)).toBe('b2c3d4e5');
+    });
+
+    it('skips the session header when present', () => {
+      const entries = [
+        header,
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'message', id: 'c3d4e5f6', parentId: 'a1b2c3d4' }),
+      ];
+      expect(resolveActiveLeafId(entries)).toBe('c3d4e5f6');
+    });
+
+    it('returns null when there are no non-header entries', () => {
+      expect(resolveActiveLeafId([header as any])).toBeNull();
+      expect(resolveActiveLeafId([])).toBeNull();
+    });
+  });
+
+  describe('buildSessionPath', () => {
+    it('walks a linear branch root -> leaf', () => {
+      const entries: PiSessionEntry[] = [
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4' }),
+        entry({ type: 'message', id: 'c3d4e5f6', parentId: 'b2c3d4e5' }),
+      ];
+      expect(buildSessionPath(entries).map((e) => e.id)).toEqual(['a1b2c3d4', 'b2c3d4e5', 'c3d4e5f6']);
+    });
+
+    it('defaults the leaf to the last-in-file entry, so the active branch excludes abandoned siblings', () => {
+      // root a -> b, and a -> b' where b' was appended later (b' is the active leaf)
+      const entries: PiSessionEntry[] = [
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'message', id: 'bbbbbbbb', parentId: 'a1b2c3d4' }),
+        entry({ type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4' }),
+      ];
+      expect(buildSessionPath(entries).map((e) => e.id)).toEqual(['a1b2c3d4', 'b2c3d4e5']);
+    });
+
+    it('honors an explicit leafId to select a non-default branch', () => {
+      const entries: PiSessionEntry[] = [
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'message', id: 'bbbbbbbb', parentId: 'a1b2c3d4' }),
+        entry({ type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4' }),
+      ];
+      expect(buildSessionPath(entries, 'bbbbbbbb').map((e) => e.id)).toEqual(['a1b2c3d4', 'bbbbbbbb']);
+    });
+
+    it('returns [] when leafId is null', () => {
+      const entries: PiSessionEntry[] = [entry({ type: 'message', id: 'a1b2c3d4', parentId: null })];
+      expect(buildSessionPath(entries, null)).toEqual([]);
+    });
+  });
+
+  describe('buildContextEntries', () => {
+    it('returns the full path when there is no compaction', () => {
+      const entries: PiSessionEntry[] = [
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4' }),
+      ];
+      expect(buildContextEntries(entries).map((e) => e.id)).toEqual(['a1b2c3d4', 'b2c3d4e5']);
+    });
+
+    it('drops entries before the latest compaction firstKeptEntryId, keeps compaction + kept tail + post-compaction', () => {
+      const entries: PiSessionEntry[] = [
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'message', id: 'summarized1', parentId: 'a1b2c3d4' }),
+        entry({ type: 'message', id: 'keptstart', parentId: 'summarized1' }),
+        entry({ type: 'message', id: 'keptnext', parentId: 'keptstart' }),
+        entry({ type: 'compaction', id: 'comp12345', parentId: 'keptnext', firstKeptEntryId: 'keptstart', summary: '...' }),
+        entry({ type: 'message', id: 'aftercmp', parentId: 'comp12345' }),
+      ];
+      expect(buildContextEntries(entries).map((e) => e.id)).toEqual(['comp12345', 'keptstart', 'keptnext', 'aftercmp']);
+    });
+
+    it('uses the latest compaction when multiple are on the path', () => {
+      const entries: PiSessionEntry[] = [
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'compaction', id: 'oldcomp12', parentId: 'a1b2c3d4', firstKeptEntryId: 'a1b2c3d4', summary: 'old' }),
+        entry({ type: 'message', id: 'midmsg12', parentId: 'oldcomp12' }),
+        entry({ type: 'compaction', id: 'newcomp12', parentId: 'midmsg12', firstKeptEntryId: 'midmsg12', summary: 'new' }),
+        entry({ type: 'message', id: 'afternew', parentId: 'newcomp12' }),
+      ];
+      // latest compaction wins: [newcomp, midmsg, afternew]
+      expect(buildContextEntries(entries).map((e) => e.id)).toEqual(['newcomp12', 'midmsg12', 'afternew']);
+    });
+  });
+});

--- a/apps/cli/src/backends/pi/directSessions/piEntryContext.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/piEntryContext.test.ts
@@ -15,7 +15,7 @@ function entry(partial: Partial<PiSessionEntry> & Pick<PiSessionEntry, 'type' | 
   } as PiSessionEntry;
 }
 
-const header = { type: 'session', id: 'root-uuid', timestamp: '2024-12-03T14:00:00.000Z', version: 3, cwd: '/proj' };
+const header: PiSessionEntry = { type: 'session', id: 'root-uuid', timestamp: '2024-12-03T14:00:00.000Z', version: 3, cwd: '/proj' };
 
 describe('piEntryContext', () => {
   describe('resolveActiveLeafId', () => {
@@ -37,7 +37,7 @@ describe('piEntryContext', () => {
     });
 
     it('returns null when there are no non-header entries', () => {
-      expect(resolveActiveLeafId([header as any])).toBeNull();
+      expect(resolveActiveLeafId([header])).toBeNull();
       expect(resolveActiveLeafId([])).toBeNull();
     });
   });
@@ -69,6 +69,15 @@ describe('piEntryContext', () => {
         entry({ type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4' }),
       ];
       expect(buildSessionPath(entries, 'bbbbbbbb').map((e) => e.id)).toEqual(['a1b2c3d4', 'bbbbbbbb']);
+    });
+
+    it('returns an empty path when an explicit leaf id is absent', () => {
+      const entries: PiSessionEntry[] = [
+        entry({ type: 'message', id: 'a1b2c3d4', parentId: null }),
+        entry({ type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4' }),
+      ];
+
+      expect(buildSessionPath(entries, 'missing-leaf')).toEqual([]);
     });
 
     it('returns [] when leafId is null', () => {

--- a/apps/cli/src/backends/pi/directSessions/piEntryContext.ts
+++ b/apps/cli/src/backends/pi/directSessions/piEntryContext.ts
@@ -1,0 +1,128 @@
+/**
+ * Pi session tree-walk helpers, ported from pi's own SessionManager
+ * (dist/core/session-manager.js: buildSessionPath, buildContextEntries, _buildIndex).
+ *
+ * Pi session files are JSONL trees keyed by `id`/`parentId`. The "active branch" is the path
+ * from the current leaf to the root, folded at the latest compaction entry. These helpers
+ * reproduce pi's own active-context resolution so direct-session import matches what a resumed
+ * pi session actually sees — not a second divergent tree resolver.
+ *
+ * The session header (`type: 'session'`) is not part of the tree and is excluded everywhere.
+ */
+
+export interface PiSessionEntry {
+  readonly type: string;
+  readonly id: string;
+  // Optional because the `session` header entry carries no parentId; headers are filtered out of
+  // all tree walks before parentId is read.
+  readonly parentId?: string | null;
+  /** ISO timestamp string on real pi entries. */
+  readonly timestamp?: string;
+  /** Present on `compaction` entries; the first entry id retained after summarization. */
+  readonly firstKeptEntryId?: string;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Index non-header entries by id (mirrors pi's `buildEntryIndex`, header-excluded).
+ */
+function indexEntries(entries: readonly PiSessionEntry[]): Map<string, PiSessionEntry> {
+  const index = new Map<string, PiSessionEntry>();
+  for (const entry of entries) {
+    if (entry.type === 'session') continue;
+    index.set(entry.id, entry);
+  }
+  return index;
+}
+
+function nonHeaderEntries(entries: readonly PiSessionEntry[]): PiSessionEntry[] {
+  return entries.filter((entry) => entry.type !== 'session');
+}
+
+/**
+ * Resolve the active leaf id on load: the last non-header entry in file order.
+ * Mirrors pi's `_buildIndex`, which assigns `leafId` at each iteration so the final entry wins.
+ * There is no persisted leaf pointer in the file; this is fully re-derivable from contents.
+ */
+export function resolveActiveLeafId(entries: readonly PiSessionEntry[]): string | null {
+  let leafId: string | null = null;
+  for (const entry of entries) {
+    if (entry.type === 'session') continue;
+    leafId = entry.id;
+  }
+  return leafId;
+}
+
+/**
+ * Walk from the leaf to the root via `parentId`, returning the path in root -> leaf order.
+ * When `leafId` is omitted, defaults to the last non-header entry (pi's load default).
+ * When `leafId` is explicitly `null`, returns `[]` (pi's reset-leaf semantics).
+ */
+export function buildSessionPath(
+  entries: readonly PiSessionEntry[],
+  leafId?: string | null,
+): PiSessionEntry[] {
+  if (leafId === null) return [];
+  const index = indexEntries(entries);
+  let leaf: PiSessionEntry | undefined;
+  if (leafId) {
+    leaf = index.get(leafId);
+  }
+  leaf ??= nonHeaderEntries(entries).at(-1);
+  if (!leaf) return [];
+
+  const path: PiSessionEntry[] = [];
+  let current: PiSessionEntry | undefined = leaf;
+  while (current) {
+    path.push(current);
+    current = current.parentId ? index.get(current.parentId) : undefined;
+  }
+  path.reverse();
+  return path;
+}
+
+/**
+ * Build the compaction-aware active entry list. Mirrors pi's `buildContextEntries`:
+ * 1. take the leaf -> root path;
+ * 2. find the latest compaction entry on it;
+ * 3. if none, return the whole path;
+ * 4. otherwise return [compaction, …entries from firstKeptEntryId up to (not incl.) compaction,
+ *    …entries after compaction], dropping older summarized entries.
+ *
+ * Note: pi's installed SessionManager honors `firstKeptEntryId` only; it does not expand
+ * `retainedTail`. This port matches that behavior.
+ */
+export function buildContextEntries(
+  entries: readonly PiSessionEntry[],
+  leafId?: string | null,
+): PiSessionEntry[] {
+  const path = buildSessionPath(entries, leafId);
+  let compaction: PiSessionEntry | null = null;
+  for (const entry of path) {
+    if (entry.type === 'compaction') {
+      compaction = entry;
+    }
+  }
+  if (!compaction) {
+    return path;
+  }
+  const compactionEntry = compaction;
+  const compactionIdx = path.findIndex((entry) => entry.id === compactionEntry.id);
+  if (compactionIdx < 0) {
+    return path;
+  }
+
+  const contextEntries: PiSessionEntry[] = [compactionEntry];
+  let foundFirstKept = false;
+  for (let i = 0; i < compactionIdx; i += 1) {
+    const entry = path[i]!;
+    if (entry.id === compactionEntry.firstKeptEntryId) {
+      foundFirstKept = true;
+    }
+    if (foundFirstKept) {
+      contextEntries.push(entry);
+    }
+  }
+  contextEntries.push(...path.slice(compactionIdx + 1));
+  return contextEntries;
+}

--- a/apps/cli/src/backends/pi/directSessions/piEntryContext.ts
+++ b/apps/cli/src/backends/pi/directSessions/piEntryContext.ts
@@ -63,10 +63,12 @@ export function buildSessionPath(
   if (leafId === null) return [];
   const index = indexEntries(entries);
   let leaf: PiSessionEntry | undefined;
-  if (leafId) {
+  if (leafId !== undefined) {
     leaf = index.get(leafId);
+    if (!leaf) return [];
+  } else {
+    leaf = nonHeaderEntries(entries).at(-1);
   }
-  leaf ??= nonHeaderEntries(entries).at(-1);
   if (!leaf) return [];
 
   const path: PiSessionEntry[] = [];

--- a/apps/cli/src/backends/pi/directSessions/piEntryContext.ts
+++ b/apps/cli/src/backends/pi/directSessions/piEntryContext.ts
@@ -1,11 +1,9 @@
 /**
- * Pi session tree-walk helpers, ported from pi's own SessionManager
- * (dist/core/session-manager.js: buildSessionPath, buildContextEntries, _buildIndex).
+ * Pi session tree-walk helpers, aligned with Pi's SessionManager active-branch traversal.
  *
  * Pi session files are JSONL trees keyed by `id`/`parentId`. The "active branch" is the path
- * from the current leaf to the root, folded at the latest compaction entry. These helpers
- * reproduce pi's own active-context resolution so direct-session import matches what a resumed
- * pi session actually sees — not a second divergent tree resolver.
+ * from the current leaf to the root. Direct-session history uses that complete path; compaction
+ * affects Pi's model context but does not remove historical records from the browser.
  *
  * The session header (`type: 'session'`) is not part of the tree and is excluded everywhere.
  */
@@ -72,57 +70,14 @@ export function buildSessionPath(
   if (!leaf) return [];
 
   const path: PiSessionEntry[] = [];
+  const visitedIds = new Set<string>();
   let current: PiSessionEntry | undefined = leaf;
   while (current) {
+    if (visitedIds.has(current.id)) break;
+    visitedIds.add(current.id);
     path.push(current);
     current = current.parentId ? index.get(current.parentId) : undefined;
   }
   path.reverse();
   return path;
-}
-
-/**
- * Build the compaction-aware active entry list. Mirrors pi's `buildContextEntries`:
- * 1. take the leaf -> root path;
- * 2. find the latest compaction entry on it;
- * 3. if none, return the whole path;
- * 4. otherwise return [compaction, …entries from firstKeptEntryId up to (not incl.) compaction,
- *    …entries after compaction], dropping older summarized entries.
- *
- * Note: pi's installed SessionManager honors `firstKeptEntryId` only; it does not expand
- * `retainedTail`. This port matches that behavior.
- */
-export function buildContextEntries(
-  entries: readonly PiSessionEntry[],
-  leafId?: string | null,
-): PiSessionEntry[] {
-  const path = buildSessionPath(entries, leafId);
-  let compaction: PiSessionEntry | null = null;
-  for (const entry of path) {
-    if (entry.type === 'compaction') {
-      compaction = entry;
-    }
-  }
-  if (!compaction) {
-    return path;
-  }
-  const compactionEntry = compaction;
-  const compactionIdx = path.findIndex((entry) => entry.id === compactionEntry.id);
-  if (compactionIdx < 0) {
-    return path;
-  }
-
-  const contextEntries: PiSessionEntry[] = [compactionEntry];
-  let foundFirstKept = false;
-  for (let i = 0; i < compactionIdx; i += 1) {
-    const entry = path[i]!;
-    if (entry.id === compactionEntry.firstKeptEntryId) {
-      foundFirstKept = true;
-    }
-    if (foundFirstKept) {
-      contextEntries.push(entry);
-    }
-  }
-  contextEntries.push(...path.slice(compactionIdx + 1));
-  return contextEntries;
 }

--- a/apps/cli/src/backends/pi/directSessions/providerOps.ts
+++ b/apps/cli/src/backends/pi/directSessions/providerOps.ts
@@ -61,12 +61,11 @@ export const piDirectSessionProviderOps: DirectSessionProviderOps = {
     // PI_CODING_AGENT_DIR points pi at the same ~/.pi/agent the discovery scanner read from.
     const agentDir = resolvePiAgentDir({ source: linked.source, env: process.env });
     const directory =
-      linked.sessionPath ??
       (await getPiDirectSessionWorkingDirectory({
         source: linked.source,
         remoteSessionId: linked.remoteSessionId,
         env: process.env,
-      }));
+      })) ?? linked.sessionPath;
     if (!directory) return null;
 
     return {

--- a/apps/cli/src/backends/pi/directSessions/providerOps.ts
+++ b/apps/cli/src/backends/pi/directSessions/providerOps.ts
@@ -1,0 +1,82 @@
+import { createPollingDirectSessionFollowLease } from '@/api/directSessions/backgroundFollow/createPollingDirectSessionFollowLease';
+import {
+  mergeDirectSessionEnvironmentVariables,
+  type DirectSessionProviderOps,
+} from '@/backends/directSessions/providerOps';
+
+import { getPiDirectSessionActivity } from './getPiDirectSessionActivity';
+import { getPiDirectSessionWorkingDirectory } from './getPiDirectSessionWorkingDirectory';
+import { listPiSessionCandidates } from './listPiSessionCandidates';
+import { pagePiTranscript } from './pagePiTranscript';
+import { readAfterPiTranscript } from './readAfterPiTranscript';
+import { resolvePiAgentDir } from './resolvePiAgentDir';
+
+export const piDirectSessionProviderOps: DirectSessionProviderOps = {
+  listCandidates: async ({ source, cursor, limit, searchTerm, searchMode }) => {
+    const res = await listPiSessionCandidates({ source, cursor, limit, searchTerm, searchMode });
+    return {
+      candidates: res.candidates,
+      nextCursor: res.nextCursor ?? null,
+      ...(res.searchIncomplete ? { searchIncomplete: true } : {}),
+    };
+  },
+
+  getActivity: async ({ source, remoteSessionId }) => {
+    const res = await getPiDirectSessionActivity({ source, remoteSessionId, env: process.env });
+    return {
+      lastActivityAtMs:
+        typeof res.lastActivityAtMs === 'number' && Number.isFinite(res.lastActivityAtMs)
+          ? res.lastActivityAtMs
+          : null,
+      // No live process probe in the direct-session model; liveness is owned by the follow-lease.
+      isRunning: false,
+    };
+  },
+
+  pageTranscript: async ({ source, remoteSessionId, direction, cursor, maxBytes, maxItems }) => {
+    const res = await pagePiTranscript({ source, remoteSessionId, direction, cursor, maxBytes, maxItems, env: process.env });
+    return {
+      items: res.items,
+      nextCursor: res.nextCursor ?? null,
+      tailCursor: res.tailCursor ?? null,
+      hasMore: res.hasMore,
+      truncated: res.truncated === true,
+    };
+  },
+
+  readAfterTranscript: async ({ source, remoteSessionId, cursor, maxBytes, maxItems }) => {
+    const res = await readAfterPiTranscript({ source, remoteSessionId, cursor, maxBytes, maxItems, env: process.env });
+    return { items: res.items, nextCursor: res.nextCursor ?? null, truncated: res.truncated === true };
+  },
+
+  acquireFollowLease: async ({ source, remoteSessionId }) =>
+    createPollingDirectSessionFollowLease({
+      readAfterTranscript: ({ cursor, maxBytes, maxItems }) =>
+        readAfterPiTranscript({ source, remoteSessionId, cursor, maxBytes, maxItems, env: process.env }),
+    }),
+
+  resolveTakeoverSpawnOptions: async ({ linked, sessionId }) => {
+    // Resume the pi session in place (pi --session <uuid>), launched from the session's own working
+    // directory (read from the authoritative header cwd, not the ambiguously-encoded dir name).
+    // PI_CODING_AGENT_DIR points pi at the same ~/.pi/agent the discovery scanner read from.
+    const agentDir = resolvePiAgentDir({ source: linked.source, env: process.env });
+    const directory =
+      linked.sessionPath ??
+      (await getPiDirectSessionWorkingDirectory({
+        source: linked.source,
+        remoteSessionId: linked.remoteSessionId,
+        env: process.env,
+      }));
+    if (!directory) return null;
+
+    return {
+      directory,
+      backendTarget: { kind: 'builtInAgent', agentId: 'pi' },
+      existingSessionId: sessionId,
+      resume: linked.remoteSessionId,
+      approvedNewDirectoryCreation: true,
+      transcriptStorage: 'direct',
+      environmentVariables: mergeDirectSessionEnvironmentVariables([{ PI_CODING_AGENT_DIR: agentDir }]),
+    };
+  },
+};

--- a/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { DirectSessionsSource } from '@happier-dev/protocol';
 
-import { encodePiForwardCursor } from './pagePiTranscript';
+import { decodePiForwardCursor, encodePiForwardCursor } from './pagePiTranscript';
 import { readAfterPiTranscript } from './readAfterPiTranscript';
 
 const SESSION_ID = '019f4a42-4617-767a-8e7c-189b454a0352';
@@ -37,6 +37,12 @@ const THREE_MESSAGES = [
 
 const LIMITS = { maxBytes: 1024 * 1024, maxItems: 100 };
 
+function expectForwardCursor(raw: string | null, delivered: number, anchorEntryId: string): void {
+  const decoded = decodePiForwardCursor(raw ?? undefined);
+  expect(decoded).toMatchObject({ v: 1, kind: 'piForward', delivered });
+  expect(decoded?.anchorItemId).toMatch(new RegExp(`:${anchorEntryId}$`));
+}
+
 async function withThreeMessages<T>(run: (params: { source: DirectSessionsSource; env: NodeJS.ProcessEnv }) => Promise<T>): Promise<T> {
   const agentDir = freshAgentDir();
   const { source, env } = writeSession(agentDir, THREE_MESSAGES);
@@ -52,7 +58,7 @@ describe('readAfterPiTranscript cursor contract', () => {
       expect(res.items).toEqual([]);
       expect(res.truncated).toBe(false);
       // A resumable cursor at the end of the active branch: polling with it must replay nothing.
-      expect(res.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }));
+      expectForwardCursor(res.nextCursor, 3, 'cccc0001');
     });
   });
 
@@ -65,7 +71,7 @@ describe('readAfterPiTranscript cursor contract', () => {
       });
       expect(res.items).toEqual([]);
       expect(res.truncated).toBe(false);
-      expect(res.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }));
+      expectForwardCursor(res.nextCursor, 3, 'cccc0001');
     });
   });
 
@@ -78,7 +84,7 @@ describe('readAfterPiTranscript cursor contract', () => {
       });
       expect(res.items).toHaveLength(2);
       expect(res.truncated).toBe(false);
-      expect(res.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }));
+      expectForwardCursor(res.nextCursor, 3, 'cccc0001');
 
       const capped = await readAfterPiTranscript({
         source, env, remoteSessionId: SESSION_ID,
@@ -87,7 +93,7 @@ describe('readAfterPiTranscript cursor contract', () => {
       });
       expect(capped.items).toHaveLength(1);
       expect(capped.truncated).toBe(true);
-      expect(capped.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 2 }));
+      expectForwardCursor(capped.nextCursor, 2, 'bbbb0001');
     });
   });
 
@@ -98,7 +104,37 @@ describe('readAfterPiTranscript cursor contract', () => {
       });
       expect(res.items).toEqual([]);
       expect(res.truncated).toBe(false);
-      expect(res.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }));
+      expectForwardCursor(res.nextCursor, 3, 'cccc0001');
     });
+  });
+
+  it('requests a full refetch when the active branch no longer contains the cursor anchor', async () => {
+    const agentDir = freshAgentDir();
+    const { source, env } = writeSession(agentDir, THREE_MESSAGES);
+    const initial = await readAfterPiTranscript({
+      source,
+      env,
+      remoteSessionId: SESSION_ID,
+      cursor: encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 2 }),
+      ...LIMITS,
+    });
+    expect(initial.items).toHaveLength(1);
+
+    writeSession(agentDir, [
+      header,
+      msg('aaaa0001', null, 'user', 'one', '2024-12-03T14:00:01.000Z'),
+      msg('dddd0001', 'aaaa0001', 'assistant', 'replacement branch', '2024-12-03T14:00:04.000Z'),
+    ]);
+
+    const afterBranchSwitch = await readAfterPiTranscript({
+      source,
+      env,
+      remoteSessionId: SESSION_ID,
+      cursor: initial.nextCursor!,
+      ...LIMITS,
+    });
+    expect(afterBranchSwitch.items).toEqual([]);
+    expect(afterBranchSwitch.truncated).toBe(true);
+    expect(afterBranchSwitch.nextCursor).not.toBeNull();
   });
 });

--- a/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.test.ts
@@ -9,7 +9,6 @@ import { decodePiForwardCursor, encodePiForwardCursor } from './pagePiTranscript
 import { readAfterPiTranscript } from './readAfterPiTranscript';
 
 const SESSION_ID = '019f4a42-4617-767a-8e7c-189b454a0352';
-const FILE_REL = `projects/2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl`;
 
 function writeSession(agentDir: string, lines: readonly object[]): { source: DirectSessionsSource; env: NodeJS.ProcessEnv } {
   const sessionsDir = join(agentDir, 'sessions', '--proj--');
@@ -40,7 +39,7 @@ const LIMITS = { maxBytes: 1024 * 1024, maxItems: 100 };
 function expectForwardCursor(raw: string | null, delivered: number, anchorEntryId: string): void {
   const decoded = decodePiForwardCursor(raw ?? undefined);
   expect(decoded).toMatchObject({ v: 1, kind: 'piForward', delivered });
-  expect(decoded?.anchorItemId).toMatch(new RegExp(`:${anchorEntryId}$`));
+  expect(decoded?.anchorItemId?.endsWith(`:${anchorEntryId}`)).toBe(true);
 }
 
 async function withThreeMessages<T>(run: (params: { source: DirectSessionsSource; env: NodeJS.ProcessEnv }) => Promise<T>): Promise<T> {

--- a/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.test.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import type { DirectSessionsSource } from '@happier-dev/protocol';
+
+import { encodePiForwardCursor } from './pagePiTranscript';
+import { readAfterPiTranscript } from './readAfterPiTranscript';
+
+const SESSION_ID = '019f4a42-4617-767a-8e7c-189b454a0352';
+const FILE_REL = `projects/2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl`;
+
+function writeSession(agentDir: string, lines: readonly object[]): { source: DirectSessionsSource; env: NodeJS.ProcessEnv } {
+  const sessionsDir = join(agentDir, 'sessions', '--proj--');
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(join(sessionsDir, `2024-12-03T14-00-00-000Z_${SESSION_ID}.jsonl`), lines.map((line) => JSON.stringify(line)).join('\n') + '\n');
+  return { source: { kind: 'piAgentDir' }, env: { ...process.env, PI_CODING_AGENT_DIR: agentDir } };
+}
+
+function freshAgentDir(): string {
+  return mkdtempSync(join(tmpdir(), 'pi-readafter-'));
+}
+
+const header = { type: 'session', id: SESSION_ID, timestamp: '2024-12-03T14:00:00.000Z', cwd: '/proj', version: 3 };
+
+function msg(id: string, parentId: string | null, role: string, text: string, ts: string): object {
+  return { type: 'message', id, parentId, timestamp: ts, message: { role, content: [{ type: 'text', text }], timestamp: Date.parse(ts) } };
+}
+
+const THREE_MESSAGES = [
+  header,
+  msg('aaaa0001', null, 'user', 'one', '2024-12-03T14:00:01.000Z'),
+  msg('bbbb0001', 'aaaa0001', 'assistant', 'two', '2024-12-03T14:00:02.000Z'),
+  msg('cccc0001', 'bbbb0001', 'user', 'three', '2024-12-03T14:00:03.000Z'),
+];
+
+const LIMITS = { maxBytes: 1024 * 1024, maxItems: 100 };
+
+async function withThreeMessages<T>(run: (params: { source: DirectSessionsSource; env: NodeJS.ProcessEnv }) => Promise<T>): Promise<T> {
+  const agentDir = freshAgentDir();
+  const { source, env } = writeSession(agentDir, THREE_MESSAGES);
+  return await run({ source, env });
+}
+
+describe('readAfterPiTranscript cursor contract', () => {
+  it("answers the 'tail' sentinel with no items and an end-positioned cursor (claude parity)", async () => {
+    await withThreeMessages(async ({ source, env }) => {
+      const res = await readAfterPiTranscript({
+        source, env, remoteSessionId: SESSION_ID, cursor: 'tail', ...LIMITS,
+      });
+      expect(res.items).toEqual([]);
+      expect(res.truncated).toBe(false);
+      // A resumable cursor at the end of the active branch: polling with it must replay nothing.
+      expect(res.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }));
+    });
+  });
+
+  it('returns a non-null cursor when fully caught up so the poller never falls back to tail', async () => {
+    await withThreeMessages(async ({ source, env }) => {
+      const res = await readAfterPiTranscript({
+        source, env, remoteSessionId: SESSION_ID,
+        cursor: encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }),
+        ...LIMITS,
+      });
+      expect(res.items).toEqual([]);
+      expect(res.truncated).toBe(false);
+      expect(res.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }));
+    });
+  });
+
+  it('returns the remainder for a mid-branch cursor and a non-null cursor when truncated', async () => {
+    await withThreeMessages(async ({ source, env }) => {
+      const res = await readAfterPiTranscript({
+        source, env, remoteSessionId: SESSION_ID,
+        cursor: encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 1 }),
+        ...LIMITS,
+      });
+      expect(res.items).toHaveLength(2);
+      expect(res.truncated).toBe(false);
+      expect(res.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }));
+
+      const capped = await readAfterPiTranscript({
+        source, env, remoteSessionId: SESSION_ID,
+        cursor: encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 1 }),
+        maxBytes: 1, maxItems: 1,
+      });
+      expect(capped.items).toHaveLength(1);
+      expect(capped.truncated).toBe(true);
+      expect(capped.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 2 }));
+    });
+  });
+
+  it('returns an end-positioned cursor for tail when byte limits would truncate a replay', async () => {
+    await withThreeMessages(async ({ source, env }) => {
+      const res = await readAfterPiTranscript({
+        source, env, remoteSessionId: SESSION_ID, cursor: 'tail', maxBytes: 1, maxItems: 1,
+      });
+      expect(res.items).toEqual([]);
+      expect(res.truncated).toBe(false);
+      expect(res.nextCursor).toBe(encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: 3 }));
+    });
+  });
+});

--- a/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.ts
+++ b/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.ts
@@ -1,7 +1,12 @@
 import type { DirectSessionsSource, DirectTranscriptRawMessageV1 } from '@happier-dev/protocol';
 
 import { mapPiSessionToDirectMessages } from './mapPiSessionToDirectMessages';
-import { decodePiForwardCursor, encodePiForwardCursor, loadPiSessionEntries } from './pagePiTranscript';
+import {
+  decodePiForwardCursor,
+  encodePiForwardCursor,
+  itemByteSize,
+  loadPiSessionEntries,
+} from './pagePiTranscript';
 import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
 
 /**
@@ -77,7 +82,7 @@ export async function readAfterPiTranscript(params: Readonly<{
   for (let i = delivered; i < total; i += 1) {
     const item = items[i]!;
     if (pageItems.length >= maxItems) break;
-    const size = Buffer.byteLength(JSON.stringify(item.raw), 'utf8');
+    const size = itemByteSize(item);
     if (pageItems.length > 0 && bytesUsed + size > maxBytes) break;
     pageItems.push(item);
     bytesUsed += size;

--- a/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.ts
+++ b/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.ts
@@ -1,0 +1,58 @@
+import type { DirectSessionsSource, DirectTranscriptRawMessageV1 } from '@happier-dev/protocol';
+
+import { mapPiSessionToDirectMessages } from './mapPiSessionToDirectMessages';
+import { decodePiForwardCursor, encodePiForwardCursor, loadPiSessionEntries } from './pagePiTranscript';
+import { resolvePiDirectSessionFile } from './resolvePiDirectSessionFile';
+
+/**
+ * Read pi transcript items appended after a forward cursor (item count already delivered from the
+ * start of the active branch). Used by the polling follow-lease to tail a live session. Because the
+ * active branch is recomputed from the whole file each call, branch switches mid-follow are handled
+ * approximately; the common steady-growth case (new entries appended to the same leaf) is exact.
+ */
+export async function readAfterPiTranscript(params: Readonly<{
+  source: DirectSessionsSource;
+  env?: NodeJS.ProcessEnv;
+  remoteSessionId: string;
+  cursor: string;
+  maxBytes: number;
+  maxItems: number;
+}>): Promise<Readonly<{
+  items: DirectTranscriptRawMessageV1[];
+  nextCursor: string | null;
+  truncated: boolean;
+}>> {
+  const resolved = await resolvePiDirectSessionFile({
+    source: params.source,
+    env: params.env,
+    remoteSessionId: params.remoteSessionId,
+  });
+  if (!resolved) {
+    return { items: [], nextCursor: null, truncated: false };
+  }
+
+  const entries = await loadPiSessionEntries(resolved.filePath);
+  const items = mapPiSessionToDirectMessages({ entries, fileRelPath: resolved.fileRelPath });
+  const total = items.length;
+
+  const delivered = Math.min(Math.max(0, decodePiForwardCursor(params.cursor)), total);
+  const maxItems = Math.max(1, Math.trunc(params.maxItems));
+  const maxBytes = Math.max(1, Math.trunc(params.maxBytes));
+
+  const pageItems: DirectTranscriptRawMessageV1[] = [];
+  let bytesUsed = 0;
+  for (let i = delivered; i < total; i += 1) {
+    const item = items[i]!;
+    if (pageItems.length >= maxItems) break;
+    const size = Buffer.byteLength(JSON.stringify(item.raw), 'utf8');
+    if (pageItems.length > 0 && bytesUsed + size > maxBytes) break;
+    pageItems.push(item);
+    bytesUsed += size;
+  }
+
+  const newDelivered = delivered + pageItems.length;
+  const truncated = newDelivered < total;
+  const nextCursor = truncated ? encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: newDelivered }) : null;
+
+  return { items: pageItems, nextCursor, truncated };
+}

--- a/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.ts
+++ b/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.ts
@@ -34,6 +34,12 @@ export async function readAfterPiTranscript(params: Readonly<{
   const entries = await loadPiSessionEntries(resolved.filePath);
   const items = mapPiSessionToDirectMessages({ entries, fileRelPath: resolved.fileRelPath });
   const total = items.length;
+  const tailCursor = encodePiForwardCursor({
+    v: 1,
+    kind: 'piForward',
+    delivered: total,
+    anchorItemId: items.at(-1)?.id ?? null,
+  });
 
   // The polling follow-lease treats a missing cursor as "start from the newest" and sends the
   // 'tail' sentinel. Answer it the way the claude provider does: no items, and a cursor
@@ -43,12 +49,26 @@ export async function readAfterPiTranscript(params: Readonly<{
   if (params.cursor === 'tail') {
     return {
       items: [],
-      nextCursor: encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: total }),
+      nextCursor: tailCursor,
       truncated: false,
     };
   }
 
-  const delivered = Math.min(Math.max(0, decodePiForwardCursor(params.cursor)), total);
+  const decoded = decodePiForwardCursor(params.cursor);
+  if (!decoded) {
+    return { items: [], nextCursor: tailCursor, truncated: true };
+  }
+  if (decoded.delivered > total) {
+    return { items: [], nextCursor: tailCursor, truncated: true };
+  }
+  if (
+    decoded.anchorItemId
+    && items[decoded.delivered - 1]?.id !== decoded.anchorItemId
+  ) {
+    return { items: [], nextCursor: tailCursor, truncated: true };
+  }
+
+  const delivered = decoded.delivered;
   const maxItems = Math.max(1, Math.trunc(params.maxItems));
   const maxBytes = Math.max(1, Math.trunc(params.maxBytes));
 
@@ -68,7 +88,12 @@ export async function readAfterPiTranscript(params: Readonly<{
   // Always hand back a resumable cursor, including when fully caught up: clients store this
   // cursor verbatim for the next poll, and a null here makes them fall back to the 'tail'
   // sentinel (claude parity: end-of-file cursors are returned, not null).
-  const nextCursor = encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: newDelivered });
+  const nextCursor = encodePiForwardCursor({
+    v: 1,
+    kind: 'piForward',
+    delivered: newDelivered,
+    anchorItemId: items[newDelivered - 1]?.id ?? null,
+  });
 
   return { items: pageItems, nextCursor, truncated };
 }

--- a/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.ts
+++ b/apps/cli/src/backends/pi/directSessions/readAfterPiTranscript.ts
@@ -35,6 +35,19 @@ export async function readAfterPiTranscript(params: Readonly<{
   const items = mapPiSessionToDirectMessages({ entries, fileRelPath: resolved.fileRelPath });
   const total = items.length;
 
+  // The polling follow-lease treats a missing cursor as "start from the newest" and sends the
+  // 'tail' sentinel. Answer it the way the claude provider does: no items, and a cursor
+  // positioned at the end of the active branch. Decoding 'tail' as 0 would replay the whole
+  // session every poll (each replay re-applies every item and truncates, forcing the client
+  // into a full-refetch loop).
+  if (params.cursor === 'tail') {
+    return {
+      items: [],
+      nextCursor: encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: total }),
+      truncated: false,
+    };
+  }
+
   const delivered = Math.min(Math.max(0, decodePiForwardCursor(params.cursor)), total);
   const maxItems = Math.max(1, Math.trunc(params.maxItems));
   const maxBytes = Math.max(1, Math.trunc(params.maxBytes));
@@ -52,7 +65,10 @@ export async function readAfterPiTranscript(params: Readonly<{
 
   const newDelivered = delivered + pageItems.length;
   const truncated = newDelivered < total;
-  const nextCursor = truncated ? encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: newDelivered }) : null;
+  // Always hand back a resumable cursor, including when fully caught up: clients store this
+  // cursor verbatim for the next poll, and a null here makes them fall back to the 'tail'
+  // sentinel (claude parity: end-of-file cursors are returned, not null).
+  const nextCursor = encodePiForwardCursor({ v: 1, kind: 'piForward', delivered: newDelivered });
 
   return { items: pageItems, nextCursor, truncated };
 }

--- a/apps/cli/src/backends/pi/directSessions/readPiSessionHeader.ts
+++ b/apps/cli/src/backends/pi/directSessions/readPiSessionHeader.ts
@@ -1,0 +1,55 @@
+import { open } from 'node:fs/promises';
+
+/**
+ * The parsed pi session header (the first JSONL line, `type: 'session'`). The header is metadata
+ * only and is not part of the entry tree.
+ */
+export type PiSessionHeader = Readonly<{
+  id: string;
+  cwd: string;
+  timestamp: string;
+  version?: number;
+  parentSession?: string;
+}>;
+
+const HEADER_READ_BUFFER_BYTES = 64 * 1024;
+
+/**
+ * Read and parse the first JSONL line of a pi session file. Returns null on any read/parse failure
+ * or when the first line is not a `session` header.
+ */
+export async function readPiSessionHeader(filePath: string): Promise<PiSessionHeader | null> {
+  let fh: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    fh = await open(filePath, 'r');
+    const buffer = Buffer.alloc(HEADER_READ_BUFFER_BYTES);
+    const { bytesRead } = await fh.read(buffer, 0, buffer.length, 0);
+    const chunk = buffer.subarray(0, bytesRead).toString('utf8');
+    const newlineIdx = chunk.indexOf('\n');
+    const firstLine = newlineIdx >= 0 ? chunk.slice(0, newlineIdx) : chunk;
+    const trimmed = firstLine.trim();
+    if (!trimmed) return null;
+
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    if (!parsed || parsed.type !== 'session') return null;
+
+    const id = typeof parsed.id === 'string' ? parsed.id : '';
+    const cwd = typeof parsed.cwd === 'string' ? parsed.cwd : '';
+    const timestamp = typeof parsed.timestamp === 'string' ? parsed.timestamp : '';
+    if (!id) return null;
+
+    return {
+      id,
+      cwd,
+      timestamp,
+      ...(typeof parsed.version === 'number' ? { version: parsed.version } : {}),
+      ...(typeof parsed.parentSession === 'string' && parsed.parentSession.trim()
+        ? { parentSession: parsed.parentSession }
+        : {}),
+    };
+  } catch {
+    return null;
+  } finally {
+    await fh?.close().catch(() => undefined);
+  }
+}

--- a/apps/cli/src/backends/pi/directSessions/readPiSessionTitle.test.ts
+++ b/apps/cli/src/backends/pi/directSessions/readPiSessionTitle.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { readPiSessionTitle } from './readPiSessionTitle';
+
+function sessionFile(lines: readonly object[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-title-'));
+  const filePath = join(dir, '2024-12-03T14-00-00-000Z_019f4a42-4617-767a-8e7c-189b454a0352.jsonl');
+  writeFileSync(filePath, lines.map((line) => JSON.stringify(line)).join('\n') + '\n');
+  return filePath;
+}
+
+const header = { type: 'session', id: '019f4a42-4617-767a-8e7c-189b454a0352', timestamp: '2024-12-03T14:00:00.000Z', cwd: '/proj', version: 3 };
+
+describe('readPiSessionTitle', () => {
+  it('prefers the latest session_info name over the first user message', async () => {
+    const filePath = sessionFile([
+      header,
+      { type: 'message', id: 'a1b2c3d4', parentId: null, timestamp: '2024-12-03T14:00:01.000Z', message: { role: 'user', content: 'first user prompt' } },
+      { type: 'session_info', id: 'sinf0001', parentId: 'a1b2c3d4', timestamp: '2024-12-03T14:00:02.000Z', name: 'Named by user' },
+    ]);
+    await expect(readPiSessionTitle(filePath)).resolves.toBe('Named by user');
+  });
+
+  it('falls back to the first user message text when no session_info name is set', async () => {
+    const filePath = sessionFile([
+      header,
+      { type: 'message', id: 'a1b2c3d4', parentId: null, timestamp: '2024-12-03T14:00:01.000Z', message: { role: 'user', content: [{ type: 'text', text: 'array-form user prompt' }] } },
+      { type: 'message', id: 'b2c3d4e5', parentId: 'a1b2c3d4', timestamp: '2024-12-03T14:00:02.000Z', message: { role: 'assistant', content: [{ type: 'text', text: 'reply' }] } },
+    ]);
+    await expect(readPiSessionTitle(filePath)).resolves.toBe('array-form user prompt');
+  });
+
+  it('returns null when there is no session_info name and no user message text', async () => {
+    const filePath = sessionFile([
+      header,
+      { type: 'message', id: 'a1b2c3d4', parentId: null, timestamp: '2024-12-03T14:00:01.000Z', message: { role: 'assistant', content: [{ type: 'text', text: 'no user yet' }] } },
+    ]);
+    await expect(readPiSessionTitle(filePath)).resolves.toBeNull();
+  });
+
+  it('uses the latest session_info entry when multiple are present', async () => {
+    const filePath = sessionFile([
+      header,
+      { type: 'message', id: 'a1b2c3d4', parentId: null, timestamp: '2024-12-03T14:00:01.000Z', message: { role: 'user', content: 'x' } },
+      { type: 'session_info', id: 'sinf0001', parentId: 'a1b2c3d4', timestamp: '2024-12-03T14:00:02.000Z', name: 'old name' },
+      { type: 'message', id: 'cccc0001', parentId: 'sinf0001', timestamp: '2024-12-03T14:00:03.000Z', message: { role: 'user', content: 'y' } },
+      { type: 'session_info', id: 'sinf0002', parentId: 'cccc0001', timestamp: '2024-12-03T14:00:04.000Z', name: 'newest name' },
+    ]);
+    await expect(readPiSessionTitle(filePath)).resolves.toBe('newest name');
+  });
+});

--- a/apps/cli/src/backends/pi/directSessions/readPiSessionTitle.ts
+++ b/apps/cli/src/backends/pi/directSessions/readPiSessionTitle.ts
@@ -1,0 +1,78 @@
+import { readJsonlFileForward } from '@/api/directSessions/filePaging/jsonlForwardReader';
+import { readDirectSessionTitleCandidate } from '@/api/directSessions/title/readDirectSessionTitleCandidate';
+
+const TITLE_SCAN_CHUNK_MAX_BYTES = 128 * 1024;
+const TITLE_SCAN_CHUNK_MAX_ITEMS = 64;
+const TITLE_SCAN_TOTAL_MAX_BYTES = 1024 * 1024;
+const TITLE_SCAN_TOTAL_MAX_ITEMS = 512;
+
+function coerceTextContent(content: unknown): string | null {
+  if (typeof content === 'string') {
+    return readDirectSessionTitleCandidate(content);
+  }
+  if (!Array.isArray(content)) return null;
+
+  const parts = content
+    .map((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return '';
+      const text = (item as Record<string, unknown>).text;
+      return typeof text === 'string' ? text : '';
+    })
+    .filter((part) => part.trim().length > 0);
+
+  return parts.length > 0 ? readDirectSessionTitleCandidate(parts.join(' ')) : null;
+}
+
+/**
+ * Read a pi session display title. Pi stores the user-defined name on the latest `session_info`
+ * entry; when none is set, fall back to the first user message text. Both are cleaned through the
+ * shared `readDirectSessionTitleCandidate` boilerplate filter.
+ */
+export async function readPiSessionTitle(filePath: string): Promise<string | null> {
+  let sessionInfoName: string | null = null;
+  let userFallback: string | null = null;
+  let offsetBytes = 0;
+  let scannedBytes = 0;
+  let scannedItems = 0;
+
+  while (scannedBytes < TITLE_SCAN_TOTAL_MAX_BYTES && scannedItems < TITLE_SCAN_TOTAL_MAX_ITEMS) {
+    const page = await readJsonlFileForward({
+      filePath,
+      offsetBytes,
+      maxBytes: Math.min(TITLE_SCAN_CHUNK_MAX_BYTES, TITLE_SCAN_TOTAL_MAX_BYTES - scannedBytes),
+      maxItems: Math.min(TITLE_SCAN_CHUNK_MAX_ITEMS, TITLE_SCAN_TOTAL_MAX_ITEMS - scannedItems),
+    });
+
+    for (const line of page.items) {
+      const value = line.value;
+      if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+      const record = value as Record<string, unknown>;
+      const type = typeof record.type === 'string' ? record.type : '';
+
+      if (type === 'session_info') {
+        const name = coerceTextContent(record.name);
+        // Latest session_info wins, matching pi's own `getSessionName` semantics.
+        if (name) sessionInfoName = name;
+        continue;
+      }
+
+      if (type === 'message' && userFallback === null) {
+        const message = record.message;
+        if (message && typeof message === 'object' && !Array.isArray(message)) {
+          const msg = message as Record<string, unknown>;
+          if (msg.role === 'user') {
+            const title = coerceTextContent(msg.content);
+            if (title) userFallback = title;
+          }
+        }
+      }
+    }
+
+    if (page.reachedEnd || page.nextOffsetBytes <= offsetBytes) break;
+    scannedBytes += Math.max(0, page.nextOffsetBytes - offsetBytes);
+    scannedItems += page.items.length;
+    offsetBytes = page.nextOffsetBytes;
+  }
+
+  return sessionInfoName ?? userFallback;
+}

--- a/apps/cli/src/backends/pi/directSessions/resolvePiAgentDir.ts
+++ b/apps/cli/src/backends/pi/directSessions/resolvePiAgentDir.ts
@@ -1,0 +1,31 @@
+import { join } from 'node:path';
+
+import type { DirectSessionsSource } from '@happier-dev/protocol';
+import { expandHomeDirPath, resolveHomeDirFromEnvironment } from '@happier-dev/cli-common/providers';
+
+/**
+ * Resolve the pi agent directory (`~/.pi/agent`) for direct-session operations. Precedence mirrors
+ * pi's own `getDefaultAgentDir`: explicit `source.agentDir`, then `PI_CODING_AGENT_DIR`, then
+ * `<home>/.pi/agent`. This is the pi equivalent of Claude's `resolveClaudeConfigDir`.
+ */
+export function resolvePiAgentDir(params: Readonly<{
+  source: DirectSessionsSource;
+  env: NodeJS.ProcessEnv;
+}>): string {
+  const env = params.env;
+  if (params.source.kind === 'piAgentDir') {
+    const fromSource = typeof params.source.agentDir === 'string' ? params.source.agentDir.trim() : '';
+    if (fromSource) {
+      const expanded = expandHomeDirPath(fromSource, env);
+      if (expanded) return expanded;
+    }
+  }
+
+  const fromEnv = typeof env.PI_CODING_AGENT_DIR === 'string' ? env.PI_CODING_AGENT_DIR.trim() : '';
+  if (fromEnv) {
+    const expanded = expandHomeDirPath(fromEnv, env);
+    if (expanded) return expanded;
+  }
+
+  return join(resolveHomeDirFromEnvironment(env), '.pi', 'agent');
+}

--- a/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
+++ b/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
@@ -111,7 +111,7 @@ export async function resolvePiDirectSessionFile(params: Readonly<{
             filePath,
             fileRelPath: `sessions/${dirName}/${name}`.replace(/\\/g, '/'),
             header,
-            mtimeMs: Math.trunc(s.mtimeMs),
+            mtimeMs: s.mtimeMs,
           };
         }
       } catch {

--- a/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
+++ b/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
@@ -100,7 +100,7 @@ export async function resolvePiDirectSessionFile(params: Readonly<{
       const filePath = join(sessionsDir, dirName, name);
       try {
         const header = await readPiSessionHeader(filePath);
-        if (!header || header.id !== remoteSessionId) continue;
+        if (!header || header.id.trim() !== remoteSessionId) continue;
         const s = await stat(filePath);
         if (!s.isFile()) continue;
         if (!best || comparePiSessionFilePreference(

--- a/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
+++ b/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
@@ -1,0 +1,99 @@
+import { type Dirent } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { DirectSessionsSource } from '@happier-dev/protocol';
+
+import { resolvePiAgentDir } from './resolvePiAgentDir';
+
+export type ResolvedPiDirectSessionFile = Readonly<{
+  filePath: string;
+  fileRelPath: string;
+}>;
+
+function isSafeSegment(value: string): boolean {
+  if (!value) return false;
+  if (value.includes('/') || value.includes('\\')) return false;
+  if (value === '.' || value === '..') return false;
+  return true;
+}
+
+/**
+ * Extract the session UUID from a pi session filename (`<ISO-timestamp>_<uuid>.jsonl` or
+ * `<uuid>.jsonl`). The UUID is the segment after the final underscore.
+ */
+export function extractPiSessionIdFromFilename(fileName: string): string | null {
+  if (!fileName.endsWith('.jsonl')) return null;
+  const base = fileName.slice(0, -'.jsonl'.length);
+  if (!base) return null;
+  const lastUnderscore = base.lastIndexOf('_');
+  const id = lastUnderscore >= 0 ? base.slice(lastUnderscore + 1) : base;
+  return id || null;
+}
+
+/**
+ * Resolve a pi session file by remote session id (UUID). Scans every `sessions/--<cwd>--/`
+ * directory under the agent dir because a session's working directory is not known ahead of time
+ * and the directory name encodes cwd ambiguously. When the same id appears in multiple directories,
+ * the most recently modified file wins (mirrors Claude's project-spanning resolution).
+ */
+export async function resolvePiDirectSessionFile(params: Readonly<{
+  source: DirectSessionsSource;
+  env?: NodeJS.ProcessEnv;
+  remoteSessionId: string;
+}>): Promise<ResolvedPiDirectSessionFile | null> {
+  const env = params.env ?? process.env;
+  const remoteSessionId = String(params.remoteSessionId ?? '').trim();
+  if (!isSafeSegment(remoteSessionId)) return null;
+
+  const agentDir = resolvePiAgentDir({ source: params.source, env });
+  const sessionsDir = join(agentDir, 'sessions');
+
+  let dirEntries: Dirent<string>[];
+  try {
+    dirEntries = await readdir(sessionsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  let best: { filePath: string; fileRelPath: string; mtimeMs: number } | null = null;
+
+  for (const dirEntry of dirEntries) {
+    if (!dirEntry.isDirectory()) continue;
+    if (dirEntry.isSymbolicLink()) continue;
+    const dirName = typeof dirEntry.name === 'string' ? dirEntry.name : String(dirEntry.name);
+    if (!isSafeSegment(dirName)) continue;
+
+    let fileEntries: Dirent<string>[];
+    try {
+      fileEntries = await readdir(join(sessionsDir, dirName), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const fileEntry of fileEntries) {
+      if (!fileEntry.isFile()) continue;
+      if (fileEntry.isSymbolicLink()) continue;
+      const name = typeof fileEntry.name === 'string' ? fileEntry.name : String(fileEntry.name);
+      const idFromFile = extractPiSessionIdFromFilename(name);
+      if (idFromFile !== remoteSessionId) continue;
+
+      const filePath = join(sessionsDir, dirName, name);
+      try {
+        const s = await stat(filePath);
+        if (!s.isFile()) continue;
+        if (!best || s.mtimeMs > best.mtimeMs) {
+          best = {
+            filePath,
+            fileRelPath: `sessions/${dirName}/${name}`.replace(/\\/g, '/'),
+            mtimeMs: Math.trunc(s.mtimeMs),
+          };
+        }
+      } catch {
+        // ignore unreadable candidate
+      }
+    }
+  }
+
+  return best ? { filePath: best.filePath, fileRelPath: best.fileRelPath } : null;
+}

--- a/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
+++ b/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import type { DirectSessionsSource } from '@happier-dev/protocol';
 
 import { resolvePiAgentDir } from './resolvePiAgentDir';
+import { readPiSessionHeader } from './readPiSessionHeader';
 
 export type ResolvedPiDirectSessionFile = Readonly<{
   filePath: string;
@@ -32,7 +33,8 @@ export function extractPiSessionIdFromFilename(fileName: string): string | null 
 }
 
 /**
- * Resolve a pi session file by remote session id (UUID). Scans every `sessions/--<cwd>--/`
+ * Resolve a pi session file by the canonical id in its session header. Scans every
+ * `sessions/--<cwd>--/`
  * directory under the agent dir because a session's working directory is not known ahead of time
  * and the directory name encodes cwd ambiguously. When the same id appears in multiple directories,
  * the most recently modified file wins (mirrors Claude's project-spanning resolution).
@@ -75,11 +77,12 @@ export async function resolvePiDirectSessionFile(params: Readonly<{
       if (!fileEntry.isFile()) continue;
       if (fileEntry.isSymbolicLink()) continue;
       const name = typeof fileEntry.name === 'string' ? fileEntry.name : String(fileEntry.name);
-      const idFromFile = extractPiSessionIdFromFilename(name);
-      if (idFromFile !== remoteSessionId) continue;
+      if (!name.endsWith('.jsonl')) continue;
 
       const filePath = join(sessionsDir, dirName, name);
       try {
+        const header = await readPiSessionHeader(filePath);
+        if (header?.id !== remoteSessionId) continue;
         const s = await stat(filePath);
         if (!s.isFile()) continue;
         if (!best || s.mtimeMs > best.mtimeMs) {

--- a/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
+++ b/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
@@ -5,11 +5,12 @@ import { join } from 'node:path';
 import type { DirectSessionsSource } from '@happier-dev/protocol';
 
 import { resolvePiAgentDir } from './resolvePiAgentDir';
-import { readPiSessionHeader } from './readPiSessionHeader';
+import { readPiSessionHeader, type PiSessionHeader } from './readPiSessionHeader';
 
 export type ResolvedPiDirectSessionFile = Readonly<{
   filePath: string;
   fileRelPath: string;
+  header: PiSessionHeader;
 }>;
 
 type PiSessionFilePreference = Readonly<{
@@ -70,7 +71,12 @@ export async function resolvePiDirectSessionFile(params: Readonly<{
     return null;
   }
 
-  let best: { filePath: string; fileRelPath: string; mtimeMs: number } | null = null;
+  let best: {
+    filePath: string;
+    fileRelPath: string;
+    header: PiSessionHeader;
+    mtimeMs: number;
+  } | null = null;
 
   for (const dirEntry of dirEntries) {
     if (!dirEntry.isDirectory()) continue;
@@ -94,7 +100,7 @@ export async function resolvePiDirectSessionFile(params: Readonly<{
       const filePath = join(sessionsDir, dirName, name);
       try {
         const header = await readPiSessionHeader(filePath);
-        if (header?.id !== remoteSessionId) continue;
+        if (!header || header.id !== remoteSessionId) continue;
         const s = await stat(filePath);
         if (!s.isFile()) continue;
         if (!best || comparePiSessionFilePreference(
@@ -104,6 +110,7 @@ export async function resolvePiDirectSessionFile(params: Readonly<{
           best = {
             filePath,
             fileRelPath: `sessions/${dirName}/${name}`.replace(/\\/g, '/'),
+            header,
             mtimeMs: Math.trunc(s.mtimeMs),
           };
         }
@@ -113,5 +120,7 @@ export async function resolvePiDirectSessionFile(params: Readonly<{
     }
   }
 
-  return best ? { filePath: best.filePath, fileRelPath: best.fileRelPath } : null;
+  return best
+    ? { filePath: best.filePath, fileRelPath: best.fileRelPath, header: best.header }
+    : null;
 }

--- a/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
+++ b/apps/cli/src/backends/pi/directSessions/resolvePiDirectSessionFile.ts
@@ -12,6 +12,18 @@ export type ResolvedPiDirectSessionFile = Readonly<{
   fileRelPath: string;
 }>;
 
+type PiSessionFilePreference = Readonly<{
+  filePath: string;
+  mtimeMs: number;
+}>;
+
+export function comparePiSessionFilePreference(
+  left: PiSessionFilePreference,
+  right: PiSessionFilePreference,
+): number {
+  return right.mtimeMs - left.mtimeMs || left.filePath.localeCompare(right.filePath);
+}
+
 function isSafeSegment(value: string): boolean {
   if (!value) return false;
   if (value.includes('/') || value.includes('\\')) return false;
@@ -85,7 +97,10 @@ export async function resolvePiDirectSessionFile(params: Readonly<{
         if (header?.id !== remoteSessionId) continue;
         const s = await stat(filePath);
         if (!s.isFile()) continue;
-        if (!best || s.mtimeMs > best.mtimeMs) {
+        if (!best || comparePiSessionFilePreference(
+          { filePath, mtimeMs: s.mtimeMs },
+          best,
+        ) < 0) {
           best = {
             filePath,
             fileRelPath: `sessions/${dirName}/${name}`.replace(/\\/g, '/'),

--- a/apps/cli/src/backends/pi/index.ts
+++ b/apps/cli/src/backends/pi/index.ts
@@ -64,6 +64,7 @@ export const agent = {
   resolveConnectedServiceCandidatePersistedSessionFile: resolvePiConnectedServiceCandidatePersistedSessionFile,
   verifyResumeReachable: async (input) =>
     await (await import('@/backends/pi/connectedServices/verifyResumeReachablePi')).verifyResumeReachablePi(input),
+  getDirectSessionProviderOps: async () => (await import('./directSessions/providerOps')).piDirectSessionProviderOps,
   getSessionUsageLimitRecoveryControlAdapter: async () => piUsageLimitRecoveryControlAdapter,
   getDaemonSpawnHooks: async () => piDaemonSpawnHooks,
   vendorResumeSupport: AGENTS_CORE.pi.resume.vendorResume,

--- a/apps/cli/src/backends/pi/rpc/PiRpcBackend.modelSelection.test.ts
+++ b/apps/cli/src/backends/pi/rpc/PiRpcBackend.modelSelection.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { AgentMessage } from '@/agent/core';
+import { PiRpcBackend } from './PiRpcBackend';
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function makeFakePiRpcModelSelectionScript(dir: string): { scriptPath: string; receivedPath: string } {
+  const scriptPath = join(dir, 'fake-pi-rpc-model-selection.js');
+  const receivedPath = join(dir, 'received.jsonl');
+  const script = `
+const fs = require('node:fs');
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+const out = (obj) => process.stdout.write(JSON.stringify(obj) + '\\n');
+let currentModel = { id: 'glm-5.3', provider: 'zai', name: 'GLM' };
+
+rl.on('line', (line) => {
+  let command;
+  try { command = JSON.parse(line); } catch { return; }
+  fs.appendFileSync(${JSON.stringify(receivedPath)}, JSON.stringify(command) + '\\n');
+
+  switch (command.type) {
+    case 'get_state':
+      out({
+        id: command.id,
+        type: 'response',
+        command: 'get_state',
+        success: true,
+        data: {
+          sessionId: 'pi-session-model-selection',
+          thinkingLevel: 'off',
+          model: currentModel
+        }
+      });
+      break;
+    case 'get_available_models':
+      out({
+        id: command.id,
+        type: 'response',
+        command: 'get_available_models',
+        success: true,
+        data: {
+          models: [
+            { id: 'glm-5.3', provider: 'zai', name: 'GLM 5.3' },
+            { id: 'prism-ml/bonsai-27b', provider: 'lmstudio/hadees', name: 'Bonsai 27B' },
+            { id: 'muse-glimmer-30b@q5_k_m', provider: 'lmstudio/hadees', name: 'Glimmer 30B' }
+          ]
+        }
+      });
+      break;
+    case 'get_commands':
+      out({
+        id: command.id,
+        type: 'response',
+        command: 'get_commands',
+        success: true,
+        data: { commands: [] }
+      });
+      break;
+    case 'set_model':
+      currentModel = { id: command.modelId, provider: command.provider, name: command.modelId };
+      out({ id: command.id, type: 'response', command: 'set_model', success: true, data: currentModel });
+      break;
+    default:
+      out({ id: command.id, type: 'response', command: command.type, success: true, data: {} });
+      break;
+  }
+});
+`;
+  writeFileSync(scriptPath, script, 'utf8');
+  chmodSync(scriptPath, 0o755);
+  return { scriptPath, receivedPath };
+}
+
+function readReceivedSetModelCommands(receivedPath: string): Array<Record<string, unknown>> {
+  let text: string;
+  try {
+    text = readFileSync(receivedPath, 'utf8');
+  } catch {
+    return [];
+  }
+  return text
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+    .filter((command) => command.type === 'set_model');
+}
+
+describe('PiRpcBackend (model selection)', () => {
+  let tempDir: string | null = null;
+  let backend: PiRpcBackend | null = null;
+
+  afterEach(async () => {
+    if (backend) {
+      await backend.dispose();
+      backend = null;
+    }
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  async function startBackendWithCatalog(): Promise<{ sessionId: string; receivedPath: string; messages: AgentMessage[] }> {
+    tempDir = makeTempDir('happier-pi-rpc-model-selection-');
+    const { scriptPath, receivedPath } = makeFakePiRpcModelSelectionScript(tempDir);
+
+    backend = new PiRpcBackend({
+      cwd: tempDir,
+      command: process.execPath,
+      args: [scriptPath],
+    });
+
+    const messages: AgentMessage[] = [];
+    backend.onMessage((message) => messages.push(message));
+
+    const { sessionId } = await backend.startSession();
+    return { sessionId, receivedPath, messages };
+  }
+
+  it('resolves a composite model id against the live catalog before naively splitting on the first slash', async () => {
+    const { sessionId, receivedPath } = await startBackendWithCatalog();
+
+    await backend!.setSessionModel(sessionId, 'lmstudio/hadees/prism-ml/bonsai-27b');
+
+    const setModelCommands = readReceivedSetModelCommands(receivedPath);
+    expect(setModelCommands).toHaveLength(1);
+    expect(setModelCommands[0]).toMatchObject({
+      type: 'set_model',
+      provider: 'lmstudio/hadees',
+      modelId: 'prism-ml/bonsai-27b',
+    });
+  });
+
+  it('strips the provider prefix from a catalog composite key for single-segment providers', async () => {
+    const { sessionId, receivedPath } = await startBackendWithCatalog();
+
+    await backend!.setSessionModel(sessionId, 'zai/glm-5.3');
+
+    const setModelCommands = readReceivedSetModelCommands(receivedPath);
+    expect(setModelCommands).toHaveLength(1);
+    expect(setModelCommands[0]).toMatchObject({
+      type: 'set_model',
+      provider: 'zai',
+      modelId: 'glm-5.3',
+    });
+  });
+
+  it('resolves bare catalog model ids without a provider prefix', async () => {
+    const { sessionId, receivedPath } = await startBackendWithCatalog();
+
+    await backend!.setSessionModel(sessionId, 'muse-glimmer-30b@q5_k_m');
+
+    const setModelCommands = readReceivedSetModelCommands(receivedPath);
+    expect(setModelCommands).toHaveLength(1);
+    expect(setModelCommands[0]).toMatchObject({
+      type: 'set_model',
+      provider: 'lmstudio/hadees',
+      modelId: 'muse-glimmer-30b@q5_k_m',
+    });
+  });
+
+  it('publishes the resolved current model with the bare model id', async () => {
+    const { sessionId, messages } = await startBackendWithCatalog();
+
+    await backend!.setSessionModel(sessionId, 'lmstudio/hadees/prism-ml/bonsai-27b');
+
+    const modelsStates = messages.filter(
+      (message): message is Extract<AgentMessage, { type: 'event' }> => (
+        message.type === 'event' && message.name === 'session_models_state'
+      ),
+    );
+    const last = modelsStates.at(-1)?.payload as { currentModelId?: unknown } | undefined;
+    expect(last?.currentModelId).toBe('prism-ml/bonsai-27b');
+  });
+});

--- a/apps/cli/src/backends/pi/rpc/PiRpcBackend.modelSelection.test.ts
+++ b/apps/cli/src/backends/pi/rpc/PiRpcBackend.modelSelection.test.ts
@@ -11,7 +11,10 @@ function makeTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix));
 }
 
-function makeFakePiRpcModelSelectionScript(dir: string): { scriptPath: string; receivedPath: string } {
+function makeFakePiRpcModelSelectionScript(
+  dir: string,
+  options: Readonly<{ failCatalogRefresh?: boolean }> = {},
+): { scriptPath: string; receivedPath: string } {
   const scriptPath = join(dir, 'fake-pi-rpc-model-selection.js');
   const receivedPath = join(dir, 'received.jsonl');
   const script = `
@@ -20,6 +23,7 @@ const readline = require('node:readline');
 const rl = readline.createInterface({ input: process.stdin });
 const out = (obj) => process.stdout.write(JSON.stringify(obj) + '\\n');
 let currentModel = { id: 'glm-5.3', provider: 'zai', name: 'GLM' };
+let availableModelCalls = 0;
 
 rl.on('line', (line) => {
   let command;
@@ -41,6 +45,11 @@ rl.on('line', (line) => {
       });
       break;
     case 'get_available_models':
+      availableModelCalls += 1;
+      if (${JSON.stringify(options.failCatalogRefresh === true)} && availableModelCalls > 1) {
+        out({ id: command.id, type: 'response', command: 'get_available_models', success: false, error: 'catalog unavailable' });
+        break;
+      }
       out({
         id: command.id,
         type: 'response',
@@ -108,9 +117,11 @@ describe('PiRpcBackend (model selection)', () => {
     }
   });
 
-  async function startBackendWithCatalog(): Promise<{ sessionId: string; receivedPath: string; messages: AgentMessage[] }> {
+  async function startBackendWithCatalog(
+    options: Readonly<{ failCatalogRefresh?: boolean }> = {},
+  ): Promise<{ sessionId: string; receivedPath: string; messages: AgentMessage[] }> {
     tempDir = makeTempDir('happier-pi-rpc-model-selection-');
-    const { scriptPath, receivedPath } = makeFakePiRpcModelSelectionScript(tempDir);
+    const { scriptPath, receivedPath } = makeFakePiRpcModelSelectionScript(tempDir, options);
 
     backend = new PiRpcBackend({
       cwd: tempDir,
@@ -164,6 +175,21 @@ describe('PiRpcBackend (model selection)', () => {
       type: 'set_model',
       provider: 'lmstudio/hadees',
       modelId: 'muse-glimmer-30b@q5_k_m',
+    });
+  });
+
+  it('does not let an uncatalogued prefixed model override later bare-model provider selection', async () => {
+    const { sessionId, receivedPath } = await startBackendWithCatalog({ failCatalogRefresh: true });
+
+    await backend!.setSessionModel(sessionId, 'lmstudio/hadees/uncatalogued-model');
+    await backend!.setSessionModel(sessionId, 'zai/glm-5.3');
+    await backend!.setSessionModel(sessionId, 'uncatalogued-model');
+
+    const setModelCommands = readReceivedSetModelCommands(receivedPath);
+    expect(setModelCommands.at(-1)).toMatchObject({
+      type: 'set_model',
+      provider: 'zai',
+      modelId: 'uncatalogued-model',
     });
   });
 

--- a/apps/cli/src/backends/pi/rpc/PiRpcBackend.ts
+++ b/apps/cli/src/backends/pi/rpc/PiRpcBackend.ts
@@ -2765,8 +2765,6 @@ export class PiRpcBackend implements AgentBackend {
       if (prefixProvider) {
         const modelId = modelIdRaw.slice(prefixProvider.length + 1).trim();
         if (modelId) {
-          this.modelProviderById.set(modelId, prefixProvider);
-          this.modelProviderById.set(`${prefixProvider}/${modelId}`, prefixProvider);
           return { provider: prefixProvider, modelId };
         }
       }

--- a/apps/cli/src/backends/pi/rpc/PiRpcBackend.ts
+++ b/apps/cli/src/backends/pi/rpc/PiRpcBackend.ts
@@ -2733,27 +2733,58 @@ export class PiRpcBackend implements AgentBackend {
     }
   }
 
+  /**
+   * Longest known provider id that prefixes the raw model reference
+   * (`provider/model`). Provider ids may themselves contain slashes (e.g.
+   * `lmstudio/hadees`), so a naive first-slash split is not sound.
+   */
+  private resolveKnownProviderPrefix(modelIdRaw: string): string | null {
+    let best: string | null = null;
+    for (const provider of this.modelProviderById.values()) {
+      if (!modelIdRaw.startsWith(`${provider}/`)) continue;
+      if (best === null || provider.length > best.length) best = provider;
+    }
+    return best;
+  }
+
   private async resolveModelSelection(modelIdRaw: string): Promise<{ provider: string; modelId: string }> {
+    // The catalog map is authoritative: it holds both bare model ids and
+    // `provider/model` composite keys exactly as pi reports them.
+    const fromKnownMap = this.modelProviderById.get(modelIdRaw);
+    if (fromKnownMap) {
+      const bareModelId = modelIdRaw.startsWith(`${fromKnownMap}/`)
+        ? modelIdRaw.slice(fromKnownMap.length + 1)
+        : modelIdRaw;
+      return { provider: fromKnownMap, modelId: bareModelId };
+    }
+
     if (modelIdRaw.includes('/')) {
+      // Composite reference: split at a known provider boundary when one
+      // matches, so multi-segment provider ids resolve correctly.
+      const prefixProvider = this.resolveKnownProviderPrefix(modelIdRaw);
+      if (prefixProvider) {
+        const modelId = modelIdRaw.slice(prefixProvider.length + 1).trim();
+        if (modelId) {
+          this.modelProviderById.set(modelId, prefixProvider);
+          this.modelProviderById.set(`${prefixProvider}/${modelId}`, prefixProvider);
+          return { provider: prefixProvider, modelId };
+        }
+      }
+
+      // Unknown composite: keep the historical first-slash split for
+      // single-segment providers, but do not cache the guess so a wrong
+      // split cannot poison later catalog-backed resolutions.
       const [provider, ...rest] = modelIdRaw.split('/');
       const modelId = rest.join('/').trim();
       const normalizedProvider = provider.trim();
       if (normalizedProvider && modelId) {
-        this.modelProviderById.set(modelId, normalizedProvider);
-        this.modelProviderById.set(`${normalizedProvider}/${modelId}`, normalizedProvider);
         return { provider: normalizedProvider, modelId };
       }
-    }
-
-    const fromKnownMap = this.modelProviderById.get(modelIdRaw);
-    if (fromKnownMap) {
-      return { provider: fromKnownMap, modelId: modelIdRaw };
-    }
-
-    if (this.currentModelProvider) {
+    } else if (this.currentModelProvider) {
       return { provider: this.currentModelProvider, modelId: modelIdRaw };
     }
 
+    // Bare id with no cached provider: resolve from the live session state.
     const state = await this.getState();
     const model = asRecord(state.model);
     const provider = asNonEmptyString(model?.provider);

--- a/apps/cli/src/backends/pi/runPi.test.ts
+++ b/apps/cli/src/backends/pi/runPi.test.ts
@@ -54,13 +54,14 @@ describe('runPi', () => {
     runStandardAcpProviderMock.mockResolvedValue(undefined);
   });
 
-  it('disables MCP server resolution for Pi sessions', async () => {
+  it('disables MCP server resolution and declares spawn-time system prompt delivery for Pi sessions', async () => {
     await runPi({ credentials });
 
     expect(runStandardAcpProviderMock).toHaveBeenCalledTimes(1);
     expect(runStandardAcpProviderMock.mock.calls[0]?.[1]).toMatchObject({
       flavor: 'pi',
       supportsMcpServers: false,
+      deliversSystemPromptAtSpawn: true,
     });
   });
 

--- a/apps/cli/src/backends/pi/runPi.ts
+++ b/apps/cli/src/backends/pi/runPi.ts
@@ -22,6 +22,7 @@ export async function runPi(opts: StandardAcpProviderRunOptions & {
     agentMessageType: 'pi',
     supportsMcpServers: false,
     resolveToolsDeliveryAvailability: resolvePiToolsDeliveryAvailability,
+    deliversSystemPromptAtSpawn: true,
     machineMetadata: initialMachineMetadata,
     terminalDisplay: PiTerminalDisplay,
     resolvePermissionModeQueueKey: (permissionMode) => buildPiToolsForPermissionMode(permissionMode)?.join(',') ?? 'native',

--- a/apps/cli/src/backends/pi/runPi.ts
+++ b/apps/cli/src/backends/pi/runPi.ts
@@ -39,6 +39,8 @@ export async function runPi(opts: StandardAcpProviderRunOptions & {
         getPermissionMode,
         pendingQueueDrainMaxPopPerWake,
         providerInputConsumer,
+        credentials: opts.credentials,
+        accountSettings: opts.accountSettingsContext?.settings ?? null,
       }),
     onAttachMetadataSnapshotMissing: (error) => {
       logger.debug(

--- a/apps/cli/src/session/handoff/resolveSessionHandoffEligibility.test.ts
+++ b/apps/cli/src/session/handoff/resolveSessionHandoffEligibility.test.ts
@@ -65,7 +65,7 @@ describe('resolveSessionHandoffEligibility', () => {
     });
   });
 
-  it('rejects unsupported direct session storage providers', () => {
+  it('rejects Pi handoff because vendor state transfer is unsupported', () => {
     expect(
       resolveSessionHandoffEligibility({
         metadata: {
@@ -80,7 +80,7 @@ describe('resolveSessionHandoffEligibility', () => {
       }),
     ).toEqual({
       eligible: false,
-      reasonCode: 'storage_mode_unsupported',
+      reasonCode: 'handoff_unsupported',
       agentId: 'pi',
       storageMode: 'direct',
     });

--- a/apps/ui/sources/agents/providers/pi/directSessions/resolvePiBrowseSourceOptions.ts
+++ b/apps/ui/sources/agents/providers/pi/directSessions/resolvePiBrowseSourceOptions.ts
@@ -1,0 +1,10 @@
+import type { DirectBrowseSourceOption } from '@/agents/registry/registryUiBehavior';
+import { t } from '@/text';
+
+export function resolvePiBrowseSourceOptions(): readonly DirectBrowseSourceOption[] {
+    return [{
+        key: 'pi:default',
+        label: t('directSessions.browseSourcePiDefault'),
+        source: { kind: 'piAgentDir' },
+    }];
+}

--- a/apps/ui/sources/agents/providers/pi/uiBehavior.ts
+++ b/apps/ui/sources/agents/providers/pi/uiBehavior.ts
@@ -1,6 +1,14 @@
 import type { AgentUiBehavior } from '@/agents/registry/registryUiBehavior';
 
+import { resolvePiBrowseSourceOptions } from './directSessions/resolvePiBrowseSourceOptions';
+
 export const PI_UI_BEHAVIOR_OVERRIDE: AgentUiBehavior = {
     // Pi thinking level is now modeled as a model-scoped option (reasoning_effort) returned
     // by model probing + session metadata, so no Pi-specific chip or env-var bridge is needed here.
+    directSessions: {
+        browse: {
+            order: 40,
+            getSourceOptions: () => resolvePiBrowseSourceOptions(),
+        },
+    },
 };

--- a/apps/ui/sources/components/sessions/directSessions/browse/resolveDirectBrowseSourceOptions.test.ts
+++ b/apps/ui/sources/components/sessions/directSessions/browse/resolveDirectBrowseSourceOptions.test.ts
@@ -11,7 +11,7 @@ const directBrowseModulePromise = import('./resolveDirectBrowseSourceOptions');
 describe('resolveDirectBrowseSourceOptions', () => {
     it('lists browse providers from registered provider behavior order', async () => {
         const { listDirectBrowseProviderIds } = await directBrowseModulePromise;
-        expect(listDirectBrowseProviderIds()).toEqual(['codex', 'claude', 'opencode']);
+        expect(listDirectBrowseProviderIds()).toEqual(['codex', 'claude', 'opencode', 'pi']);
     });
 
     it('returns the codex user home and per-profile connected-service sources when codex profiles exist', async () => {

--- a/apps/ui/sources/text/translations/ca.ts
+++ b/apps/ui/sources/text/translations/ca.ts
@@ -5839,6 +5839,7 @@ deps: {
         browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
         browseSourceClaudeDefault: "Configuració predeterminada de Claude",
         browseSourceOpenCodeDefault: "Servidor predeterminat d'OpenCode",
+        browseSourcePiDefault: "Directori per defecte de l'agent pi",
         browseCandidates: "Sessions disponibles",
         browseNoMachines: "Encara no hi ha màquines disponibles per a sessions directes.",
         browseNoCandidates: "No s'han trobat sessions del proveïdor per a aquesta màquina i aquest proveïdor.",

--- a/apps/ui/sources/text/translations/ca.ts
+++ b/apps/ui/sources/text/translations/ca.ts
@@ -5839,7 +5839,7 @@ deps: {
         browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
         browseSourceClaudeDefault: "Configuració predeterminada de Claude",
         browseSourceOpenCodeDefault: "Servidor predeterminat d'OpenCode",
-        browseSourcePiDefault: "Directori per defecte de l'agent pi",
+        browseSourcePiDefault: "Directori per defecte de l'agent Pi",
         browseCandidates: "Sessions disponibles",
         browseNoMachines: "Encara no hi ha màquines disponibles per a sessions directes.",
         browseNoCandidates: "No s'han trobat sessions del proveïdor per a aquesta màquina i aquest proveïdor.",

--- a/apps/ui/sources/text/translations/en.ts
+++ b/apps/ui/sources/text/translations/en.ts
@@ -5836,7 +5836,7 @@ export const en = {
         browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
         browseSourceClaudeDefault: 'Default Claude config',
         browseSourceOpenCodeDefault: 'Default OpenCode server',
-        browseSourcePiDefault: 'Default pi agent directory',
+        browseSourcePiDefault: 'Default Pi agent directory',
         browseCandidates: 'Available sessions',
         browseNoMachines: 'No machines are available for direct sessions yet.',
         browseNoCandidates: 'No provider sessions were found for this machine and provider.',

--- a/apps/ui/sources/text/translations/en.ts
+++ b/apps/ui/sources/text/translations/en.ts
@@ -5836,6 +5836,7 @@ export const en = {
         browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
         browseSourceClaudeDefault: 'Default Claude config',
         browseSourceOpenCodeDefault: 'Default OpenCode server',
+        browseSourcePiDefault: 'Default pi agent directory',
         browseCandidates: 'Available sessions',
         browseNoMachines: 'No machines are available for direct sessions yet.',
         browseNoCandidates: 'No provider sessions were found for this machine and provider.',

--- a/apps/ui/sources/text/translations/es.ts
+++ b/apps/ui/sources/text/translations/es.ts
@@ -6199,7 +6199,7 @@ export const es: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "Configuración predeterminada de Claude",
     browseSourceOpenCodeDefault: "Servidor predeterminado de OpenCode",
-    browseSourcePiDefault: "Directorio predeterminado del agente pi",
+    browseSourcePiDefault: "Directorio predeterminado del agente Pi",
     browseCandidates: "Sesiones disponibles",
     browseNoMachines: "Aún no hay máquinas disponibles para sesiones directas.",
     browseNoCandidates: "No se encontraron sesiones del proveedor para esta máquina y este proveedor.",

--- a/apps/ui/sources/text/translations/es.ts
+++ b/apps/ui/sources/text/translations/es.ts
@@ -6199,6 +6199,7 @@ export const es: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "Configuración predeterminada de Claude",
     browseSourceOpenCodeDefault: "Servidor predeterminado de OpenCode",
+    browseSourcePiDefault: "Directorio predeterminado del agente pi",
     browseCandidates: "Sesiones disponibles",
     browseNoMachines: "Aún no hay máquinas disponibles para sesiones directas.",
     browseNoCandidates: "No se encontraron sesiones del proveedor para esta máquina y este proveedor.",

--- a/apps/ui/sources/text/translations/fr.ts
+++ b/apps/ui/sources/text/translations/fr.ts
@@ -5825,7 +5825,7 @@ export const fr: TranslationStructure = {
         browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} services connectés`,
         browseSourceClaudeDefault: 'Config Claude par défaut',
         browseSourceOpenCodeDefault: 'Serveur OpenCode par défaut',
-        browseSourcePiDefault: 'Répertoire de l’agent pi par défaut',
+        browseSourcePiDefault: 'Répertoire de l’agent Pi par défaut',
         browseCandidates: 'Sessions disponibles',
         browseNoMachines: 'Aucune machine n’est disponible pour les sessions directes.',
         browseNoCandidates: 'Aucune session provider trouvée pour cette machine et ce provider.',

--- a/apps/ui/sources/text/translations/fr.ts
+++ b/apps/ui/sources/text/translations/fr.ts
@@ -5825,6 +5825,7 @@ export const fr: TranslationStructure = {
         browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} services connectés`,
         browseSourceClaudeDefault: 'Config Claude par défaut',
         browseSourceOpenCodeDefault: 'Serveur OpenCode par défaut',
+        browseSourcePiDefault: 'Répertoire de l’agent pi par défaut',
         browseCandidates: 'Sessions disponibles',
         browseNoMachines: 'Aucune machine n’est disponible pour les sessions directes.',
         browseNoCandidates: 'Aucune session provider trouvée pour cette machine et ce provider.',

--- a/apps/ui/sources/text/translations/it.ts
+++ b/apps/ui/sources/text/translations/it.ts
@@ -6538,6 +6538,7 @@ export const it: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} servizi collegati`,
     browseSourceClaudeDefault: "Configurazione predefinita di Claude",
     browseSourceOpenCodeDefault: "Server OpenCode predefinito",
+    browseSourcePiDefault: "Directory predefinita dell'agente pi",
     browseCandidates: "Sessioni disponibili",
     browseNoMachines: "Non ci sono ancora macchine disponibili per le sessioni dirette.",
     browseNoCandidates: "Nessuna sessione del provider trovata per questa macchina e questo provider.",

--- a/apps/ui/sources/text/translations/it.ts
+++ b/apps/ui/sources/text/translations/it.ts
@@ -6538,7 +6538,7 @@ export const it: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} servizi collegati`,
     browseSourceClaudeDefault: "Configurazione predefinita di Claude",
     browseSourceOpenCodeDefault: "Server OpenCode predefinito",
-    browseSourcePiDefault: "Directory predefinita dell'agente pi",
+    browseSourcePiDefault: "Directory predefinita dell'agente Pi",
     browseCandidates: "Sessioni disponibili",
     browseNoMachines: "Non ci sono ancora macchine disponibili per le sessioni dirette.",
     browseNoCandidates: "Nessuna sessione del provider trovata per questa macchina e questo provider.",

--- a/apps/ui/sources/text/translations/ja.ts
+++ b/apps/ui/sources/text/translations/ja.ts
@@ -6458,7 +6458,7 @@ localTailscale: {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "デフォルトの Claude 設定",
     browseSourceOpenCodeDefault: "デフォルトの OpenCode サーバー",
-    browseSourcePiDefault: "デフォルトの pi エージェントディレクトリ",
+    browseSourcePiDefault: "デフォルトの Pi エージェントディレクトリ",
     browseCandidates: "利用可能なセッション",
     browseNoMachines: "直接セッションに利用できるマシンはまだありません。",
     browseNoCandidates: "このマシンとプロバイダーに対するセッションは見つかりませんでした。",

--- a/apps/ui/sources/text/translations/ja.ts
+++ b/apps/ui/sources/text/translations/ja.ts
@@ -6458,6 +6458,7 @@ localTailscale: {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "デフォルトの Claude 設定",
     browseSourceOpenCodeDefault: "デフォルトの OpenCode サーバー",
+    browseSourcePiDefault: "デフォルトの pi エージェントディレクトリ",
     browseCandidates: "利用可能なセッション",
     browseNoMachines: "直接セッションに利用できるマシンはまだありません。",
     browseNoCandidates: "このマシンとプロバイダーに対するセッションは見つかりませんでした。",

--- a/apps/ui/sources/text/translations/pl.ts
+++ b/apps/ui/sources/text/translations/pl.ts
@@ -6216,7 +6216,7 @@ export const pl: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "Domyślna konfiguracja Claude",
     browseSourceOpenCodeDefault: "Domyślny serwer OpenCode",
-    browseSourcePiDefault: "Domyślny katalog agenta pi",
+    browseSourcePiDefault: "Domyślny katalog agenta Pi",
     browseCandidates: "Dostępne sesje",
     browseNoMachines: "Na razie nie ma dostępnych maszyn dla sesji bezpośrednich.",
     browseNoCandidates: "Nie znaleziono sesji dostawcy dla tej maszyny i dostawcy.",

--- a/apps/ui/sources/text/translations/pl.ts
+++ b/apps/ui/sources/text/translations/pl.ts
@@ -6216,6 +6216,7 @@ export const pl: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "Domyślna konfiguracja Claude",
     browseSourceOpenCodeDefault: "Domyślny serwer OpenCode",
+    browseSourcePiDefault: "Domyślny katalog agenta pi",
     browseCandidates: "Dostępne sesje",
     browseNoMachines: "Na razie nie ma dostępnych maszyn dla sesji bezpośrednich.",
     browseNoCandidates: "Nie znaleziono sesji dostawcy dla tej maszyny i dostawcy.",

--- a/apps/ui/sources/text/translations/pt.ts
+++ b/apps/ui/sources/text/translations/pt.ts
@@ -6317,6 +6317,7 @@ export const pt: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "Configuração padrão do Claude",
     browseSourceOpenCodeDefault: "Servidor padrão do OpenCode",
+    browseSourcePiDefault: "Diretório padrão do agente pi",
     browseCandidates: "Sessões disponíveis",
     browseNoMachines: "Ainda não há máquinas disponíveis para sessões diretas.",
     browseNoCandidates: "Nenhuma sessão do provedor foi encontrada para esta máquina e este provedor.",

--- a/apps/ui/sources/text/translations/pt.ts
+++ b/apps/ui/sources/text/translations/pt.ts
@@ -6317,7 +6317,7 @@ export const pt: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "Configuração padrão do Claude",
     browseSourceOpenCodeDefault: "Servidor padrão do OpenCode",
-    browseSourcePiDefault: "Diretório padrão do agente pi",
+    browseSourcePiDefault: "Diretório padrão do agente Pi",
     browseCandidates: "Sessões disponíveis",
     browseNoMachines: "Ainda não há máquinas disponíveis para sessões diretas.",
     browseNoCandidates: "Nenhuma sessão do provedor foi encontrada para esta máquina e este provedor.",

--- a/apps/ui/sources/text/translations/ru.ts
+++ b/apps/ui/sources/text/translations/ru.ts
@@ -5204,7 +5204,7 @@ export const ru: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "Стандартная конфигурация Claude",
     browseSourceOpenCodeDefault: "Стандартный сервер OpenCode",
-    browseSourcePiDefault: "Каталог агента pi по умолчанию",
+    browseSourcePiDefault: "Каталог агента Pi по умолчанию",
     browseCandidates: "Доступные сессии",
     browseNoMachines: "Для прямых сессий пока нет доступных машин.",
     browseNoCandidates: "Для этой машины и провайдера сессии не найдены.",

--- a/apps/ui/sources/text/translations/ru.ts
+++ b/apps/ui/sources/text/translations/ru.ts
@@ -5204,6 +5204,7 @@ export const ru: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "Стандартная конфигурация Claude",
     browseSourceOpenCodeDefault: "Стандартный сервер OpenCode",
+    browseSourcePiDefault: "Каталог агента pi по умолчанию",
     browseCandidates: "Доступные сессии",
     browseNoMachines: "Для прямых сессий пока нет доступных машин.",
     browseNoCandidates: "Для этой машины и провайдера сессии не найдены.",

--- a/apps/ui/sources/text/translations/zh-Hans.ts
+++ b/apps/ui/sources/text/translations/zh-Hans.ts
@@ -5996,6 +5996,7 @@ export const zhHans: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "默认 Claude 配置",
     browseSourceOpenCodeDefault: "默认 OpenCode 服务器",
+    browseSourcePiDefault: "默认 pi 代理目录",
     browseCandidates: "可用会话",
     browseNoMachines: "尚无可用于直连会话的机器。",
     browseNoCandidates: "未找到此机器和提供方对应的会话。",

--- a/apps/ui/sources/text/translations/zh-Hans.ts
+++ b/apps/ui/sources/text/translations/zh-Hans.ts
@@ -5996,7 +5996,7 @@ export const zhHans: TranslationStructure = {
     browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
     browseSourceClaudeDefault: "默认 Claude 配置",
     browseSourceOpenCodeDefault: "默认 OpenCode 服务器",
-    browseSourcePiDefault: "默认 pi 代理目录",
+    browseSourcePiDefault: "默认 Pi 代理目录",
     browseCandidates: "可用会话",
     browseNoMachines: "尚无可用于直连会话的机器。",
     browseNoCandidates: "未找到此机器和提供方对应的会话。",

--- a/apps/ui/sources/text/translations/zh-Hant.ts
+++ b/apps/ui/sources/text/translations/zh-Hant.ts
@@ -5248,7 +5248,7 @@ const zhHantOverrides: DeepPartial<TranslationStructure> = {
         browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
         browseSourceClaudeDefault: "預設 Claude 設定",
         browseSourceOpenCodeDefault: "預設 OpenCode 伺服器",
-        browseSourcePiDefault: "預設 pi 代理目錄",
+        browseSourcePiDefault: "預設 Pi 代理目錄",
         browseCandidates: "可用工作階段",
         browseNoMachines: "目前尚無可用於直接工作階段的機器。",
         browseNoCandidates: "找不到這台機器與提供者對應的工作階段。",

--- a/apps/ui/sources/text/translations/zh-Hant.ts
+++ b/apps/ui/sources/text/translations/zh-Hant.ts
@@ -5248,6 +5248,7 @@ const zhHantOverrides: DeepPartial<TranslationStructure> = {
         browseSourceCodexConnectedServices: ({ service }: { service: string }) => `${service} connected services`,
         browseSourceClaudeDefault: "預設 Claude 設定",
         browseSourceOpenCodeDefault: "預設 OpenCode 伺服器",
+        browseSourcePiDefault: "預設 pi 代理目錄",
         browseCandidates: "可用工作階段",
         browseNoMachines: "目前尚無可用於直接工作階段的機器。",
         browseNoCandidates: "找不到這台機器與提供者對應的工作階段。",

--- a/packages/agents/src/manifest.ts
+++ b/packages/agents/src/manifest.ts
@@ -408,7 +408,7 @@ export const AGENTS_CORE = {
             },
         },
         resume: { vendorResume: 'supported', vendorResumeIdField: 'piSessionId' },
-        sessionStorage: { direct: false, persisted: true },
+        sessionStorage: { direct: true, persisted: true },
         sessionCapabilities: {
             sessionListing: 'unsupported',
             sessionFork: { conversation: 'unsupported', fromMessage: 'unsupported' },

--- a/packages/agents/src/sessionControls/vendorHandoffPolicy.test.ts
+++ b/packages/agents/src/sessionControls/vendorHandoffPolicy.test.ts
@@ -13,7 +13,7 @@ describe('vendorHandoffPolicy', () => {
     expect(AGENTS_CORE.claude.sessionStorage).toEqual({ direct: true, persisted: true });
     expect(AGENTS_CORE.opencode.sessionStorage).toEqual({ direct: true, persisted: true });
     expect(AGENTS_CORE.codex.sessionStorage).toEqual({ direct: true, persisted: true });
-    expect(AGENTS_CORE.pi.sessionStorage).toEqual({ direct: false, persisted: true });
+    expect(AGENTS_CORE.pi.sessionStorage).toEqual({ direct: true, persisted: true });
   });
 
   it('resolves vendor handoff ids from metadata using the vendor resume field', () => {
@@ -35,9 +35,9 @@ describe('vendorHandoffPolicy', () => {
   it('rejects unsupported direct handoff when the provider does not support direct session storage', () => {
     expect(
       evaluateVendorHandoffEligibility({
-        agentId: 'pi',
+        agentId: 'gemini',
         storageMode: 'direct',
-        metadata: { piSessionId: 'p1' },
+        metadata: {},
       }),
     ).toEqual({ eligible: false, reasonCode: 'storage_mode_unsupported' });
   });

--- a/packages/protocol/src/directSessions/daemonRpcV1.ts
+++ b/packages/protocol/src/directSessions/daemonRpcV1.ts
@@ -52,10 +52,19 @@ const DirectSessionsOpenCodeServerSourceSchema = z
   })
   .passthrough();
 
+const DirectSessionsPiAgentDirSourceSchema = z
+  .object({
+    kind: z.literal('piAgentDir'),
+    // Resolved ~/.pi/agent directory; falls back to env PI_CODING_AGENT_DIR / ~/.pi/agent when nullish.
+    agentDir: z.string().min(1).max(10_000).nullish(),
+  })
+  .passthrough();
+
 export const DirectSessionsSourceSchema = z.discriminatedUnion('kind', [
   DirectSessionsCodexHomeSourceSchema,
   DirectSessionsClaudeConfigSourceSchema,
   DirectSessionsOpenCodeServerSourceSchema,
+  DirectSessionsPiAgentDirSourceSchema,
 ]);
 export type DirectSessionsSource = z.infer<typeof DirectSessionsSourceSchema>;
 

--- a/packages/protocol/src/index.exports.test.ts
+++ b/packages/protocol/src/index.exports.test.ts
@@ -125,6 +125,10 @@ describe('protocol package root exports', () => {
         expect((protocol as any).DirectSessionsProviderIdSchema.parse('codex')).toBe('codex');
         expect((protocol as any).DirectSessionsProviderIdSchema.parse('claude')).toBe('claude');
         expect((protocol as any).DirectSessionsProviderIdSchema.parse('opencode')).toBe('opencode');
+        expect((protocol as any).DirectSessionsProviderIdSchema.parse('pi')).toBe('pi');
+        expect((protocol as any).DirectSessionsSourceSchema.safeParse({ kind: 'piAgentDir' }).success).toBe(true);
+        expect((protocol as any).DirectSessionsSourceSchema.safeParse({ kind: 'piAgentDir', agentDir: '/custom/.pi/agent' }).success).toBe(true);
+        expect((protocol as any).DirectSessionsSourceSchema.safeParse({ kind: 'piAgentDir', agentDir: '' }).success).toBe(false);
         expect(typeof (protocol as any).DirectSessionsCandidatesListRequestSchema?.safeParse).toBe('function');
         expect(typeof (protocol as any).DirectTranscriptPageRequestSchema?.safeParse).toBe('function');
         expect(typeof (protocol as any).DirectTranscriptReadAfterRequestSchema?.safeParse).toBe('function');

--- a/packages/protocol/src/providers/agentProviderIdsV1.ts
+++ b/packages/protocol/src/providers/agentProviderIdsV1.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 // Intentionally scoped: this is the subset of providers that participate in v1 daemon-facing
 // provider ids (direct sessions, handoff resume plans, MCP detection).
-export const AGENT_PROVIDER_IDS_V1 = ['claude', 'codex', 'opencode'] as const;
+export const AGENT_PROVIDER_IDS_V1 = ['claude', 'codex', 'opencode', 'pi'] as const;
 
 export type AgentProviderIdV1 = (typeof AGENT_PROVIDER_IDS_V1)[number];
 


### PR DESCRIPTION
## Summary

Adds `pi` (the `@earendil-works/pi-coding-agent` harness) as a fourth direct-session provider alongside Claude, Codex, and OpenCode. Pi sessions are tree-structured JSONL on disk, so this mirrors the Claude filesystem model while porting pi's own active-branch resolution so imported transcripts match what a resumed pi session actually sees.

Discovery, transcript import/follow, linking, and takeover all resolve through the existing shared seam (`getDirectSessionProviderOps('pi')` via the backend catalog), keeping shared orchestration provider-agnostic.

## Changes

- **Protocol** (`packages/protocol`): add `'pi'` to `AgentProviderIdV1` and a `piAgentDir` source variant to `DirectSessionsSource`.
- **Provider** (`apps/cli/src/backends/pi/directSessions/`): full `DirectSessionProviderOps` implementation — discovery (cwd-encoded directory scan), paging (whole-file tree-walk → active-branch item-list paging), readAfter/follow, activity, working-directory (from authoritative header `cwd`), and takeover spawn options (`pi --session <uuid>` from the session's cwd, `PI_CODING_AGENT_DIR` env).
- **Catalog** (`backends/pi/index.ts`): wire `getDirectSessionProviderOps`.
- **Linking** (`ensureDirectSessionLink`): pi arms for source-keyed identity (`piAgentDir:<agentDir>`), `piSessionId` metadata, and pi marker recognition.
- **Security gate** (`validateDirectMachineSource`): pi arm mirroring Claude's model (daemon-controlled agent dir, client override must match — path-traversal guard).

## Key implementation notes

- **Active-branch resolution**: ports pi's own `buildContextEntries` / `buildSessionPath` / `_buildIndex` (last-in-file leaf derivation, `firstKeptEntryId` compaction fold) so imports never include abandoned sibling branches or duplicate history. Faithful to the installed binary.
- **Paging cursor**: backward paging uses an `endExclusive` cursor (collect newest-first, byte-limit truncates the older end) so pages stay gap-free and overlap-free even when `maxBytes` truncates below `maxItems` — reconstructable into full chronological order.
- **Takeover**: resumes in place via `pi --session <uuid>` (not `--fork`), launched from the header `cwd` (authoritative; the `--<cwd>--` directory name is not decoded since its encoding collapses separators and drive colons).

## Two bugs found and fixed via testing

1. **Paging overlap**: the original backward pager's `consumed` cursor caused overlapping windows when `maxBytes` truncated pages → duplicated/gapped, out-of-order imports of any substantial session. Caught by live validation against a real 700-item pi session.
2. **Security gate**: `validateDirectMachineSource` had a closed `switch` over the provider enum with no `pi` arm → every pi RPC request rejected at runtime with `unsupported direct session provider`, despite TypeScript compiling. Caught by an RPC-handler integration test.

## Testing

- Unit: pi provider module suite (entry-context, mapping, paging, title, discovery) + linking + validation.
- Integration: RPC-handler tests exercising list/page/readAfter/link.ensure/takeover through the **real catalog + real pi providerOps** with fixture pi sessions (including an abandoned sibling branch so active-branch selection comes through the RPC stack).
- Live validation (throwaway, not committed): ran the provider against real `~/.pi/agent` — discovered 119 sessions, paged a 700-item session across 7 pages (chronological, gap-free, duplicate-free).
- No regressions across the direct-session corridor (Claude/Codex/OpenCode unaffected).

## Out of scope / residual

- The literal `pi --session <uuid>` process spawn was not run against a live daemon+server (needs a running daemon build + server auth). The spawn *options* are proven correct and match pi's verified resume semantics.
- Protocol dist is a gitignored build artifact; CI will regenerate it from source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788863152&installation_model_id=20481&pr_number=233&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F233&signature=c5ce9034c9daff2d96cdb7661bde8a6deb9ef7160ca0d23c92025a613cfb256f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pi as a direct-session provider with transcript paging, candidate listing, and takeover support
> - Registers `pi` as a valid `AgentProviderIdV1` and extends `DirectSessionsSourceSchema` with a new `piAgentDir` source kind.
> - Adds `piDirectSessionProviderOps` implementing the full `DirectSessionProviderOps` interface: listing session candidates, paging transcripts (backward with byte/item limits), tail-reading via polling forward cursor, retrieving activity from file mtime, and resolving spawn options to resume pi in-place.
> - Session files are discovered by scanning `<agentDir>/sessions` subdirectories, extracting UUIDs from JSONL filenames, and sorting by mtime. Candidate listing supports pagination via base64url index cursors and optional title/metadata search.
> - Transcript mapping walks the active branch via `parentId` links, handles compaction (`firstKeptEntryId`), and normalizes entries to `DirectTranscriptRawMessageV1` with stable `pi:<relPath>:<id>` identifiers.
> - `validateDirectMachineSource` enforces that client-supplied `agentDir` matches the daemon-configured path, mirroring the existing claude policy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db3805b. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for browsing, linking, resuming, taking over, and managing Pi direct sessions.
  * Added Pi session discovery, titles, working directories, activity status, transcript paging, and incremental updates.
  * Added a selectable default Pi agent directory with localized labels.
  * Added improved prompt delivery, filtering, and optional appended system prompts for Pi sessions.
* **Bug Fixes**
  * Improved session identity validation, imported-session handling, model selection, marker matching, and directory validation.
* **Tests**
  * Expanded coverage for Pi sessions, transcripts, handoffs, prompts, model selection, and directory validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->