### PR TITLE
fix(ui-pickers): keep the keyboard while typing a custom model id

### DIFF
--- a/apps/ui/sources/components/sessions/pickers/OptionPickerOverlay.test.tsx
+++ b/apps/ui/sources/components/sessions/pickers/OptionPickerOverlay.test.tsx
@@ -193,7 +193,7 @@ describe('OptionPickerOverlay', () => {
         expect(screen.getTextContent()).toContain('modelPickerOverlay.loadingModelsA11y');
     });
 
-    it('updates the custom value immediately (no Save button) when entering a custom model', async () => {
+    it('commits a custom model on blur (no Save button) without pushing a value up-tree on each keystroke', async () => {
         const onSubmitCustomValue = vi.fn();
         const onSelect = vi.fn();
         const { OptionPickerOverlay } = await import('./OptionPickerOverlay');
@@ -216,13 +216,306 @@ describe('OptionPickerOverlay', () => {
         expect(screen.findByTestId('model-picker-overlay-custom')).toBeTruthy();
         await screen.pressByTestIdAsync('model-picker-overlay-custom');
         expect(screen.findByTestId('model-picker-overlay-custom-input')).toBeTruthy();
+
+        // Typing must NOT commit up-tree per keystroke. Committing mid-type churns the
+        // parent picker option list, which remounts this input and drops the keyboard.
         await act(async () => {
-            screen.changeTextByTestId('model-picker-overlay-custom-input', '  custom-model  ');
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'c');
+        });
+        await act(async () => {
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'custom-model');
+        });
+        expect(onSubmitCustomValue).not.toHaveBeenCalled();
+
+        // There is no explicit Save button; commit happens on blur with the full value.
+        expect(screen.findByTestId('model-picker-overlay-custom-save')).toBeNull();
+        await act(async () => {
+            screen.findByTestId('model-picker-overlay-custom-input')?.props.onBlur?.();
         });
 
-        expect(screen.findByTestId('model-picker-overlay-custom-save')).toBeNull();
-        expect(onSubmitCustomValue).toHaveBeenCalledWith('  custom-model  ');
+        expect(onSubmitCustomValue).toHaveBeenCalledTimes(1);
+        expect(onSubmitCustomValue).toHaveBeenCalledWith('custom-model');
         expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('does not commit typed custom text when a listed option is selected instead', async () => {
+        const onSubmitCustomValue = vi.fn();
+        let closeOnSelect = false;
+        const host: { unmount: () => Promise<void> } = { unmount: async () => {} };
+        const onSelect = vi.fn(() => {
+            if (closeOnSelect) void host.unmount();
+        });
+        const { OptionPickerOverlay } = await import('./OptionPickerOverlay');
+
+        const screen = await renderScreen(<OptionPickerOverlay
+                    title="Model"
+                    effectiveLabel="Default"
+                    notes={[]}
+                    options={[
+                        { value: 'default', label: 'Default', description: '' },
+                        { value: 'fast', label: 'Fast', description: '' },
+                    ]}
+                    selectedValue="default"
+                    emptyText="empty"
+                    canEnterCustomValue
+                    customLabel="Custom model"
+                    onSubmitCustomValue={onSubmitCustomValue}
+                    onSelect={onSelect}
+                />);
+        host.unmount = screen.unmount;
+
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        await act(async () => {
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'half-typed');
+        });
+
+        // A host that closes the picker on select unmounts inside the onSelect call, before the
+        // passive effect that refreshes the pending-commit ref can run. The unmount flush must
+        // already know the editor was abandoned, or it commits the half-typed id over the choice.
+        closeOnSelect = true;
+        await screen.pressByTestIdAsync('model-picker-overlay-option:fast');
+
+        expect(onSelect).toHaveBeenCalledWith('fast');
+        expect(onSubmitCustomValue).not.toHaveBeenCalled();
+    });
+
+    it('discards abandoned custom text when a listed option is selected', async () => {
+        const onSubmitCustomValue = vi.fn();
+        const onSelect = vi.fn();
+        const { OptionPickerOverlay } = await import('./OptionPickerOverlay');
+
+        const screen = await renderScreen(<OptionPickerOverlay
+                    title="Model"
+                    effectiveLabel="Default"
+                    notes={[]}
+                    options={[
+                        { value: 'default', label: 'Default', description: '' },
+                        { value: 'fast', label: 'Fast', description: '' },
+                    ]}
+                    selectedValue="default"
+                    emptyText="empty"
+                    canEnterCustomValue
+                    customLabel="Custom model"
+                    onSubmitCustomValue={onSubmitCustomValue}
+                    onSelect={onSelect}
+                />);
+
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        await act(async () => {
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'half-typed');
+        });
+        await screen.pressByTestIdAsync('model-picker-overlay-option:fast');
+
+        // Reopening the editor must not revive the abandoned text, or dismissing later would
+        // commit it over the selection the user actually made.
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        expect(screen.findByTestId('model-picker-overlay-custom-input')?.props.value).toBe('');
+
+        await screen.unmount();
+        expect(onSubmitCustomValue).not.toHaveBeenCalled();
+        expect(onSelect).toHaveBeenCalledWith('fast');
+    });
+
+    it('allows re-selecting the same custom model after picking a listed option', async () => {
+        const onSubmitCustomValue = vi.fn();
+        const { OptionPickerOverlay } = await import('./OptionPickerOverlay');
+
+        const screen = await renderScreen(<OptionPickerOverlay
+                    title="Model"
+                    effectiveLabel="Default"
+                    notes={[]}
+                    options={[
+                        { value: 'default', label: 'Default', description: '' },
+                        { value: 'fast', label: 'Fast', description: '' },
+                    ]}
+                    selectedValue="default"
+                    emptyText="empty"
+                    canEnterCustomValue
+                    customLabel="Custom model"
+                    onSubmitCustomValue={onSubmitCustomValue}
+                    onSelect={() => {}}
+                />);
+
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        await act(async () => {
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'my-model');
+        });
+        await act(async () => {
+            screen.findByTestId('model-picker-overlay-custom-input')?.props.onSubmitEditing?.();
+        });
+        expect(onSubmitCustomValue).toHaveBeenCalledTimes(1);
+
+        // Switching to a listed option abandons that custom selection, so choosing the same custom
+        // id again is a real new selection — the commit de-dup must not swallow it.
+        await screen.pressByTestIdAsync('model-picker-overlay-option:fast');
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        await act(async () => {
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'my-model');
+        });
+        await act(async () => {
+            screen.findByTestId('model-picker-overlay-custom-input')?.props.onSubmitEditing?.();
+        });
+
+        expect(onSubmitCustomValue).toHaveBeenCalledTimes(2);
+        expect(onSubmitCustomValue).toHaveBeenLastCalledWith('my-model');
+    });
+
+    it('discards abandoned custom text when the selection changes from outside the picker', async () => {
+        const onSubmitCustomValue = vi.fn();
+        const { OptionPickerOverlay } = await import('./OptionPickerOverlay');
+
+        let setSelected: ((next: string) => void) | null = null;
+        function Host() {
+            const [selectedValue, setSelectedValue] = React.useState('default');
+            setSelected = setSelectedValue;
+            return (
+                <OptionPickerOverlay
+                    title="Model"
+                    effectiveLabel="Default"
+                    notes={[]}
+                    options={[
+                        { value: 'default', label: 'Default', description: '' },
+                        { value: 'fast', label: 'Fast', description: '' },
+                    ]}
+                    selectedValue={selectedValue}
+                    emptyText="empty"
+                    canEnterCustomValue
+                    customLabel="Custom model"
+                    onSubmitCustomValue={onSubmitCustomValue}
+                    onSelect={() => {}}
+                />
+            );
+        }
+
+        const screen = await renderScreen(<Host />);
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        await act(async () => {
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'half-typed');
+        });
+
+        // The selection changes programmatically, not through the picker's own handler.
+        await act(async () => {
+            setSelected?.('fast');
+        });
+
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        expect(screen.findByTestId('model-picker-overlay-custom-input')?.props.value).toBe('');
+
+        await screen.unmount();
+        expect(onSubmitCustomValue).not.toHaveBeenCalled();
+    });
+
+    it('discards the draft when an external listed selection replaces an initially custom one', async () => {
+        const onSubmitCustomValue = vi.fn();
+        const { OptionPickerOverlay } = await import('./OptionPickerOverlay');
+
+        let setSelected: ((next: string) => void) | null = null;
+        function Host() {
+            const [selectedValue, setSelectedValue] = React.useState('my-model');
+            setSelected = setSelectedValue;
+            return (
+                <OptionPickerOverlay
+                    title="Model"
+                    effectiveLabel="Default"
+                    notes={[]}
+                    options={[
+                        { value: 'default', label: 'Default', description: '' },
+                        { value: 'fast', label: 'Fast', description: '' },
+                    ]}
+                    selectedValue={selectedValue}
+                    emptyText="empty"
+                    canEnterCustomValue
+                    customLabel="Custom model"
+                    onSubmitCustomValue={onSubmitCustomValue}
+                    onSelect={() => {}}
+                />
+            );
+        }
+
+        // Mounts with a custom model already selected, so the editor opens with reason
+        // 'selected-custom' — the branch that returns early.
+        const screen = await renderScreen(<Host />);
+        expect(screen.findByTestId('model-picker-overlay-custom-input')?.props.value).toBe('my-model');
+
+        await act(async () => {
+            setSelected?.('fast');
+        });
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        expect(screen.findByTestId('model-picker-overlay-custom-input')?.props.value).toBe('');
+
+        await screen.unmount();
+        expect(onSubmitCustomValue).not.toHaveBeenCalled();
+    });
+
+    it('does not commit the draft when blur is caused by tapping a listed option', async () => {
+        const onSubmitCustomValue = vi.fn();
+        const onSelect = vi.fn();
+        const { OptionPickerOverlay } = await import('./OptionPickerOverlay');
+
+        const screen = await renderScreen(<OptionPickerOverlay
+                    title="Model"
+                    effectiveLabel="Default"
+                    notes={[]}
+                    options={[
+                        { value: 'default', label: 'Default', description: '' },
+                        { value: 'fast', label: 'Fast', description: '' },
+                    ]}
+                    selectedValue="default"
+                    emptyText="empty"
+                    canEnterCustomValue
+                    customLabel="Custom model"
+                    onSubmitCustomValue={onSubmitCustomValue}
+                    onSelect={onSelect}
+                />);
+
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        await act(async () => {
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'half-typed');
+        });
+
+        // Tapping another control blurs the focused input first. Committing there would publish an
+        // unintended intermediate model change before the option the user actually chose.
+        await act(async () => {
+            screen.findByTestId('model-picker-overlay-option:fast')?.props.onPressIn?.();
+            screen.findByTestId('model-picker-overlay-custom-input')?.props.onBlur?.();
+        });
+        await screen.pressByTestIdAsync('model-picker-overlay-option:fast');
+
+        expect(onSubmitCustomValue).not.toHaveBeenCalled();
+        expect(onSelect).toHaveBeenCalledWith('fast');
+    });
+
+    it('commits a typed custom model when the picker is dismissed without a blur', async () => {
+        const onSubmitCustomValue = vi.fn();
+        const { OptionPickerOverlay } = await import('./OptionPickerOverlay');
+
+        const screen = await renderScreen(<OptionPickerOverlay
+                    title="Model"
+                    effectiveLabel="Default"
+                    notes={[]}
+                    options={[
+                        { value: 'default', label: 'Default', description: '' },
+                    ]}
+                    selectedValue="default"
+                    emptyText="empty"
+                    canEnterCustomValue
+                    customLabel="Custom model"
+                    onSubmitCustomValue={onSubmitCustomValue}
+                    onSelect={() => {}}
+                />);
+
+        await screen.pressByTestIdAsync('model-picker-overlay-custom');
+        await act(async () => {
+            screen.changeTextByTestId('model-picker-overlay-custom-input', 'custom-model');
+        });
+        expect(onSubmitCustomValue).not.toHaveBeenCalled();
+
+        // Dismissing the overlay unmounts a still-focused input, which fires no blur on
+        // either React Native or React Native Web — the typed id must not be lost.
+        await screen.unmount();
+
+        expect(onSubmitCustomValue).toHaveBeenCalledTimes(1);
+        expect(onSubmitCustomValue).toHaveBeenCalledWith('custom-model');
     });
 
     it('matches and submits model identifiers as exact opaque values', async () => {

--- a/apps/ui/sources/components/sessions/pickers/OptionPickerOverlay.tsx
+++ b/apps/ui/sources/components/sessions/pickers/OptionPickerOverlay.tsx
@@ -114,6 +114,36 @@ export function OptionPickerOverlay(props: OptionPickerOverlayProps) {
     );
     const lastCommittedCustomValueRef = React.useRef<string>(selectedCustomValue);
     const previousSelectedValueRef = React.useRef(selectedValue);
+    // Dismissing the picker unmounts a still-focused input without firing `onBlur` on either
+    // React Native or React Native Web, so the unmount path has to flush the pending value.
+    // `commitCustomValue` is idempotent, so a blur followed by unmount commits once. Seeded
+    // neutral and refreshed on every render below, so it can live above the code that resets it.
+    const pendingCustomCommitRef = React.useRef<{
+        visible: boolean;
+        value: string;
+        commit: (raw: string) => void;
+    }>({ visible: false, value: '', commit: () => {} });
+
+    /**
+     * Forget an in-progress custom model draft.
+     *
+     * Called wherever a listed option supersedes the custom selection — through this picker or
+     * from outside it. Hiding the editor is not enough: a surviving draft is revived when the
+     * editor reopens and a later dismiss commits it over the real selection. Clearing the
+     * last-committed marker matters too, or re-choosing that same custom id afterwards is
+     * swallowed as a duplicate.
+     */
+    // Pressing another control blurs the focused input BEFORE that control's press handler runs.
+    // Without this, tapping a listed option commits the half-typed draft first and publishes an
+    // unintended intermediate model change before the option the user actually chose.
+    const selectionPressPendingRef = React.useRef(false);
+
+    const abandonCustomDraft = React.useCallback(() => {
+        selectionPressPendingRef.current = false;
+        pendingCustomCommitRef.current = { ...pendingCustomCommitRef.current, visible: false, value: '' };
+        lastCommittedCustomValueRef.current = '';
+        setCustomValue('');
+    }, []);
     const probeHintText = React.useMemo(() => {
         if (!probe || probe.phase === 'idle') return null;
         if (props.options.length > 1 || props.canEnterCustomValue) return null;
@@ -148,8 +178,9 @@ export function OptionPickerOverlay(props: OptionPickerOverlayProps) {
             }
             customEditorOpenReasonRef.current = null;
             setCustomEditorVisible(false);
+            abandonCustomDraft();
         }
-    }, [customEditorVisible, optionValues, selectedCustomValue, selectedValue]);
+    }, [abandonCustomDraft, customEditorVisible, optionValues, selectedCustomValue, selectedValue]);
 
     const filteredOptions = React.useMemo(() => {
         if (!showSearch || !normalizedQuery) return props.options;
@@ -255,9 +286,12 @@ export function OptionPickerOverlay(props: OptionPickerOverlayProps) {
 
     const handleSelectOption = React.useCallback((nextValue: string) => {
         customEditorOpenReasonRef.current = null;
+        // Synchronously, before `onSelect`: a host that unmounts inside it never runs the passive
+        // effect that refreshes the pending-commit ref.
+        abandonCustomDraft();
         setCustomEditorVisible(false);
         props.onSelect(nextValue);
-    }, [props]);
+    }, [abandonCustomDraft, props]);
 
     const commitCustomValue = React.useCallback((raw: string) => {
         const normalized = readNonBlankSessionControlIdentifier(raw);
@@ -271,10 +305,26 @@ export function OptionPickerOverlay(props: OptionPickerOverlayProps) {
         props.onSelect(normalized);
     }, [props]);
 
+    React.useEffect(() => {
+        pendingCustomCommitRef.current = {
+            visible: customEditorVisible,
+            value: customValue,
+            commit: commitCustomValue,
+        };
+    });
+    React.useEffect(() => () => {
+        const pending = pendingCustomCommitRef.current;
+        if (!pending.visible) return;
+        pending.commit(pending.value);
+    }, []);
+
     const handleCustomValueChange = React.useCallback((next: string) => {
+        // Only update local editor state while typing. Committing on every keystroke
+        // pushes the value up to the parent, which regenerates the picker option list
+        // (with a fresh detail-content closure) and remounts this input — dropping the
+        // keyboard after each character. Commit happens on submit/blur instead.
         setCustomValue(next);
-        commitCustomValue(next);
-    }, [commitCustomValue]);
+    }, []);
 
     const selectedTileValue = customEditorVisible ? null : props.selectedValue;
     return (
@@ -400,6 +450,7 @@ export function OptionPickerOverlay(props: OptionPickerOverlayProps) {
                                                 >
                                                     <Pressable
                                                         testID={`${optionTestIDPrefix}:${option.value}`}
+                                                        onPressIn={() => { selectionPressPendingRef.current = true; }}
                                                         onPress={() => handleSelectOption(option.value)}
                                                         accessibilityRole="button"
                                                         accessibilityLabel={option.accessibilityLabel}
@@ -558,6 +609,15 @@ export function OptionPickerOverlay(props: OptionPickerOverlayProps) {
                                         autoCorrect={false}
                                         autoCapitalize="none"
                                         onSubmitEditing={() => commitCustomValue(customValue)}
+                                        onBlur={() => {
+                                            if (selectionPressPendingRef.current) {
+                                                // Consume the flag: this blur belongs to a listed-option press,
+                                                // whose handler discards the draft moments later.
+                                                selectionPressPendingRef.current = false;
+                                                return;
+                                            }
+                                            commitCustomValue(customValue);
+                                        }}
                                         style={[styles.searchInput, styles.customEditorInput] as any}
                                     />
                                 </View>


### PR DESCRIPTION
## Summary

The custom-model editor committed on every keystroke, which remounted the input and closed the
keyboard after each character. Typing now stays local to the editor and commits on submit, blur,
and unmount.

## Why

Reported in Discord: "android app- cannot type custom model - crash/hide the keyboard"
(https://discord.com/channels/1467127365317558402/1478724067195355240/1535308686354944040) — and
explicitly not Android-only: *"actually same as web app"*. That matches the cause below, which is in
shared component logic rather than any platform keyboard behaviour.

`handleCustomValueChange` called `commitCustomValue` per keystroke. Each commit pushes the value to
the parent, which regenerates the picker option list with a fresh detail-content closure and
remounts the `TextInput` — so the field lost focus after every character and a custom model id was
effectively untypeable.

Committing on submit/blur alone is not enough: dismissing the picker unmounts a still-focused input
without firing `onBlur` on either React Native or React Native Web, which would silently discard
what was typed. The unmount path flushes the pending value; `commitCustomValue` de-duplicates so
blur followed by unmount commits once.

Draft invalidation has one owner, `abandonCustomDraft`. Both transitions where a listed option
supersedes the custom selection call it — the picker's own handler and the prop-driven effect. It
clears the draft text, the pending-commit ref, and the last-committed marker together, because
partial clearing produced three separate defects during review: a stale draft revived on reopen, a
draft committed over a real selection, and a genuine re-selection of the same custom id swallowed as
a duplicate.

## How to test

1. `cd apps/ui && yarn typecheck` — 0 errors.
2. `cd apps/ui && yarn vitest run sources/components/sessions/pickers sources/sync/domains/models`
   — 83 passed / 8 files.
3. Manual, per the reporter's repro, on **both** Android and web: session → model picker →
   "Custom model" → type a full model id. The keyboard stays up. Submit or tap away and the id
   applies. Then: type an id, pick a listed option instead, reopen the custom field — it must be
   empty. Then: commit a custom id, pick a listed option, re-enter that same id — it must apply.

## Screenshots / recording (UI changes)

Deliberately omitted. The defect is focus loss between keystrokes, so a still image shows nothing,
and a recording would only restate what the tests assert. The behaviour is pinned by
`sources/components/sessions/pickers/OptionPickerOverlay.test.tsx`, which covers typing without an
up-tree commit, commit on blur, commit on dismiss without blur, discarding an abandoned draft on a
listed selection (both in-picker and prop-driven), re-selecting the same custom id afterwards, and
not committing the draft when blur is caused by tapping a listed option.

Repro if you want to see it by hand, on Android or web: model picker -> "Custom model" -> type a
multi-character id. Before this change the keyboard closes after each character.

## Notes

Confined to `OptionPickerOverlay` commit timing and draft lifecycle — no provider, sync, or storage
surface.

Pairs with the Claude dynamic model list PR: the users in that Discord thread are only in the
custom-model field because the listed Claude models are stale. This PR fixes the workaround; that one
removes the need for it. Either can land first.

## AI disclosure

Authored with Claude Code (Opus 5), reviewed across five rounds by Codex (gpt-5.5), which found four
real defects in this file; all four are fixed and covered by regression tests, and its final round
returned no findings. Checks executed on `406d17822`, rebased onto `4b76fc8c6`:

- `cd apps/ui && yarn typecheck` — 0 errors
- `cd apps/ui && yarn vitest run sources/components/sessions/pickers sources/sync/domains/models` — 83 passed / 8 files

Not verified: the on-device keyboard behaviour this PR exists to fix. The unmount and dismiss paths
are covered by tests that simulate unmount, not by a real dismiss on a device. Codex's review was
static analysis only — its sandbox is read-only and could not execute tests.

## Checklist

- [x] PR targets `dev` (not `main`)
- [x] I linked an issue/discussion (recommended for non-trivial changes)
- [x] I added/updated tests where feasible (or explained why not)
- [ ] I updated docs if behavior changed
- [x] If AI-assisted, I disclosed it and listed what I personally verified

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788970684&installation_model_id=20481&pr_number=236&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F236&signature=66254f2742395eae92381a3d3a348e80d67a214bcb65907e2cfc647f62fbe97b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OptionPickerOverlay` to preserve keyboard while typing a custom model ID
> - Custom model input no longer commits on each keystroke; it now commits on blur or when the picker is dismissed (unmount).
> - Blur triggered by tapping a listed option is ignored for commit purposes, so selecting a listed option cleanly abandons any in-progress custom draft.
> - Selecting a listed option calls `abandonCustomDraft` before invoking `onSelect`, clearing the last-committed custom value marker.
> - External changes to `selectedValue` that replace a custom selection close the editor and discard the draft.
> - Behavioral Change: commit timing shifts from per-keystroke to blur/unmount, which may affect flows that relied on the old eager-commit behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c51b4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom picker values are now submitted only after editing is complete, such as when leaving the field, submitting, or dismissing the picker.
  * Prevented incomplete or abandoned custom entries from being submitted.
  * Selecting a listed option now clears pending custom input.
  * Re-submitting a previously used custom value now works reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->