### PR TITLE
fix(profiles): refresh MiniMax model id

### DIFF
--- a/apps/cli/src/settings/profiles/buildProfileEnvOverlay.test.ts
+++ b/apps/cli/src/settings/profiles/buildProfileEnvOverlay.test.ts
@@ -203,16 +203,13 @@ describe('buildProfileEnvOverlay with the shipped MiniMax built-in profiles', ()
       expect(result.envOverlayExpanded).toMatchObject({
         ANTHROPIC_BASE_URL: expectedBaseUrl,
         ANTHROPIC_AUTH_TOKEN: 'mm-from-env',
-        // The `[1m]` suffix and the compaction window are a pair: MiniMax's Claude
-        // Code guide specifies both, and without them sessions compact against the
-        // 200K the endpoint advertises rather than M3's 1M.
-        ANTHROPIC_MODEL: 'MiniMax-M3[1m]',
+        ANTHROPIC_MODEL: 'MiniMax-M3',
         CLAUDE_CODE_AUTO_COMPACT_WINDOW: '1000000',
         // Claude Code resolves the opus/sonnet/haiku aliases through these keys.
         // Without them a model switch would send "opus"/"sonnet" upstream, which
         // MiniMax rejects.
-        ANTHROPIC_DEFAULT_OPUS_MODEL: 'MiniMax-M3[1m]',
-        ANTHROPIC_DEFAULT_SONNET_MODEL: 'MiniMax-M3[1m]',
+        ANTHROPIC_DEFAULT_OPUS_MODEL: 'MiniMax-M3',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'MiniMax-M3',
         ANTHROPIC_DEFAULT_HAIKU_MODEL: 'MiniMax-M2.7',
         API_TIMEOUT_MS: '600000',
       });

--- a/apps/ui/sources/sync/domains/profiles/profileDocumentation.ts
+++ b/apps/ui/sources/sync/domains/profiles/profileDocumentation.ts
@@ -174,24 +174,24 @@ export Z_AI_HAIKU_MODEL="GLM-4.5-Air"`,
                     {
                         name: 'MINIMAX_AUTO_COMPACT_WINDOW',
                         expectedValue: '1000000',
-                        description: 'Context capacity used for auto-compaction. Required alongside the [1m] model id to get M3\'s full 1M window.',
+                        description: 'Context capacity used for auto-compaction. Matches M3\'s 1M context window.',
                         isSecret: false,
                     },
                     {
                         name: 'MINIMAX_MODEL',
-                        expectedValue: 'MiniMax-M3[1m]',
-                        description: 'Default model. The [1m] suffix selects M3\'s 1M-context variant, as MiniMax\'s Claude Code guide specifies.',
+                        expectedValue: 'MiniMax-M3',
+                        description: 'Default model with a 1M-token context window.',
                         isSecret: false,
                     },
                     {
                         name: 'MINIMAX_OPUS_MODEL',
-                        expectedValue: 'MiniMax-M3[1m]',
+                        expectedValue: 'MiniMax-M3',
                         description: 'Model used when the session selects the Opus tier',
                         isSecret: false,
                     },
                     {
                         name: 'MINIMAX_SONNET_MODEL',
-                        expectedValue: 'MiniMax-M3[1m]',
+                        expectedValue: 'MiniMax-M3',
                         description: 'Model used when the session selects the Sonnet tier',
                         isSecret: false,
                     },
@@ -213,15 +213,14 @@ export MINIMAX_BASE_URL="https://api.minimax.io/anthropic"
 export MINIMAX_AUTH_TOKEN="YOUR_MINIMAX_API_KEY"
 export MINIMAX_API_TIMEOUT_MS="600000"
 export MINIMAX_AUTO_COMPACT_WINDOW="1000000"
-export MINIMAX_MODEL="MiniMax-M3[1m]"
-export MINIMAX_OPUS_MODEL="MiniMax-M3[1m]"
-export MINIMAX_SONNET_MODEL="MiniMax-M3[1m]"
+export MINIMAX_MODEL="MiniMax-M3"
+export MINIMAX_OPUS_MODEL="MiniMax-M3"
+export MINIMAX_SONNET_MODEL="MiniMax-M3"
 export MINIMAX_HAIKU_MODEL="MiniMax-M2.7"
 export MINIMAX_CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
 
 # Model selection guide:
-# - MiniMax-M3[1m]: Default. M3 with its 1M-context variant selected.
-# - MiniMax-M3: Same model without the extended-context suffix (200K).
+# - MiniMax-M3: Default model with a 1M-token context window.
 # - MiniMax-M2.7: Faster, lighter model for background work.`,
             };
         case 'minimax-cn':
@@ -250,24 +249,24 @@ export MINIMAX_CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
                     {
                         name: 'MINIMAX_CN_AUTO_COMPACT_WINDOW',
                         expectedValue: '1000000',
-                        description: 'Context capacity used for auto-compaction. Required alongside the [1m] model id to get M3\'s full 1M window.',
+                        description: 'Context capacity used for auto-compaction. Matches M3\'s 1M context window.',
                         isSecret: false,
                     },
                     {
                         name: 'MINIMAX_CN_MODEL',
-                        expectedValue: 'MiniMax-M3[1m]',
-                        description: 'Default model. The [1m] suffix selects M3\'s 1M-context variant, as MiniMax\'s Claude Code guide specifies.',
+                        expectedValue: 'MiniMax-M3',
+                        description: 'Default model with a 1M-token context window.',
                         isSecret: false,
                     },
                     {
                         name: 'MINIMAX_CN_OPUS_MODEL',
-                        expectedValue: 'MiniMax-M3[1m]',
+                        expectedValue: 'MiniMax-M3',
                         description: 'Model used when the session selects the Opus tier',
                         isSecret: false,
                     },
                     {
                         name: 'MINIMAX_CN_SONNET_MODEL',
-                        expectedValue: 'MiniMax-M3[1m]',
+                        expectedValue: 'MiniMax-M3',
                         description: 'Model used when the session selects the Sonnet tier',
                         isSecret: false,
                     },
@@ -289,9 +288,9 @@ export MINIMAX_CN_BASE_URL="https://api.minimaxi.com/anthropic"
 export MINIMAX_CN_AUTH_TOKEN="YOUR_MINIMAX_API_KEY"
 export MINIMAX_CN_API_TIMEOUT_MS="600000"
 export MINIMAX_CN_AUTO_COMPACT_WINDOW="1000000"
-export MINIMAX_CN_MODEL="MiniMax-M3[1m]"
-export MINIMAX_CN_OPUS_MODEL="MiniMax-M3[1m]"
-export MINIMAX_CN_SONNET_MODEL="MiniMax-M3[1m]"
+export MINIMAX_CN_MODEL="MiniMax-M3"
+export MINIMAX_CN_OPUS_MODEL="MiniMax-M3"
+export MINIMAX_CN_SONNET_MODEL="MiniMax-M3"
 export MINIMAX_CN_HAIKU_MODEL="MiniMax-M2.7"
 export MINIMAX_CN_CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"`,
             };

--- a/packages/protocol/src/providers/claude/builtInBackendProfiles.ts
+++ b/packages/protocol/src/providers/claude/builtInBackendProfiles.ts
@@ -78,13 +78,11 @@ export const CLAUDE_BUILT_IN_BACKEND_PROFILES: ReadonlyArray<AIBackendProfile> =
       { name: 'ANTHROPIC_BASE_URL', value: '${MINIMAX_BASE_URL:-https://api.minimax.io/anthropic}' },
       { name: 'ANTHROPIC_AUTH_TOKEN', value: '${MINIMAX_AUTH_TOKEN}' },
       { name: 'API_TIMEOUT_MS', value: '${MINIMAX_API_TIMEOUT_MS:-600000}' },
-      // MiniMax's Claude Code guide pairs the `[1m]` extended-context model id with
-      // an explicit compaction window; without both, sessions compact against the
-      // 200K the endpoint advertises by default instead of M3's 1M.
+      // Match Claude Code's compaction window to M3's 1M context capacity.
       { name: 'CLAUDE_CODE_AUTO_COMPACT_WINDOW', value: '${MINIMAX_AUTO_COMPACT_WINDOW:-1000000}' },
-      { name: 'ANTHROPIC_MODEL', value: '${MINIMAX_MODEL:-MiniMax-M3[1m]}' },
-      { name: 'ANTHROPIC_DEFAULT_OPUS_MODEL', value: '${MINIMAX_OPUS_MODEL:-MiniMax-M3[1m]}' },
-      { name: 'ANTHROPIC_DEFAULT_SONNET_MODEL', value: '${MINIMAX_SONNET_MODEL:-MiniMax-M3[1m]}' },
+      { name: 'ANTHROPIC_MODEL', value: '${MINIMAX_MODEL:-MiniMax-M3}' },
+      { name: 'ANTHROPIC_DEFAULT_OPUS_MODEL', value: '${MINIMAX_OPUS_MODEL:-MiniMax-M3}' },
+      { name: 'ANTHROPIC_DEFAULT_SONNET_MODEL', value: '${MINIMAX_SONNET_MODEL:-MiniMax-M3}' },
       // MiniMax maps every tier to M3; we keep the cheaper documented M2.7 for
       // Haiku-class background work, which is what that tier exists for.
       { name: 'ANTHROPIC_DEFAULT_HAIKU_MODEL', value: '${MINIMAX_HAIKU_MODEL:-MiniMax-M2.7}' },
@@ -111,9 +109,9 @@ export const CLAUDE_BUILT_IN_BACKEND_PROFILES: ReadonlyArray<AIBackendProfile> =
       { name: 'ANTHROPIC_AUTH_TOKEN', value: '${MINIMAX_CN_AUTH_TOKEN}' },
       { name: 'API_TIMEOUT_MS', value: '${MINIMAX_CN_API_TIMEOUT_MS:-600000}' },
       { name: 'CLAUDE_CODE_AUTO_COMPACT_WINDOW', value: '${MINIMAX_CN_AUTO_COMPACT_WINDOW:-1000000}' },
-      { name: 'ANTHROPIC_MODEL', value: '${MINIMAX_CN_MODEL:-MiniMax-M3[1m]}' },
-      { name: 'ANTHROPIC_DEFAULT_OPUS_MODEL', value: '${MINIMAX_CN_OPUS_MODEL:-MiniMax-M3[1m]}' },
-      { name: 'ANTHROPIC_DEFAULT_SONNET_MODEL', value: '${MINIMAX_CN_SONNET_MODEL:-MiniMax-M3[1m]}' },
+      { name: 'ANTHROPIC_MODEL', value: '${MINIMAX_CN_MODEL:-MiniMax-M3}' },
+      { name: 'ANTHROPIC_DEFAULT_OPUS_MODEL', value: '${MINIMAX_CN_OPUS_MODEL:-MiniMax-M3}' },
+      { name: 'ANTHROPIC_DEFAULT_SONNET_MODEL', value: '${MINIMAX_CN_SONNET_MODEL:-MiniMax-M3}' },
       { name: 'ANTHROPIC_DEFAULT_HAIKU_MODEL', value: '${MINIMAX_CN_HAIKU_MODEL:-MiniMax-M2.7}' },
       { name: 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC', value: '${MINIMAX_CN_CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:-1}' },
     ],


### PR DESCRIPTION
Reason: The shipped global and China MiniMax profiles use a suffixed model identifier instead of the current M3 identifier.

- Use `MiniMax-M3` for the default, Opus, and Sonnet mappings in both profiles.
- Keep the 1,000,000-token compaction window and the M2.7 secondary-tier mapping unchanged.
- Update the setup documentation and focused environment-overlay expectations.

Checks:
- `node --experimental-strip-types --check packages/protocol/src/providers/claude/builtInBackendProfiles.ts`
- `node --experimental-strip-types --check apps/ui/sources/sync/domains/profiles/profileDocumentation.ts`
- `node --experimental-strip-types --check apps/cli/src/settings/profiles/buildProfileEnvOverlay.test.ts`
- Exact source assertions for `MiniMax-M3`, `MiniMax-M2.7`, and removal of the suffixed profile identifier
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789161427&installation_model_id=20481&pr_number=255&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F255&signature=f17fba1553869f91da743dabc9414dd632dc867959f99ebd04370623080feefa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MiniMax model configurations to use the correct `MiniMax-M3` identifier.
  * Preserved the 1-million-token context and automatic compaction behavior.
  * Updated MiniMax documentation and model-selection examples to reflect the corrected configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update MiniMax model IDs to remove `[1m]` suffix from built-in profiles
> Changes the default model identifiers for MiniMax and MiniMax CN built-in profiles from `MiniMax-M3[1m]` to `MiniMax-M3` across profile definitions, documentation, and tests. The 1M token context window is retained; only the model ID string is updated to match MiniMax's current API naming.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1830ee8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->