### PR TITLE
fix(release): unblock the local-monorepo e2e smoke (stack packaging + entrypoint)

### DIFF
--- a/apps/stack/package.json
+++ b/apps/stack/package.json
@@ -74,6 +74,7 @@
     "menubar:uninstall": "node ./scripts/menubar.mjs uninstall",
     "menubar:open": "bash -lc 'DIR=\"$(defaults read com.ameba.SwiftBar PluginDirectory 2>/dev/null)\"; if [[ -z \"$DIR\" ]]; then DIR=\"$HOME/Library/Application Support/SwiftBar/Plugins\"; fi; open \"$DIR\"'",
     "prepack": "node ./scripts/bundleWorkspaceDeps.mjs",
+    "postpack": "node ./scripts/postpack/patchPackedTarballForWorkspaces.mjs",
     "test": "yarn -s test:unit",
     "test:unit": "node ./scripts/test_ci.mjs",
     "test:integration": "node ./scripts/test_integration.mjs",

--- a/apps/stack/scripts/postpack/patchPackedTarballForWorkspaces.mjs
+++ b/apps/stack/scripts/postpack/patchPackedTarballForWorkspaces.mjs
@@ -1,0 +1,229 @@
+// postpack: vendor the repo-root build-system helpers that apps/stack/scripts/ reaches via
+// `../../../../../` imports into the packed @happier-dev/stack tarball, and rewrite those escaping
+// imports to the in-package vendored copies.
+//
+// Background: several apps/stack/scripts/ files import repo-root siblings through paths like
+// `../../../../../scripts/workspaces/...` or `../../../../../packages/cli-common/...`. These
+// resolve at the monorepo root in dev but, once @happier-dev/stack is `npm pack`-ed and installed
+// standalone, the five `../` escape the package to the npm install root
+// (`<prefix>/node_modules/scripts/...` / `.../packages/...`) — ENOENT. npm's `files` glob also
+// cannot traverse parent dirs to include those files. So the packed tarball is broken for
+// standalone consumers (hstack setup/start crash). This postpack (mirroring
+// apps/cli/scripts/postpack/patchPackedTarballForBun.mjs) unpacks the tarball produced by
+// `npm pack`, copies each escaped helper into package/scripts/utils/workspaces/, rewrites every
+// escaping import to the in-package vendored copy, rewrites the helpers' own back-imports into
+// apps/stack/scripts/utils/* to in-package relative paths, and repacks. The repo-root sources stay
+// canonical for monorepo builds; only the published tarball is made self-contained.
+import { execFileSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Repo-root-relative paths of the files that apps/stack/scripts/ reaches through escaping imports.
+// Each is vendored into package/scripts/utils/workspaces/ (basename preserved). Keep in sync with
+// the actual escaping imports in apps/stack/scripts/ (guarded by a source-drift test).
+export const VENDOR_SPECS = Object.freeze([
+  'scripts/workspaces/ensureWorkspacePackagesBuilt.mjs',
+  'scripts/workspaces/execYarnCommand.mjs',
+  'scripts/workspaces/workspacePackageBuildLock.mjs',
+  'packages/cli-common/processInstance.mjs',
+]);
+
+// Escaping import prefix: five `../` from package/scripts/utils/<subdir>/ reaches the npm install
+// root, escaping the @happier-dev/stack package. Each escaping import
+// `<ESCAPE_PREFIX><spec>` is rewritten to the in-package `<VENDORED_PREFIX><basename>`.
+const ESCAPE_IMPORT_PREFIX = '../../../../../';
+const VENDORED_PREFIX = '../workspaces/';
+
+// Vendored helpers (the scripts/workspaces/ ones) reach back into apps/stack/scripts/utils/* via
+// this prefix; from their new in-package location (scripts/utils/workspaces/) the same targets are
+// one level up. Applied to every vendored file (a no-op for files without such imports).
+const BACK_TO_UTILS_IMPORT = '../../apps/stack/scripts/utils/';
+const VENDORED_TO_UTILS_IMPORT = '../';
+
+const VENDORED_DIR_REL = path.join('scripts', 'utils', 'workspaces');
+
+export function rewriteBackToUtilsImport(content) {
+  return content.split(BACK_TO_UTILS_IMPORT).join(VENDORED_TO_UTILS_IMPORT);
+}
+
+/**
+ * Build the escaping-import → vendored-import rewrite map. Each spec's escaping import
+ * `${ESCAPE_PREFIX}<repoPath>` maps to `${VENDORED_PREFIX}<basename>`.
+ */
+export function buildEscapeRewriteMap() {
+  const map = new Map();
+  for (const spec of VENDOR_SPECS) {
+    const basename = path.basename(spec);
+    map.set(`${ESCAPE_IMPORT_PREFIX}${spec}`, `${VENDORED_PREFIX}${basename}`);
+  }
+  return map;
+}
+
+export function applyRewriteMap(content, rewriteMap) {
+  let out = content;
+  for (const [from, to] of rewriteMap) {
+    out = out.split(from).join(to);
+  }
+  return out;
+}
+
+function listMjsFilesRecursive(dir) {
+  const out = [];
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listMjsFilesRecursive(full));
+    } else if (entry.isFile() && entry.name.endsWith('.mjs')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Vendor the escaped helpers into an already-extracted `package/` dir and rewrite the affected
+ * imports in place. Pure filesystem transform — no tarball logic — so it is unit-testable.
+ */
+export function patchExtractedPackage({ extractedPackageDir, monorepoRoot }) {
+  if (!existsSync(extractedPackageDir)) {
+    throw new Error(`[postpack] extracted package dir missing: ${extractedPackageDir}`);
+  }
+
+  const vendoredDir = path.join(extractedPackageDir, ...VENDORED_DIR_REL.split(path.sep));
+  mkdirSync(vendoredDir, { recursive: true });
+
+  for (const spec of VENDOR_SPECS) {
+    const src = path.join(monorepoRoot, ...spec.split('/'));
+    if (!existsSync(src)) {
+      throw new Error(`[postpack] missing vendor source: ${src}`);
+    }
+    const content = readFileSync(src, 'utf8');
+    writeFileSync(path.join(vendoredDir, path.basename(spec)), rewriteBackToUtilsImport(content));
+  }
+
+  const rewriteMap = buildEscapeRewriteMap();
+  for (const file of listMjsFilesRecursive(path.join(extractedPackageDir, 'scripts'))) {
+    const original = readFileSync(file, 'utf8');
+    const rewritten = applyRewriteMap(original, rewriteMap);
+    if (rewritten !== original) {
+      writeFileSync(file, rewritten);
+    }
+  }
+}
+
+export function findMonorepoRootFrom(startDir) {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(path.join(dir, 'package.json')) && existsSync(path.join(dir, 'yarn.lock'))) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function normalizePackNameForFilename(name) {
+  const raw = String(name ?? '').trim();
+  if (!raw) return '';
+  return raw.replace(/^@/, '').replaceAll('/', '-');
+}
+
+export function resolveTarballPathFromEnv(env, cwd = process.cwd()) {
+  const destRaw = String(env?.npm_config_pack_destination ?? '').trim();
+  const destDir = destRaw ? path.resolve(cwd, destRaw) : cwd;
+  const name = normalizePackNameForFilename(env?.npm_package_name);
+  const version = String(env?.npm_package_version ?? '').trim();
+  if (name && version) {
+    const candidate = path.join(destDir, `${name}-${version}.tgz`);
+    if (existsSync(candidate)) return candidate;
+  }
+  try {
+    const newest = readdirSync(destDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.tgz'))
+      .map((entry) => ({ name: entry.name, mtimeMs: statSync(path.join(destDir, entry.name)).mtimeMs }))
+      .sort((a, b) => b.mtimeMs - a.mtimeMs)[0];
+    if (newest) return path.join(destDir, newest.name);
+  } catch {
+    // ignore
+  }
+  return '';
+}
+
+/**
+ * Patch the tarball produced by `npm pack` in place. Invoked as the stack package's `postpack`
+ * lifecycle script (npm sets npm_package_name / npm_package_version / npm_config_pack_destination).
+ * Also accepts explicit options for testing.
+ */
+export function patchPackedTarballForWorkspaces(options = {}) {
+  const env = options.env ?? process.env;
+  const tarballPath = String(options.tarballPath ?? '').trim() || resolveTarballPathFromEnv(env);
+  if (!tarballPath) {
+    throw new Error('[postpack] could not resolve packed tarball path (missing npm env?)');
+  }
+  if (!existsSync(tarballPath)) {
+    throw new Error(`[postpack] packed tarball not found: ${tarballPath}`);
+  }
+
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const monorepoRoot = options.monorepoRoot ?? findMonorepoRootFrom(scriptDir);
+  if (!monorepoRoot) {
+    throw new Error('[postpack] could not locate monorepo root (package.json + yarn.lock)');
+  }
+
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'happier-stack-postpack-'));
+  try {
+    execFileSync('tar', ['-xzf', tarballPath, '-C', tmpDir], { stdio: 'pipe' });
+    const extractedPackageDir = path.join(tmpDir, 'package');
+    if (!existsSync(extractedPackageDir)) {
+      throw new Error(`[postpack] tarball did not contain package/: ${tarballPath}`);
+    }
+
+    patchExtractedPackage({ extractedPackageDir, monorepoRoot });
+
+    const outTarball = path.join(tmpDir, path.basename(tarballPath));
+    execFileSync('tar', ['-czf', outTarball, '-C', tmpDir, 'package'], { stdio: 'pipe' });
+
+    // Replace the original tarball. copyFileSync + unlink is cross-device safe (the tmp dir may be
+    // on a different mount than the pack destination); fs.renameSync would throw EXDEV there.
+    copyFileSync(outTarball, tarballPath);
+    unlinkSync(outTarball);
+
+    return { tarballPath, vendored: VENDOR_SPECS.map((spec) => path.basename(spec)) };
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+const invokedAsMain = (() => {
+  const argv1 = process.argv[1];
+  if (!argv1) return false;
+  return path.resolve(argv1) === path.resolve(fileURLToPath(import.meta.url));
+})();
+
+if (invokedAsMain) {
+  try {
+    const result = patchPackedTarballForWorkspaces();
+    // eslint-disable-next-line no-console
+    console.log(`[postpack] vendored workspace helpers into ${path.basename(result.tarballPath)}: ${result.vendored.join(', ')}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/apps/stack/scripts/postpack/patchPackedTarballForWorkspaces.test.mjs
+++ b/apps/stack/scripts/postpack/patchPackedTarballForWorkspaces.test.mjs
@@ -1,0 +1,198 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyRewriteMap,
+  buildEscapeRewriteMap,
+  findMonorepoRootFrom,
+  patchExtractedPackage,
+  patchPackedTarballForWorkspaces,
+  rewriteBackToUtilsImport,
+  VENDOR_SPECS,
+} from './patchPackedTarballForWorkspaces.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function tarCreate(outTarball, cwd) {
+  execFileSync('tar', ['-czf', outTarball, '-C', cwd, 'package'], { stdio: 'pipe' });
+}
+
+function tarExtract(tarball, cwd) {
+  execFileSync('tar', ['-xzf', tarball, '-C', cwd], { stdio: 'pipe' });
+}
+
+const PM_ESCAPE = "from '../../../../../scripts/workspaces/ensureWorkspacePackagesBuilt.mjs';";
+const PM_REWRITTEN = "from '../workspaces/ensureWorkspacePackagesBuilt.mjs';";
+const PROCINST_ESCAPE = "from '../../../../../packages/cli-common/processInstance.mjs';";
+const PROCINST_REWRITTEN = "from '../workspaces/processInstance.mjs';";
+const BACK_IMPORT = "from '../../apps/stack/scripts/utils/paths/paths.mjs';";
+const BACK_REWRITTEN = "from '../paths/paths.mjs';";
+
+// Build a fake monorepo root (with the escaped source files) + a fake extracted package/ (with the
+// escaping importers). Mirrors the real layout: source files live under scripts/workspaces/ and
+// packages/cli-common/, importers under apps/stack's scripts/utils/{proc,stack}/.
+function buildFixture() {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'happier-stack-postpack-test-'));
+  const monorepoRoot = path.join(root, 'source-root');
+
+  // Escaped source files (repo-root-relative per VENDOR_SPECS).
+  mkdirSync(path.join(monorepoRoot, 'scripts', 'workspaces'), { recursive: true });
+  writeFileSync(
+    path.join(monorepoRoot, 'scripts', 'workspaces', 'ensureWorkspacePackagesBuilt.mjs'),
+    `import { resolveYarnCommandInvocation } from './execYarnCommand.mjs'\nimport { coerceHappyMonorepoRootFromPath } ${BACK_IMPORT}\nexport async function ensureWorkspacePackagesBuiltForComponent() {}\n`,
+  );
+  writeFileSync(
+    path.join(monorepoRoot, 'scripts', 'workspaces', 'execYarnCommand.mjs'),
+    `import { execFileSync } from 'node:child_process';\nexport function resolveYarnCommandInvocation() {}\n`,
+  );
+  writeFileSync(
+    path.join(monorepoRoot, 'scripts', 'workspaces', 'workspacePackageBuildLock.mjs'),
+    `import { coerceHappyMonorepoRootFromPath } ${BACK_IMPORT}\nexport function resolveWorkspacePackageBuildLockPath() {}\n`,
+  );
+  mkdirSync(path.join(monorepoRoot, 'packages', 'cli-common'), { recursive: true });
+  writeFileSync(
+    path.join(monorepoRoot, 'packages', 'cli-common', 'processInstance.mjs'),
+    `import { spawnSync } from 'node:child_process';\nimport { readFileSync } from 'node:fs';\nexport function readProcessInstanceFingerprintSync() {}\n`,
+  );
+
+  // Fake packed package/ tree with the escaping importers.
+  const packageDir = path.join(root, 'package');
+  const procDir = path.join(packageDir, 'scripts', 'utils', 'proc');
+  const stackDir = path.join(packageDir, 'scripts', 'utils', 'stack');
+  mkdirSync(procDir, { recursive: true });
+  mkdirSync(stackDir, { recursive: true });
+  writeFileSync(path.join(packageDir, 'package.json'), '{"name":"@happier-dev/stack","version":"0.0.0"}\n');
+  writeFileSync(
+    path.join(procDir, 'pm.mjs'),
+    `import { ensureWorkspacePackagesBuiltForComponent } ${PM_ESCAPE}\nexport { ensureWorkspacePackagesBuiltForComponent };\n`,
+  );
+  writeFileSync(
+    path.join(procDir, 'ensureWorkspacePackagesBuilt.test.mjs'),
+    `import { ensureWorkspacePackagesBuiltForComponent } ${PM_ESCAPE}\nimport { test } from 'node:test';\n`,
+  );
+  writeFileSync(
+    path.join(stackDir, 'runtime_daemon_state.mjs'),
+    `import { readProcessInstanceFingerprintSync } ${PROCINST_ESCAPE}\nexport function readRuntimeDaemonState() {}\n`,
+  );
+
+  return { root, monorepoRoot, packageDir };
+}
+
+test('rewriteBackToUtilsImport rewrites the apps/stack back-import to an in-package relative path', () => {
+  const out = rewriteBackToUtilsImport(`import { x } ${BACK_IMPORT}\n`);
+  assert.equal(out, `import { x } ${BACK_REWRITTEN}\n`);
+});
+
+test('buildEscapeRewriteMap maps every VENDOR_SPEC escape to its vendored import', () => {
+  const map = buildEscapeRewriteMap();
+  assert.equal(map.size, VENDOR_SPECS.length);
+  assert.equal(map.get("../../../../../scripts/workspaces/ensureWorkspacePackagesBuilt.mjs"), '../workspaces/ensureWorkspacePackagesBuilt.mjs');
+  assert.equal(map.get("../../../../../packages/cli-common/processInstance.mjs"), '../workspaces/processInstance.mjs');
+});
+
+test('applyRewriteMap rewrites all known escapes in a single pass', () => {
+  const out = applyRewriteMap(`a ${PM_ESCAPE}\nb ${PROCINST_ESCAPE}\n`, buildEscapeRewriteMap());
+  assert.ok(out.includes(PM_REWRITTEN));
+  assert.ok(out.includes(PROCINST_REWRITTEN));
+  assert.ok(!out.includes('../../../../../'));
+});
+
+test('patchExtractedPackage vendors every spec and rewrites every escaping import', () => {
+  const { root, monorepoRoot, packageDir } = buildFixture();
+  try {
+    patchExtractedPackage({ extractedPackageDir: packageDir, monorepoRoot });
+
+    const vendoredDir = path.join(packageDir, 'scripts', 'utils', 'workspaces');
+    for (const spec of VENDOR_SPECS) {
+      assert.ok(existsSync(path.join(vendoredDir, path.basename(spec))), `vendored file missing: ${spec}`);
+    }
+
+    // Vendored helpers had their back-imports rewritten (processInstance.mjs has none — unchanged).
+    const vendoredEnsure = readFileSync(path.join(vendoredDir, 'ensureWorkspacePackagesBuilt.mjs'), 'utf8');
+    assert.ok(!vendoredEnsure.includes('../../apps/stack/scripts/utils/'));
+    assert.ok(vendoredEnsure.includes('../paths/paths.mjs'));
+    const vendoredProcInst = readFileSync(path.join(vendoredDir, 'processInstance.mjs'), 'utf8');
+    assert.ok(vendoredProcInst.includes("from 'node:child_process'"));
+
+    // pm.mjs + packed test had their scripts/workspaces escape rewritten.
+    const pm = readFileSync(path.join(packageDir, 'scripts', 'utils', 'proc', 'pm.mjs'), 'utf8');
+    assert.ok(pm.includes('../workspaces/ensureWorkspacePackagesBuilt.mjs'));
+    assert.ok(!pm.includes('../../../../../scripts/workspaces/'));
+
+    const packedTest = readFileSync(path.join(packageDir, 'scripts', 'utils', 'proc', 'ensureWorkspacePackagesBuilt.test.mjs'), 'utf8');
+    assert.ok(packedTest.includes('../workspaces/ensureWorkspacePackagesBuilt.mjs'));
+
+    // runtime_daemon_state.mjs had its packages/cli-common escape rewritten.
+    const rds = readFileSync(path.join(packageDir, 'scripts', 'utils', 'stack', 'runtime_daemon_state.mjs'), 'utf8');
+    assert.ok(rds.includes('../workspaces/processInstance.mjs'));
+    assert.ok(!rds.includes('../../../../../packages/cli-common/'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('patchPackedTarballForWorkspaces round-trips a real tarball: all specs vendored + imports rewritten', () => {
+  const { root, monorepoRoot, packageDir } = buildFixture();
+  const tarballPath = path.join(root, 'artifact.tgz');
+  tarCreate(tarballPath, root);
+
+  const extractDir = mkdtempSync(path.join(os.tmpdir(), 'happier-stack-postpack-extract-'));
+  try {
+    const result = patchPackedTarballForWorkspaces({ tarballPath, monorepoRoot });
+    assert.equal(result.tarballPath, tarballPath);
+
+    tarExtract(tarballPath, extractDir);
+    const extractedPackage = path.join(extractDir, 'package');
+    const vendoredDir = path.join(extractedPackage, 'scripts', 'utils', 'workspaces');
+    for (const spec of VENDOR_SPECS) {
+      assert.ok(existsSync(path.join(vendoredDir, path.basename(spec))), `vendored missing in tarball: ${spec}`);
+    }
+
+    const pm = readFileSync(path.join(extractedPackage, 'scripts', 'utils', 'proc', 'pm.mjs'), 'utf8');
+    assert.ok(pm.includes('../workspaces/ensureWorkspacePackagesBuilt.mjs'));
+    const rds = readFileSync(path.join(extractedPackage, 'scripts', 'utils', 'stack', 'runtime_daemon_state.mjs'), 'utf8');
+    assert.ok(rds.includes('../workspaces/processInstance.mjs'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(extractDir, { recursive: true, force: true });
+  }
+});
+
+// Guard: the real repo files must still use the import prefixes this postpack rewrites. If someone
+// changes the import style in pm.mjs / runtime_daemon_state.mjs or the vendored sources, this fails
+// loudly so the postpack transform stays in sync with the source.
+test('real repo escaping imports + vendor sources still use the prefixes this postpack rewrites', () => {
+  const repoRoot = findMonorepoRootFrom(__dirname);
+  assert.ok(repoRoot, 'could not locate monorepo root from postpack test');
+
+  const realPm = path.join(repoRoot, 'apps', 'stack', 'scripts', 'utils', 'proc', 'pm.mjs');
+  const realRds = path.join(repoRoot, 'apps', 'stack', 'scripts', 'utils', 'stack', 'runtime_daemon_state.mjs');
+  const realEnsure = path.join(repoRoot, 'scripts', 'workspaces', 'ensureWorkspacePackagesBuilt.mjs');
+  assert.ok(existsSync(realPm), `real pm.mjs missing at ${realPm}`);
+  assert.ok(existsSync(realRds), `real runtime_daemon_state.mjs missing at ${realRds}`);
+  assert.ok(existsSync(realEnsure), `real ensureWorkspacePackagesBuilt.mjs missing at ${realEnsure}`);
+
+  const pmContent = readFileSync(realPm, 'utf8');
+  assert.ok(
+    pmContent.includes('../../../../../scripts/workspaces/ensureWorkspacePackagesBuilt.mjs'),
+    'pm.mjs no longer imports the repo-root workspace helper — postpack rewrite may be stale',
+  );
+
+  const rdsContent = readFileSync(realRds, 'utf8');
+  assert.ok(
+    rdsContent.includes('../../../../../packages/cli-common/processInstance.mjs'),
+    'runtime_daemon_state.mjs no longer imports the repo-root cli-common helper — postpack rewrite may be stale',
+  );
+
+  const ensureContent = readFileSync(realEnsure, 'utf8');
+  assert.ok(
+    ensureContent.includes('../../apps/stack/scripts/utils/'),
+    'ensureWorkspacePackagesBuilt.mjs no longer reaches back into apps/stack/scripts/utils — postpack rewrite may be stale',
+  );
+});

--- a/scripts/release/release-assets-e2e/bin/stack-entrypoint.sh
+++ b/scripts/release/release-assets-e2e/bin/stack-entrypoint.sh
@@ -119,6 +119,9 @@ setup_args=(
 
 if [[ -n "$HSTACK_HAPPIER_REPO" ]]; then
   setup_args+=( "--happier-repo=$HSTACK_HAPPIER_REPO" )
+  # Bind-mounted repos are owned by the host user; git refuses to read them inside the container
+  # (dubious ownership), which breaks the `git clone <repo>` in hstack setup. Trust them here.
+  git config --global --add safe.directory '*' 2>/dev/null || true
 fi
 
 if [[ "$HSTACK_E2E_WITH_UI" != "1" ]]; then
@@ -218,11 +221,20 @@ kill_phase1_no_ui_supervisor() {
 
 kill_phase1_server_light() {
   # If the phase1 supervisor is killed abruptly, the server-light process can linger and keep the port busy.
+  # Match on `main.light.ts` (stable across invocations): dev uses `--import tsx .../main.light.ts`,
+  # from-source uses `tsx --tsconfig ... ./sources/main.light.ts`. The old `--import tsx ./sources/main.light.ts`
+  # pattern missed the from-source invocation, leaving port 3005 occupied and tripping phase2's topology guard
+  # (ESERVERTOPOLOGYUNOWNED: healthy-unowned + --restart).
   local pids_raw
   local pids
-  pids_raw="$(ps -eo pid,args -ww | awk '/--import tsx \.\/sources\/main\.light\.ts/ {print $1}' || true)"
+  pids_raw="$(ps -eo pid,args -ww | awk '/main\.light\.ts/ {print $1}' || true)"
   pids="$(echo "$pids_raw" | tr '\n' ' ' | xargs echo 2>/dev/null || true)"
   if [[ -z "$pids" ]]; then
+    # Fall back to an anchored pkill (procps) if ps parsing missed it.
+    if pkill -9 -f 'main\.light\.ts' >/dev/null 2>&1; then
+      echo "[stack] killing phase1 server-light (pkill fallback)"
+      sleep 1
+    fi
     return 0
   fi
   echo "[stack] killing phase1 server-light: $pids"


### PR DESCRIPTION
## Summary

The `scripts/release/release-assets-e2e` local-monorepo smoke (`run.sh --mode=local --monorepo=local`) was broken by two independent issues. Either alone blocks the stack container; together they prevented the smoke from ever passing. This PR fixes both — they are **co-required** for the smoke to reach `[npm-e2e-smoke] OK`.

## 1. Stack packaging: repo-root escape targets (`apps/stack`)

`apps/stack/scripts/` reaches repo-root siblings through `../../../../../` imports. These resolve at the monorepo root in dev but, once `@happier-dev/stack` is `npm pack`-ed + installed standalone, the five `../` escape the package to the npm install root — `ENOENT`. npm's `files` glob can't traverse parent dirs to include them either. Two escape targets exist (comprehensive grep found no others):

- \`scripts/utils/proc/pm.mjs\` (+ packed test) → \`scripts/workspaces/{ensureWorkspacePackagesBuilt,execYarnCommand,workspacePackageBuildLock}.mjs\`
- \`scripts/utils/stack/runtime_daemon_state.mjs\` → \`packages/cli-common/processInstance.mjs\` (not bundled/exported by cli-common, so it must be vendored too)

**Fix**: add a `postpack` (mirroring `apps/cli`'s `patchPackedTarballForBun`) that unpacks the tarball produced by `npm pack`, copies each escaped file into `package/scripts/utils/workspaces/`, rewrites every escaping import to the in-package copy, rewrites the helpers' own back-imports into `apps/stack/scripts/utils/*`, and repacks. Cross-device safe (`copyFileSync`, not `renameSync`). Repo-root sources stay canonical for monorepo builds.

The escaping imports were introduced by `ed1cf5955` ("refactor(stack): centralize dependency refresh admission"); the published `0.2.1-preview` predates them.

## 2. Entrypoint: git dubious ownership + phase1 server-light kill (`scripts/release/release-assets-e2e`)

**2a. git dubious ownership.** The host repo is bind-mounted read-only into the container as `/repo`, owned by the host user. git refuses to read it inside the container (different UID) → \`git clone <repo>\` in `hstack setup` fails ("detected dubious ownership" + "Could not read from remote repository"). Set `safe.directory '*'` when `HSTACK_HAPPIER_REPO` is wired.

**2b. `kill_phase1_server_light` missed the from-source invocation.** The function matched \`--import tsx ./sources/main.light.ts\` (the *dev* invocation), but from-source the server-light runs \`tsx --tsconfig ./tsconfig.json ./sources/main.light.ts\` (`apps/server` \`start:light\`). The awk found nothing, the function returned early with **no fallback**, phase1's server-light survived into phase2 holding port 3005, and phase2's \`start --restart\` tripped \`decideDevStartupTopology\`'s guard (\`ESERVERTOPOLOGYUNOWNED: healthy-unowned + restart\`). Match the stable \`main.light.ts\` (covers dev + from-source) and add a `pkill` fallback mirroring \`kill_phase1_no_ui_supervisor\`.

## Validation

End-to-end \`run.sh --mode=local --monorepo=local --no-remote-daemon --no-remote-server\` now reaches \`[npm-e2e-smoke] OK\` (exit 0): the stack container builds from source, the phase1 server-light is killed (\`killing phase1 server-light: <pids>\`), phase2 starts cleanly, the daemon registers, and the connectivity smoke passes.

- `patchPackedTarballForWorkspaces.test.mjs`: 6/6 node:test cases (rewrite fns, escape map, extracted-dir transform, real tarball round-trip, source-drift guards for both escaping imports).
- Real \`npm pack\` of \`apps/stack\`: both escapes fixed, all 4 files vendored, prepack's bundled \`@happier-dev/*\` deps preserved.

## Notes

- The two fixes touch disjoint files; keeping them in one PR because the smoke only passes with both.
- Test-first: the postpack transform is covered by node:test; the entrypoint changes are bash + validated by the composed e2e smoke (no unit harness for the entrypoint).

## Checklist

- [x] Full local-monorepo e2e smoke passes (exit 0)
- [x] postpack node:test suite (6/6)
- [x] No unrelated changes; primary worktree untouched

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789003977&installation_model_id=20481&pr_number=238&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F238&signature=47c1dc5437b35184b396c73e65ca2153330b623e9ed117b1013d9a82c7267500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix local-monorepo e2e smoke by adding stack postpack tarball patching and entrypoint fixes
> - Adds a `postpack` lifecycle script to `apps/stack` that vendors workspace helper scripts into the packed tarball and rewrites their imports so the package works standalone outside the monorepo.
> - Implements [patchPackedTarballForWorkspaces.mjs](https://github.com/happier-dev/happier/pull/238/files#diff-6d8a0ef771b31e717a2c602b2a34bd2f7fb5a6ff736f1b7aeaaf6f471039a659) which extracts the tarball, copies vendored helpers into `scripts/utils/workspaces/`, rewrites escaping imports to point at vendored copies, then repacks in-place.
> - Fixes [stack-entrypoint.sh](https://github.com/happier-dev/happier/pull/238/files#diff-409c2aef27b1df118e3e28d11eed8f066a35e6486c84d69c6bd40e2255d3ff9b) to trust bind-mounted repo directories via `git config --global --add safe.directory '*'`, avoiding dubious ownership errors in the container.
> - Broadens the `kill_phase1_server_light` process match pattern and adds a `pkill` fallback to reliably terminate lingering server-light processes and prevent port conflicts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8478bb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->