### PR TITLE
fix(ui-appearance): apply Text Size and Content Width to the transcript on web

### DIFF
--- a/apps/ui/sources/components/markdown/enriched/useEnrichedMarkdownStyle.test.ts
+++ b/apps/ui/sources/components/markdown/enriched/useEnrichedMarkdownStyle.test.ts
@@ -1,3 +1,4 @@
+import type { TextStyle } from 'react-native';
 import { describe, expect, it } from 'vitest';
 
 import { buildEnrichedMarkdownStyle } from './useEnrichedMarkdownStyle';
@@ -8,10 +9,12 @@ const colors = {
     border: { default: '#cccccc' },
 } as const;
 
+type WebUnistylesTextStyle = TextStyle & Record<`unistyles_${string}`, unknown>;
+
 // Mirrors the transcript's real web textStyle: a Unistyles-registered style whose numeric
 // metrics are non-enumerable, non-writable (but configurable) data properties.
-function createWebUnistylesTextStyle(values: Record<string, number>): unknown {
-    const style: Record<string, unknown> = {};
+function createWebUnistylesTextStyle(values: Readonly<Record<'fontSize' | 'lineHeight', number>>): WebUnistylesTextStyle {
+    const style: WebUnistylesTextStyle = { unistyles_test: {} };
     Object.defineProperties(
         style,
         Object.fromEntries(Object.entries(values).map(([key, value]) => [key, {
@@ -20,7 +23,6 @@ function createWebUnistylesTextStyle(values: Record<string, number>): unknown {
             configurable: true,
         }])),
     );
-    style.unistyles_test = {};
     return style;
 }
 
@@ -43,7 +45,7 @@ describe('buildEnrichedMarkdownStyle uiFontScale', () => {
             colors,
             profile: 'transcript',
             uiFontScale: 1.3,
-            textStyle: createWebUnistylesTextStyle({ fontSize: 16, lineHeight: 24 }) as never,
+            textStyle: createWebUnistylesTextStyle({ fontSize: 16, lineHeight: 24 }),
         });
 
         expect(bundle.markdownStyle.paragraph?.fontSize).toBe(20.8);
@@ -57,7 +59,7 @@ describe('buildEnrichedMarkdownStyle uiFontScale', () => {
             colors,
             profile: 'transcript',
             uiFontScale: 1,
-            textStyle: createWebUnistylesTextStyle({ fontSize: 16, lineHeight: 24 }) as never,
+            textStyle: createWebUnistylesTextStyle({ fontSize: 16, lineHeight: 24 }),
         });
 
         expect(bundle.markdownStyle.paragraph?.fontSize).toBe(16);

--- a/apps/ui/sources/components/markdown/enriched/useEnrichedMarkdownStyle.test.ts
+++ b/apps/ui/sources/components/markdown/enriched/useEnrichedMarkdownStyle.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildEnrichedMarkdownStyle } from './useEnrichedMarkdownStyle';
+
+const colors = {
+    text: { primary: '#111111', secondary: '#666666', link: '#0066cc' },
+    surface: { inset: '#eeeeee', elevated: '#ffffff', selected: '#dddddd' },
+    border: { default: '#cccccc' },
+} as const;
+
+// Mirrors the transcript's real web textStyle: a Unistyles-registered style whose numeric
+// metrics are non-enumerable, non-writable (but configurable) data properties.
+function createWebUnistylesTextStyle(values: Record<string, number>): unknown {
+    const style: Record<string, unknown> = {};
+    Object.defineProperties(
+        style,
+        Object.fromEntries(Object.entries(values).map(([key, value]) => [key, {
+            value,
+            enumerable: false,
+            configurable: true,
+        }])),
+    );
+    style.unistyles_test = {};
+    return style;
+}
+
+describe('buildEnrichedMarkdownStyle uiFontScale', () => {
+    it('scales the markdown metrics from a plain transcript textStyle', () => {
+        const bundle = buildEnrichedMarkdownStyle({
+            colors,
+            profile: 'transcript',
+            uiFontScale: 1.3,
+            textStyle: { fontSize: 16, lineHeight: 24 },
+        });
+
+        expect(bundle.markdownStyle.paragraph?.fontSize).toBe(20.8);
+        expect(bundle.markdownStyle.paragraph?.lineHeight).toBe(31.2);
+        expect(bundle.markdownStyle.codeBlock?.fontSize).toBe(18.2);
+    });
+
+    it('scales the markdown metrics from a web Unistyles transcript textStyle', () => {
+        const bundle = buildEnrichedMarkdownStyle({
+            colors,
+            profile: 'transcript',
+            uiFontScale: 1.3,
+            textStyle: createWebUnistylesTextStyle({ fontSize: 16, lineHeight: 24 }) as never,
+        });
+
+        expect(bundle.markdownStyle.paragraph?.fontSize).toBe(20.8);
+        expect(bundle.markdownStyle.paragraph?.lineHeight).toBe(31.2);
+        expect(bundle.markdownStyle.list?.fontSize).toBe(20.8);
+        expect(bundle.markdownStyle.h1?.fontSize).toBe(31.2);
+    });
+
+    it('keeps the unscaled metrics at scale 1', () => {
+        const bundle = buildEnrichedMarkdownStyle({
+            colors,
+            profile: 'transcript',
+            uiFontScale: 1,
+            textStyle: createWebUnistylesTextStyle({ fontSize: 16, lineHeight: 24 }) as never,
+        });
+
+        expect(bundle.markdownStyle.paragraph?.fontSize).toBe(16);
+        expect(bundle.markdownStyle.paragraph?.lineHeight).toBe(24);
+    });
+});

--- a/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.discardFallback.test.ts
+++ b/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.discardFallback.test.ts
@@ -148,6 +148,7 @@ vi.mock('@/components/ui/scroll/useScrollEdgeFades', () => ({
 
 vi.mock('@/components/ui/layout/layout', () => ({
     layout: { maxWidth: 800, headerMaxWidth: 800 },
+    useLayoutMaxWidth: () => 800,
 }));
 
 describe('PendingMessagesTranscriptBlock send cleanup failure', () => {

--- a/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.test.tsx
+++ b/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.test.tsx
@@ -249,6 +249,7 @@ vi.mock('@/components/ui/scroll/useScrollEdgeFades', () => ({
 
 vi.mock('@/components/ui/layout/layout', () => ({
     layout: { maxWidth: 800, headerMaxWidth: 800 },
+    useLayoutMaxWidth: () => 800,
 }));
 
 describe('PendingMessagesTranscriptBlock', () => {

--- a/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.tsx
+++ b/apps/ui/sources/components/sessions/pending/PendingMessagesTranscriptBlock.tsx
@@ -7,7 +7,7 @@ import { useSession, useSetting } from '@/sync/domains/state/storage';
 import { sync } from '@/sync/sync';
 import { Modal } from '@/modal';
 import { MarkdownView } from '@/components/markdown/MarkdownView';
-import { layout } from '@/components/ui/layout/layout';
+import { useLayoutMaxWidth } from '@/components/ui/layout/layout';
 import { Text } from '@/components/ui/text/Text';
 import { ActivitySpinner } from '@/components/ui/feedback/ActivitySpinner';
 import { t } from '@/text';
@@ -202,6 +202,7 @@ export function PendingMessagesTranscriptBlock(props: Readonly<{
     onEditPendingMessage?: (request: PendingMessageEditRequest) => void | Promise<void>;
 }>) {
     const { theme } = useUnistyles();
+    const contentMaxWidth = useLayoutMaxWidth();
     const session = useSession(props.sessionId);
     const pendingInputServerId = session?.serverId ?? resolvePreferredServerIdForSessionId(props.sessionId);
     const serverFeaturesSnapshot = useServerFeaturesSnapshotForServerId(pendingInputServerId ?? null, {
@@ -1383,9 +1384,9 @@ export function PendingMessagesTranscriptBlock(props: Readonly<{
 
     return (
         <View testID="pendingMessages.block" style={styles.messageContainer} renderToHardwareTextureAndroid={true}>
-            <View style={styles.messageContent}>
+            <View style={[styles.messageContent, { maxWidth: contentMaxWidth }]}>
                 <View style={styles.userMessageContainer}>
-                    <View style={{ width: '100%', maxWidth: layout.maxWidth }}>
+                    <View style={{ width: '100%', maxWidth: contentMaxWidth }}>
                         <View style={styles.sectionHeader}>
                             <TranscriptSeparatorRow
                                 iconName="clock"
@@ -1621,7 +1622,6 @@ const styles = StyleSheet.create(() => ({
         flexDirection: 'column',
         flexGrow: 1,
         flexBasis: 0,
-        maxWidth: layout.maxWidth,
     },
     userMessageContainer: {
         maxWidth: '100%',

--- a/apps/ui/sources/components/sessions/transcript/MessageView.tsx
+++ b/apps/ui/sources/components/sessions/transcript/MessageView.tsx
@@ -7,7 +7,7 @@ import { t } from '@/text';
 import { Message, UserTextMessage, AgentTextMessage, ToolCallMessage } from "@/sync/domains/messages/messageTypes";
 import { Metadata } from "@/sync/domains/state/storageTypes";
 import type { OpenApprovalArtifactForSession } from '@/sync/domains/artifacts/approvalArtifacts';
-import { layout } from "@/components/ui/layout/layout";
+import { useLayoutMaxWidth } from "@/components/ui/layout/layout";
 import { ToolView } from '@/components/tools/shell/views/ToolView';
 import { ToolTimelineRow } from '@/components/tools/shell/views/ToolTimelineRow';
 import { resolveToolStatusIndicatorKind } from '@/components/tools/shell/presentation/resolveToolStatusIndicatorKind';
@@ -313,6 +313,7 @@ export const MessageViewWithSessionCommon = React.memo(function MessageViewWithS
   toolChromeCommon: TranscriptToolChromeCommon;
   toolRouteCommon: TranscriptToolRouteCommon;
 }) {
+  const contentMaxWidth = useLayoutMaxWidth();
   const interaction = props.interaction ?? FAIL_CLOSED_TRANSCRIPT_INTERACTION;
   const canFork = interaction.canFork === true;
   const committedCanForkRef = React.useRef(canFork);
@@ -333,7 +334,7 @@ export const MessageViewWithSessionCommon = React.memo(function MessageViewWithS
   ) === 'hidden') return null;
   return (
     <View style={styles.messageContainer} renderToHardwareTextureAndroid={true}>
-      <View style={styles.messageContent}>
+      <View style={[styles.messageContent, { maxWidth: contentMaxWidth }]}>
         <RecoveredHistoryIndicator message={props.message} />
         <RenderBlock
           message={props.message}
@@ -1773,7 +1774,6 @@ const styles = StyleSheet.create((theme) => ({
     flexDirection: 'column',
     flexGrow: 1,
     flexBasis: 0,
-    maxWidth: layout.maxWidth,
   },
   recoveredHistoryIndicator: {
     marginHorizontal: 16,

--- a/apps/ui/sources/components/sessions/transcript/toolCalls/ToolCallsGroupRow.tsx
+++ b/apps/ui/sources/components/sessions/transcript/toolCalls/ToolCallsGroupRow.tsx
@@ -13,7 +13,7 @@ import {
     ToolCallsGroupViewWithSessionCommon,
 } from '@/components/sessions/transcript/turns/toolCalls/ToolCallsGroupView';
 import { TRANSCRIPT_WEB_TOOL_GROUP_PREPEND_ANCHOR_TEST_ID_PREFIX } from '@/components/sessions/transcript/viewport/prepend/webTranscriptPrependAnchor';
-import { layout } from '@/components/ui/layout/layout';
+import { useLayoutMaxWidth } from '@/components/ui/layout/layout';
 import type { TranscriptInteraction } from '@/utils/sessions/deriveTranscriptInteraction';
 import { resolveInactiveSessionToolCallFailure } from '@/components/tools/shell/permissions/resolveInactiveSessionToolCallFailure';
 import { resolveToolStatusIndicatorKind } from '@/components/tools/shell/presentation/resolveToolStatusIndicatorKind';
@@ -54,6 +54,7 @@ export const ToolCallsGroupRow = React.memo(function ToolCallsGroupRow(props: To
 export const ToolCallsGroupRowWithSessionCommon = React.memo(function ToolCallsGroupRowWithSessionCommon(
     props: ToolCallsGroupRowProps & TranscriptSessionCommonProps,
 ) {
+    const contentMaxWidth = useLayoutMaxWidth();
     const toolMessagesRaw = useMessagesByIds(props.sessionId, props.toolMessageIds);
     const toolMessages = React.useMemo(() => {
         const byId = new Map<string, ToolCallMessage>();
@@ -113,7 +114,7 @@ export const ToolCallsGroupRowWithSessionCommon = React.memo(function ToolCallsG
         <View testID={`${TRANSCRIPT_WEB_TOOL_GROUP_PREPEND_ANCHOR_TEST_ID_PREFIX}${webPrependAnchorId}`}>
             <TranscriptEnterWrapper id={props.toolCallsGroupId} createdAt={createdAt}>
                 <View style={styles.centered}>
-                    <View style={styles.centeredContent}>
+                    <View style={[styles.centeredContent, { maxWidth: contentMaxWidth }]}>
                         <ToolCallsGroupViewWithSessionCommon
                             id={props.toolCallsGroupId}
                             status={status}
@@ -148,6 +149,5 @@ const styles = StyleSheet.create(() => ({
     centeredContent: {
         flexGrow: 1,
         flexBasis: 0,
-        maxWidth: layout.maxWidth,
     },
 }));

--- a/apps/ui/sources/components/sessions/transcript/toolCalls/units/toolCallsGroupChrome.contentWidth.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/toolCalls/units/toolCallsGroupChrome.contentWidth.test.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { act } from 'react-test-renderer';
+import React, { act } from 'react';
+import type { ReactTestInstance } from 'react-test-renderer';
 import { describe, expect, it, vi } from 'vitest';
 
 import { renderScreen } from '@/dev/testkit';
 import { installToolCallsGroupViewCommonModuleMocks } from '@/components/sessions/transcript/turns/toolCalls/toolCallsGroupViewTestHelpers';
 import { flattenStyleProp } from './toolCallsGroupUnitsTestFixtures';
 
-(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const shared = vi.hoisted(() => ({
     contentWidthMode: 'compact' as 'compact' | 'medium' | 'full',
@@ -16,7 +16,10 @@ installToolCallsGroupViewCommonModuleMocks({
     reactNative: async () => {
         const { createReactNativeWebMock } = await import('@/dev/testkit/mocks/reactNative');
         return createReactNativeWebMock({
-            Platform: { OS: 'web', select: (values: any) => values?.web ?? values?.default ?? null },
+            Platform: {
+                OS: 'web',
+                select: <T,>(values: Readonly<{ web?: T; default?: T }>) => values.web ?? values.default ?? null,
+            },
         });
     },
     storage: async (importOriginal) => {
@@ -45,11 +48,11 @@ vi.mock('@/sync/domains/state/storageStore', () => ({
 }));
 
 function findRowFrameMaxWidth(screen: Awaited<ReturnType<typeof renderScreen>>): unknown {
-    const matchingNode = screen.findAllByType('View' as never).find((node: any) => {
+    const matchingNode = screen.findAllByType('View' as never).find((node: ReactTestInstance) => {
         const style = flattenStyleProp(node.props.style);
         return style.flexGrow === 1 && style.flexBasis === 0 && style.maxWidth !== undefined;
     });
-    return matchingNode ? flattenStyleProp((matchingNode as any).props.style).maxWidth : undefined;
+    return matchingNode ? flattenStyleProp(matchingNode.props.style).maxWidth : undefined;
 }
 
 describe('ToolCallsGroupUnitRowFrame content width', () => {

--- a/apps/ui/sources/components/sessions/transcript/toolCalls/units/toolCallsGroupChrome.contentWidth.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/toolCalls/units/toolCallsGroupChrome.contentWidth.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderScreen } from '@/dev/testkit';
+import { installToolCallsGroupViewCommonModuleMocks } from '@/components/sessions/transcript/turns/toolCalls/toolCallsGroupViewTestHelpers';
+import { flattenStyleProp } from './toolCallsGroupUnitsTestFixtures';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const shared = vi.hoisted(() => ({
+    contentWidthMode: 'compact' as 'compact' | 'medium' | 'full',
+}));
+
+installToolCallsGroupViewCommonModuleMocks({
+    reactNative: async () => {
+        const { createReactNativeWebMock } = await import('@/dev/testkit/mocks/reactNative');
+        return createReactNativeWebMock({
+            Platform: { OS: 'web', select: (values: any) => values?.web ?? values?.default ?? null },
+        });
+    },
+    storage: async (importOriginal) => {
+        const { createStorageModuleMock } = await import('@/dev/testkit/mocks/storage');
+        return createStorageModuleMock({
+            importOriginal,
+            overrides: {
+                useLocalSetting: ((key: string) => {
+                    if (key === 'uiContentWidthMode') return shared.contentWidthMode;
+                    if (key === 'uiFontScale') return 1;
+                    return undefined;
+                }) as typeof import('@/sync/domains/state/storage')['useLocalSetting'],
+            },
+        });
+    },
+});
+
+vi.mock('@/sync/domains/state/storageStore', () => ({
+    getStorage: () => ({
+        getState: () => ({
+            localSettings: {
+                uiContentWidthMode: shared.contentWidthMode,
+            },
+        }),
+    }),
+}));
+
+function findRowFrameMaxWidth(screen: Awaited<ReturnType<typeof renderScreen>>): unknown {
+    const matchingNode = screen.findAllByType('View' as never).find((node: any) => {
+        const style = flattenStyleProp(node.props.style);
+        return style.flexGrow === 1 && style.flexBasis === 0 && style.maxWidth !== undefined;
+    });
+    return matchingNode ? flattenStyleProp((matchingNode as any).props.style).maxWidth : undefined;
+}
+
+describe('ToolCallsGroupUnitRowFrame content width', () => {
+    it('updates the row width cap when the local content width setting changes', async () => {
+        shared.contentWidthMode = 'compact';
+        const { ToolCallsGroupUnitRowFrame } = await import('./toolCallsGroupChrome');
+
+        const renderElement = () => (
+            <ToolCallsGroupUnitRowFrame variant="cards" position="middle" unitTestID="unit.row">
+                {null}
+            </ToolCallsGroupUnitRowFrame>
+        );
+        const screen = await renderScreen(renderElement());
+
+        expect(findRowFrameMaxWidth(screen)).toBe(850);
+
+        shared.contentWidthMode = 'full';
+        await act(async () => {
+            screen.tree.update(renderElement());
+        });
+
+        expect(findRowFrameMaxWidth(screen)).toBe(Number.POSITIVE_INFINITY);
+    });
+});

--- a/apps/ui/sources/components/sessions/transcript/toolCalls/units/toolCallsGroupChrome.tsx
+++ b/apps/ui/sources/components/sessions/transcript/toolCalls/units/toolCallsGroupChrome.tsx
@@ -10,7 +10,7 @@ import { ActivitySpinner, iconMatchedSpinnerSize } from '@/components/ui/feedbac
 import { Text } from '@/components/ui/text/Text';
 import { t } from '@/text';
 import { Typography } from '@/constants/Typography';
-import { layout } from '@/components/ui/layout/layout';
+import { useLayoutMaxWidth } from '@/components/ui/layout/layout';
 import { resolveInactiveSessionToolCallFailure } from '@/components/tools/shell/permissions/resolveInactiveSessionToolCallFailure';
 import { resolveToolStatusIndicatorKind } from '@/components/tools/shell/presentation/resolveToolStatusIndicatorKind';
 
@@ -98,9 +98,10 @@ export function ToolCallsGroupUnitRowFrame(props: Readonly<{
     unitTestID: string;
     children: React.ReactNode;
 }>) {
+    const contentMaxWidth = useLayoutMaxWidth();
     return (
         <View style={unitStyles.centered}>
-            <View style={unitStyles.centeredContent}>
+            <View style={[unitStyles.centeredContent, { maxWidth: contentMaxWidth }]}>
                 <View
                     testID={props.unitTestID}
                     style={resolveToolCallsGroupUnitContainerStyle(props.variant, props.position)}
@@ -270,7 +271,6 @@ const unitStyles = StyleSheet.create((theme) => ({
     centeredContent: {
         flexGrow: 1,
         flexBasis: 0,
-        maxWidth: layout.maxWidth,
     },
     container: {
         marginHorizontal: 16,

--- a/apps/ui/sources/components/ui/text/uiFontScale.test.ts
+++ b/apps/ui/sources/components/ui/text/uiFontScale.test.ts
@@ -88,6 +88,35 @@ describe('uiFontScale', () => {
         expect(scaled[marker]).toEqual({ className: 'unistyles_x' });
     });
 
+    it('scales web Unistyles styles whose metrics are non-enumerable, non-writable properties', () => {
+        // Mirrors react-native-unistyles/src/web removeInlineStyles + assignSecrets: style values
+        // become non-enumerable, non-writable (but configurable) data properties, and the secret
+        // lives under an enumerable `unistyles_*` key without the native `uni__getStyles` shape.
+        const style: any = {};
+        Object.defineProperties(style, {
+            fontSize: { value: 16, enumerable: false, configurable: true },
+            lineHeight: { value: 24, enumerable: false, configurable: true },
+        });
+        style.unistyles_web1 = {};
+        Object.defineProperty(style.unistyles_web1, '__uni__key', {
+            value: 'transcriptMarkdownText',
+            enumerable: false,
+            configurable: true,
+        });
+
+        const scaled = scaleTextStyle(style, 1.3) as any;
+
+        expect(scaled).not.toBe(style);
+        expect(scaled.fontSize).toBe(20.8);
+        expect(scaled.lineHeight).toBe(31.2);
+        // Enumerability is preserved so the web renderer keeps sizing text via CSS classes.
+        expect(Object.getOwnPropertyDescriptor(scaled, 'fontSize')?.enumerable).toBe(false);
+        expect(scaled.unistyles_web1).toBe(style.unistyles_web1);
+        // The original registered style must never be mutated.
+        expect(style.fontSize).toBe(16);
+        expect(style.lineHeight).toBe(24);
+    });
+
     it('does not crash on nullish styles', () => {
         expect(scaleTextStyle(null, 1.1)).toBe(null);
         expect(scaleTextStyle(undefined, 1.1)).toBe(undefined);

--- a/apps/ui/sources/components/ui/text/uiFontScale.ts
+++ b/apps/ui/sources/components/ui/text/uiFontScale.ts
@@ -16,6 +16,23 @@ function clonePreservingOwnProps<T extends object>(entry: T): T {
     }
 }
 
+function setScaledMetric(target: any, key: string, value: number): void {
+    const descriptor = Object.getOwnPropertyDescriptor(target, key);
+    if (!descriptor || (descriptor.writable === true && !descriptor.get && !descriptor.set)) {
+        target[key] = value;
+        return;
+    }
+    // Web Unistyles registers style values as non-enumerable, non-writable data properties
+    // (see react-native-unistyles/src/web removeInlineStyles). Redefine the metric on the
+    // clone while preserving its enumerability so CSS-class-driven rendering is unaffected.
+    Object.defineProperty(target, key, {
+        value,
+        enumerable: descriptor.enumerable,
+        configurable: true,
+        writable: true,
+    });
+}
+
 function scaleNumericTextMetrics(entry: any, uiFontScale: number): any {
     const hasFontSize = typeof entry?.fontSize === 'number';
     const hasLineHeight = typeof entry?.lineHeight === 'number';
@@ -24,12 +41,13 @@ function scaleNumericTextMetrics(entry: any, uiFontScale: number): any {
 
     const next: any = clonePreservingOwnProps(entry as any);
     try {
-        if (hasFontSize) next.fontSize = roundTo2(next.fontSize * uiFontScale);
-        if (hasLineHeight) next.lineHeight = roundTo2(next.lineHeight * uiFontScale);
-        if (hasLetterSpacing) next.letterSpacing = roundTo2(next.letterSpacing * uiFontScale);
+        if (hasFontSize) setScaledMetric(next, 'fontSize', roundTo2(entry.fontSize * uiFontScale));
+        if (hasLineHeight) setScaledMetric(next, 'lineHeight', roundTo2(entry.lineHeight * uiFontScale));
+        if (hasLetterSpacing) setScaledMetric(next, 'letterSpacing', roundTo2(entry.letterSpacing * uiFontScale));
         return next;
     } catch {
-        // If the style object is non-writable (or uses accessors), avoid corrupting opaque metadata.
+        // A non-configurable, non-writable metric cannot be scaled without corrupting opaque
+        // metadata; fail closed to the unscaled style.
         return entry;
     }
 }


### PR DESCRIPTION
## Summary

Settings → Appearance has two defects on the session transcript, both reported on the web app:

1. **Text Size (`uiFontScale`) never applies to transcript markdown on web — not even after a reload.**
2. **Content Width (`uiContentWidthMode`) only applies to the transcript after a browser reload**, while other surfaces (settings screens, headers, item groups) update instantly.

## Root causes

**Text Size** — a property-descriptor interaction between web Unistyles and the font-scaling helper:

- On web, Unistyles registers style values as **non-enumerable, non-writable (configurable) data properties** (`react-native-unistyles/src/web` → `removeInlineStyles`), with the secret under an enumerable `unistyles_*` key that does not carry the native `uni__getStyles` shape.
- `scaleTextStyle` clones the style *preserving descriptors*, so the scaling assignment (`next.fontSize = …`) throws on the non-writable clone in strict mode, and the fail-closed `catch` returns the **original, unscaled** style.
- `buildEnrichedMarkdownStyle`'s `flattenTextStyle` returns the raw object, so the unscaled `fontSize: 16` is still readable via property access and wins over the would-be scaled fallback (`16 × uiFontScale`). Every markdown metric derives from that base → the whole transcript is pinned at 16px.
- The global CSS override sheet (`useWebUiFontScale`) can't compensate: it scales `.unistyles_*` class rules, but the enriched markdown renderer emits inline pixel styles built from the poisoned base.

**Content Width** — the transcript row caps read the static `layout.maxWidth` getter **inside `StyleSheet.create`**, which Unistyles evaluates once at registration, so no re-render can refresh them. The surrounding list/header already use the reactive `useLayoutMaxWidth()`, which is why only the per-row cap (the narrower constraint) appeared dead until reload.

## Fix

- `scaleTextStyle` now sets scaled numeric metrics on the clone via `defineProperty` when the original property is non-writable or accessor-based, **preserving enumerability** so CSS-class-driven text rendering (and the existing override sheet) are unaffected. It still fails closed for genuinely non-configurable metrics. The enumerable `unistyles_*` secret is carried over unchanged, so className-based rendering keeps working.
- The transcript row owners — `MessageView`, `ToolCallsGroupRow`, `ToolCallsGroupUnitRowFrame` (`toolCallsGroupChrome`), and `PendingMessagesTranscriptBlock` — now apply the reactive `useLayoutMaxWidth()` value instead of the frozen stylesheet cap, matching the already-reactive `ChatListInternal` / `ChatHeaderView` / `ItemGroup` consumers.

## Tests (RED → GREEN)

- `uiFontScale.test.ts`: new case for the exact web-Unistyles property shape (non-enumerable/non-writable metrics + `__uni__key` secret) — scaled values readable, enumerability preserved, secret reference kept, original not mutated. Failed before the fix (helper returned the original unscaled object).
- `useEnrichedMarkdownStyle.test.ts` (new): composed contract — transcript markdown metrics scale from both a plain and a web-Unistyles `textStyle`, and stay unscaled at scale 1. The web-shape case failed before the fix (paragraph pinned at 16 instead of 20.8).
- `toolCallsGroupChrome.contentWidth.test.tsx` (new): the row frame's width cap follows a `uiContentWidthMode` change without remount (850 → ∞), following the existing `*.contentWidth.test.tsx` pattern. Verified failing against the unfixed component (frozen at 850) and passing after.

## Validation

- `yarn workspace @happier-dev/app typecheck` — clean.
- Text + markdown test directories: 209/209 pass.
- toolCalls + pending directories: 167/168 — the one failure (`'Send now'` vs `'Send to agent now'` label assertion in `PendingMessagesTranscriptBlock.test.tsx`) reproduces identically on a pristine checkout of `dev` and is unrelated to this change.
- Full transcript suite (349 files / 3,219 tests): every failure accounted for as pre-existing — 46 reproduce identically on the pristine base, and the 3 `ChatList.legendPrimary` failures reproduce at this branch's base commit with this PR's changes reverted.
- Two existing `PendingMessagesTranscriptBlock` test mocks of `@/components/ui/layout/layout` gained the `useLayoutMaxWidth` export they now need.

## Known remaining (out of scope)

The frozen-`StyleSheet.create` + `layout.maxWidth` pattern also exists on a handful of non-transcript surfaces (`SessionsList`, `InboxView`, `FriendsView`, `ProfileEditForm`, `ToolFullView`, `SettingsActionFooter`, `ApprovalDetailScreen`, some prompt/MCP screens). Those only surface when navigating to an already-registered screen after changing the setting without a reload; left for a follow-up rather than widening this PR.

---
*Implemented with Claude (AI), directed by @hubikj.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789312095&installation_model_id=20481&pr_number=262&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F262&signature=e6f679864c9ccbec1a31582b7c2b13dac111917bb74ac35d4e032240e0318c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply Text Size and Content Width settings to the web transcript
> - Replaces static `layout.maxWidth` constants with calls to the `useLayoutMaxWidth` hook in [`MessageView`](https://github.com/happier-dev/happier/pull/262/files#diff-d3cd774655fc341ce890d758ff3974a85b1a4e8e2e5420b9bc7e444a6873b9ce), [`PendingMessagesTranscriptBlock`](https://github.com/happier-dev/happier/pull/262/files#diff-20e2f00be3412be6b1d1ab4821490e7eb18e14bc6472ddfc154c9155a0d19a77), [`ToolCallsGroupRow`](https://github.com/happier-dev/happier/pull/262/files#diff-b1992fac38837363d16d0ba1606f108f257644f7c4d3a955367cc6e257a99310), and [`toolCallsGroupChrome`](https://github.com/happier-dev/happier/pull/262/files#diff-02a9ba093c9e74d581ba26696bd0bee72c38b153fd72ecb13adc34c36a19419c) so content width responds to the user's Content Width setting.
> - Fixes `scaleTextStyle` in [`uiFontScale.ts`](https://github.com/happier-dev/happier/pull/262/files#diff-af5b3d686b87acd012c4e963fea37932a80aea54135785b4e09c9ab04def9b2a) to handle web Unistyles properties that are non-enumerable and non-writable by redefining them on a clone, so Text Size scaling now works on the web transcript.
> - Behavioral Change: content width in transcript views is now dynamic (from the hook) rather than a build-time constant, so changing the Content Width setting takes effect without a reload.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b342bad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive message and tool-call content widths across layouts.
  * Fixed font scaling for web text styles, including line height and letter spacing.
  * Preserved text-style metadata and original styles when scaling cannot be safely applied.

* **Tests**
  * Added coverage for responsive width changes and scaled markdown and text metrics.
  * Expanded validation for web-specific, non-enumerable text-style properties and scaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->