### PR TITLE
fix(ui): web login/restore QR unscannable — finder rings vanish on transparent background

### DIFF
--- a/apps/ui/sources/__tests__/routes/(app)/restore/index.spec.tsx
+++ b/apps/ui/sources/__tests__/routes/(app)/restore/index.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import renderer, { act } from 'react-test-renderer';
 import { renderScreen } from '@/dev/testkit';
+import { lightTheme } from '@/theme';
 import { installRestoreRouteCommonModuleMocks, resetRestoreRouteTestState } from './restoreRouteTestHelpers';
 
 
@@ -242,7 +243,7 @@ describe('/restore', () => {
         }
     });
 
-    it('renders the QR image without painting a separate white card behind the unauth shell', async () => {
+    it('renders the QR image on an opaque themed surface so finder rings stay scannable', async () => {
         vi.resetModules();
         const { authQRStart } = await import('@/auth/flows/qrStart');
         const { authQRWait } = await import('@/auth/flows/qrWait');
@@ -258,7 +259,7 @@ describe('/restore', () => {
             await act(async () => {});
 
             const qrCode = screen.findByType('QRCode' as never);
-            expect(qrCode.props.backgroundColor).toBe('transparent');
+            expect(qrCode.props.backgroundColor).toBe(lightTheme.colors.surface.base);
         } finally {
             act(() => {
                 tree?.unmount();

--- a/apps/ui/sources/components/account/restore/RestoreQrView.tsx
+++ b/apps/ui/sources/components/account/restore/RestoreQrView.tsx
@@ -208,7 +208,7 @@ export const RestoreQrView = React.memo(function RestoreQrView() {
                                 data={buildAccountConnectDeepLink({ publicKeyB64Url: encodeBase64(keypair.publicKey, 'base64url') })}
                                 size={260}
                                 foregroundColor={theme.colors.text.primary}
-                                backgroundColor="transparent"
+                                backgroundColor={theme.colors.surface.base}
                             />
                         )}
                     </View>

--- a/apps/ui/sources/components/qr/QRCode.web.test.tsx
+++ b/apps/ui/sources/components/qr/QRCode.web.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { describe, expect, it } from 'vitest';
-import renderer, { act } from 'react-test-renderer';
-import type { ReactTestRenderer } from 'react-test-renderer';
+import { renderScreen } from '@/dev/testkit';
 import { QRCode } from './QRCode.web';
 
 type ReactActEnvironmentGlobal = typeof globalThis & {
@@ -10,46 +9,36 @@ type ReactActEnvironmentGlobal = typeof globalThis & {
 (globalThis as ReactActEnvironmentGlobal).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe('QRCode.web', () => {
-    it('keeps finder rings scannable when backgroundColor is transparent', () => {
-        let tree: ReactTestRenderer | undefined;
-        act(() => {
-            tree = renderer.create(
-                <QRCode
-                    data="happier:///account/connect?publicKey=test"
-                    size={260}
-                    foregroundColor="#FFFFFF"
-                    backgroundColor="transparent"
-                />,
-            );
-        });
-        if (!tree) throw new Error('Expected renderer');
+    it('keeps finder rings scannable when backgroundColor is transparent', async () => {
+        const screen = await renderScreen(
+            <QRCode
+                data="happier:///account/connect?publicKey=test"
+                size={260}
+                foregroundColor="#FFFFFF"
+                backgroundColor="transparent"
+            />,
+        );
 
-        try {
-            // The quiet-zone background rect is the only shape allowed to use the
-            // background color. Finder rings painted with the background color
-            // disappear on transparent and leave solid 7x7 squares.
-            const backgroundFills = tree.root.findAll((node) => (
-                typeof node.type === 'string' && node.props?.fill === 'transparent'
-            ));
-            expect(backgroundFills).toHaveLength(1);
-            expect(backgroundFills[0].type).toBe('rect');
-            expect(backgroundFills[0].props.width).toBe(260);
-            expect(backgroundFills[0].props.height).toBe(260);
+        // The quiet-zone background rect is the only shape allowed to use the
+        // background color. Finder rings painted with the background color
+        // disappear on transparent and leave solid 7x7 squares.
+        const backgroundFills = screen.findAll((node) => (
+            typeof node.type === 'string' && node.props?.fill === 'transparent'
+        ));
+        expect(backgroundFills).toHaveLength(1);
+        expect(backgroundFills[0].type).toBe('rect');
+        expect(backgroundFills[0].props.width).toBe(260);
+        expect(backgroundFills[0].props.height).toBe(260);
 
-            // Each of the three finder patterns keeps its ring as a foreground
-            // shape with a punched-out hole (outer + inner subpath, even-odd),
-            // independent of the background color.
-            const ringPaths = tree.root.findAll((node) => (
-                node.type === 'path'
-                && node.props?.fillRule === 'evenodd'
-                && node.props?.fill === '#FFFFFF'
-                && (String(node.props?.d).match(/M /g) ?? []).length === 2
-            ));
-            expect(ringPaths).toHaveLength(3);
-        } finally {
-            act(() => {
-                tree?.unmount();
-            });
-        }
+        // Each of the three finder patterns keeps its ring as a foreground
+        // shape with a punched-out hole (outer + inner subpath, even-odd),
+        // independent of the background color.
+        const ringPaths = screen.findAll((node) => (
+            node.type === 'path'
+            && node.props?.fillRule === 'evenodd'
+            && node.props?.fill === '#FFFFFF'
+            && (String(node.props?.d).match(/M /g) ?? []).length === 2
+        ));
+        expect(ringPaths).toHaveLength(3);
     });
 });

--- a/apps/ui/sources/components/qr/QRCode.web.test.tsx
+++ b/apps/ui/sources/components/qr/QRCode.web.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import renderer, { act } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { QRCode } from './QRCode.web';
+
+type ReactActEnvironmentGlobal = typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+(globalThis as ReactActEnvironmentGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('QRCode.web', () => {
+    it('keeps finder rings scannable when backgroundColor is transparent', () => {
+        let tree: ReactTestRenderer | undefined;
+        act(() => {
+            tree = renderer.create(
+                <QRCode
+                    data="happier:///account/connect?publicKey=test"
+                    size={260}
+                    foregroundColor="#FFFFFF"
+                    backgroundColor="transparent"
+                />,
+            );
+        });
+        if (!tree) throw new Error('Expected renderer');
+
+        try {
+            // The quiet-zone background rect is the only shape allowed to use the
+            // background color. Finder rings painted with the background color
+            // disappear on transparent and leave solid 7x7 squares.
+            const backgroundFills = tree.root.findAll((node) => (
+                typeof node.type === 'string' && node.props?.fill === 'transparent'
+            ));
+            expect(backgroundFills).toHaveLength(1);
+            expect(backgroundFills[0].type).toBe('rect');
+            expect(backgroundFills[0].props.width).toBe(260);
+            expect(backgroundFills[0].props.height).toBe(260);
+
+            // Each of the three finder patterns keeps its ring as a foreground
+            // shape with a punched-out hole (outer + inner subpath, even-odd),
+            // independent of the background color.
+            const ringPaths = tree.root.findAll((node) => (
+                node.type === 'path'
+                && node.props?.fillRule === 'evenodd'
+                && node.props?.fill === '#FFFFFF'
+                && (String(node.props?.d).match(/M /g) ?? []).length === 2
+            ));
+            expect(ringPaths).toHaveLength(3);
+        } finally {
+            act(() => {
+                tree?.unmount();
+            });
+        }
+    });
+});

--- a/apps/ui/sources/components/qr/QRCode.web.tsx
+++ b/apps/ui/sources/components/qr/QRCode.web.tsx
@@ -27,6 +27,19 @@ function getRectPath(x: number, y: number, w: number, h: number,
             Z`;
 }
 
+// Compound even-odd path for a locator ring: outer 7x7 rounded square with the
+// inner 5x5 punched out. The ring is painted purely in the foreground color so
+// a transparent background cannot erase it (mirrors DiffRect in QRCode.tsx).
+function getLocatorRingPath(x: number, y: number, moduleSize: number, baseRadius: number): string {
+    const outerRadius = moduleSize * (baseRadius + 1);
+    const innerRadius = moduleSize * baseRadius;
+    const outer = getRectPath(x, y, 7 * moduleSize, 7 * moduleSize,
+        outerRadius, outerRadius, outerRadius, outerRadius);
+    const inner = getRectPath(x + moduleSize, y + moduleSize, 5 * moduleSize, 5 * moduleSize,
+        innerRadius, innerRadius, innerRadius, innerRadius);
+    return `${outer} ${inner}`;
+}
+
 interface QRCodeProps {
     data: string;
     size?: number;
@@ -138,23 +151,10 @@ export const QRCode = React.memo((props: QRCodeProps) => {
                 {modules}
 
                 {/* Top-left locator pattern */}
-                <rect
-                    x={2 * moduleSize}
-                    y={2 * moduleSize}
-                    width={7 * moduleSize}
-                    height={7 * moduleSize}
-                    rx={moduleSize * (baseRadius + 1)}
-                    ry={moduleSize * (baseRadius + 1)}
+                <path
+                    d={getLocatorRingPath(2 * moduleSize, 2 * moduleSize, moduleSize, baseRadius)}
                     fill={foregroundColor}
-                />
-                <rect
-                    x={3 * moduleSize}
-                    y={3 * moduleSize}
-                    width={5 * moduleSize}
-                    height={5 * moduleSize}
-                    rx={moduleSize * baseRadius}
-                    ry={moduleSize * baseRadius}
-                    fill={backgroundColor}
+                    fillRule="evenodd"
                 />
                 <rect
                     x={4 * moduleSize}
@@ -167,23 +167,10 @@ export const QRCode = React.memo((props: QRCodeProps) => {
                 />
 
                 {/* Top-right locator pattern */}
-                <rect
-                    x={(qrMatrix.size - 7 + 2) * moduleSize}
-                    y={2 * moduleSize}
-                    width={7 * moduleSize}
-                    height={7 * moduleSize}
-                    rx={moduleSize * (baseRadius + 1)}
-                    ry={moduleSize * (baseRadius + 1)}
+                <path
+                    d={getLocatorRingPath((qrMatrix.size - 7 + 2) * moduleSize, 2 * moduleSize, moduleSize, baseRadius)}
                     fill={foregroundColor}
-                />
-                <rect
-                    x={(qrMatrix.size - 7 + 1 + 2) * moduleSize}
-                    y={3 * moduleSize}
-                    width={5 * moduleSize}
-                    height={5 * moduleSize}
-                    rx={moduleSize * baseRadius}
-                    ry={moduleSize * baseRadius}
-                    fill={backgroundColor}
+                    fillRule="evenodd"
                 />
                 <rect
                     x={(qrMatrix.size - 7 + 2 + 2) * moduleSize}
@@ -196,23 +183,10 @@ export const QRCode = React.memo((props: QRCodeProps) => {
                 />
 
                 {/* Bottom-left locator pattern */}
-                <rect
-                    x={2 * moduleSize}
-                    y={(qrMatrix.size - 7 + 2) * moduleSize}
-                    width={7 * moduleSize}
-                    height={7 * moduleSize}
-                    rx={moduleSize * (baseRadius + 1)}
-                    ry={moduleSize * (baseRadius + 1)}
+                <path
+                    d={getLocatorRingPath(2 * moduleSize, (qrMatrix.size - 7 + 2) * moduleSize, moduleSize, baseRadius)}
                     fill={foregroundColor}
-                />
-                <rect
-                    x={3 * moduleSize}
-                    y={(qrMatrix.size - 7 + 1 + 2) * moduleSize}
-                    width={5 * moduleSize}
-                    height={5 * moduleSize}
-                    rx={moduleSize * baseRadius}
-                    ry={moduleSize * baseRadius}
-                    fill={backgroundColor}
+                    fillRule="evenodd"
                 />
                 <rect
                     x={4 * moduleSize}


### PR DESCRIPTION
## Problem

The login/restore QR code on web (`/restore`) is unscannable: all three corner
finder patterns render as solid squares instead of rings.

Reproduced on ui-web v0.2.10-dev.52 (self-hosted relay), Vivaldi on Windows,
both light and dark themes.

## Cause

`apps/ui/sources/components/qr/QRCode.web.tsx` painted each finder pattern as
three stacked rects: a 7×7 foreground square, a 5×5 rect filled with the
`backgroundColor` prop (the "ring"), and a 3×3 foreground center.
`RestoreQrView` passed `backgroundColor="transparent"`, so the 5×5 overpaint
was invisible and the 7×7 square showed through solid.

The native `QRCode.tsx` was never affected — it already draws the ring as a
Skia `DiffRect` (outer minus inner), independent of the background color.

## Fix

1. **Harden `QRCode.web.tsx`**: draw each finder ring as a single foreground
   `<path fillRule="evenodd">` (outer 7×7 rounded square with the inner 5×5
   punched out), mirroring the native `DiffRect` approach. A transparent
   background can no longer erase the rings. Geometry (radii/offsets) is
   unchanged, so call sites with opaque backgrounds render identically.
2. **`RestoreQrView`**: pass `theme.colors.surface.base` instead of
   `"transparent"`, matching `AddPhoneSettingsView` (the working reference),
   so the code also keeps a proper opaque quiet zone in both themes. This is
   still theme-dark in dark mode, so no white card appears behind the unauth
   shell (the apparent intent of the previous `transparent`).

Audited the remaining `QRCode` call sites (`PublicLinkDialog`, `dev/qr-test`,
`AddPhoneSettingsView`) — none pass a transparent background.

## How to test

- `apps/ui`: `yarn vitest run sources/components/qr/QRCode.web.test.tsx "sources/__tests__/routes/(app)/restore/index.spec.tsx"`
  - New `QRCode.web.test.tsx` asserts only the quiet-zone rect uses the
    background color and that the three even-odd ring paths exist (fails on
    the previous implementation).
  - The existing `/restore` route spec previously asserted
    `backgroundColor === 'transparent'` (locking in the bug); it now expects
    the opaque themed surface.
- Manual: open `/restore` on web, dark or light theme — the QR now has ring
  finder patterns and scans (previously solid squares, unscannable).
- `yarn typecheck` clean; the restore spec folder and AddPhoneSettingsView
  tests pass. (`QrCodeScannerView.test.tsx` has one failing test on current
  `dev` unrelated to this change — reproduced on a clean `dev` checkout.)

## Screenshots / recording (UI changes)

<img width="974" height="1052" alt="image" src="https://github.com/user-attachments/assets/17b81ff3-651e-4c27-b432-9d02090ead42" />

## AI assistance

Implemented with Claude Code. I diagnosed the root cause myself first
(devtools: setting the 5×5 ring rect to an opaque fill made the QR scan) and
instructed the agent to (a) verify the diagnosis, (b) mirror the working
AddPhoneSettingsView call site for the minimal fix, and (c) align the web
locator rendering with the native Skia `DiffRect` layering so transparent
backgrounds can't break it again. I personally reproduced the bug and
verified the opaque-ring fix.

## Checklist

- [x] PR targets `dev` (not `main`)
- [x] I linked an issue/discussion (recommended for non-trivial changes) - I did not, trivial change
- [x] I added/updated tests where feasible (or explained why not)
- [x] I updated docs if behavior changed - No behavior change
- [x] If AI-assisted, I disclosed it and listed what I personally verified

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789032178&installation_model_id=20481&pr_number=241&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F241&signature=23ccd9af95164907cdd4064f893e5c7ea9c43d30a39f45fe994347fc4b25651f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix QR code finder rings vanishing on transparent background in web login/restore
> - The three finder (locator) rings in the web QR code were rendered using a foreground outer rect and a background-colored inner rect. When `backgroundColor` is transparent, the inner rect erased the ring, making the QR unscannable.
> - [`QRCode.web.tsx`](https://github.com/happier-dev/happier/pull/241/files#diff-9366f7888662bcba162ab005ebcb22e665ad34624e8d2118a22fe12909a57bff) replaces this approach with a single compound even-odd path per ring (outer 7×7 + inner 5×5 rounded rects) filled in the foreground color, so the ring center is transparent without overwriting what's beneath.
> - [`RestoreQrView.tsx`](https://github.com/happier-dev/happier/pull/241/files#diff-6fe286f6fac2a1139c60025feb3946987472c74f9384da30420d4949e0380168) now passes `theme.colors.surface.base` as `backgroundColor` instead of `'transparent'`, giving the QR a legible opaque surface on the restore screen.
> - Behavioral Change: the restore/login QR now renders on a themed surface color rather than a transparent background.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd96b23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - QR codes in the restore flow now use the appropriate themed surface color instead of a transparent background.
  - Improved QR code locator patterns for clearer, more consistent rendering, especially when displayed on transparent backgrounds.
  - Preserved the correct finder-ring appearance across all three QR code corners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->