### PR TITLE
fix(ui): seed dynamic session model lists from the wizard preflight probe

### DIFF
--- a/apps/cli/src/backends/pi/models/piModelCatalog.ts
+++ b/apps/cli/src/backends/pi/models/piModelCatalog.ts
@@ -1,0 +1,59 @@
+export type PiThinkingEffort = 'low' | 'medium' | 'high' | 'xhigh';
+
+export type PiModelCatalogEntry = Readonly<{
+  id: string;
+  name: string;
+  description: string;
+  modelOptions?: unknown[];
+}>;
+
+export function normalizePiThinkingEffort(raw: unknown): PiThinkingEffort | null {
+  const value = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  if (value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh') return value;
+  if (value === 'max') return 'xhigh';
+  return null;
+}
+
+export function qualifyPiModelId(providerRaw: unknown, modelIdRaw: unknown): string | null {
+  const provider = typeof providerRaw === 'string' ? providerRaw.trim() : '';
+  const modelId = typeof modelIdRaw === 'string' ? modelIdRaw.trim() : '';
+  if (!provider || !modelId) return null;
+  return modelId.includes('/') ? modelId : `${provider}/${modelId}`;
+}
+
+export function createPiModelCatalogEntry(params: Readonly<{
+  provider: unknown;
+  modelId: unknown;
+  name?: unknown;
+  supportsThinking?: boolean;
+  thinkingEffort?: unknown;
+}>): PiModelCatalogEntry | null {
+  const provider = typeof params.provider === 'string' ? params.provider.trim() : '';
+  const id = qualifyPiModelId(provider, params.modelId);
+  if (!provider || !id) return null;
+
+  const name = typeof params.name === 'string' && params.name.trim().length > 0
+    ? params.name.trim()
+    : id.slice(id.indexOf('/') + 1);
+  const thinkingEffort = normalizePiThinkingEffort(params.thinkingEffort) ?? 'medium';
+
+  return {
+    id,
+    name,
+    description: provider,
+    ...(params.supportsThinking === true ? {
+      modelOptions: [{
+        id: 'reasoning_effort',
+        name: 'Thinking',
+        type: 'select',
+        currentValue: thinkingEffort,
+        options: [
+          { value: 'low', name: 'Low' },
+          { value: 'medium', name: 'Medium' },
+          { value: 'high', name: 'High' },
+          { value: 'xhigh', name: 'Max' },
+        ],
+      }],
+    } : {}),
+  };
+}

--- a/apps/cli/src/backends/pi/preflight/piPreflightModelsProbeAdapter.ts
+++ b/apps/cli/src/backends/pi/preflight/piPreflightModelsProbeAdapter.ts
@@ -4,15 +4,9 @@ import { resolveCliPathOverride } from '@/agent/acp/resolveCliPathOverride';
 import { resolveWindowsCommandInvocation } from '@happier-dev/cli-common/process';
 import { killProcessTree } from '@/agent/acp/killProcessTree';
 import { spawn } from 'node:child_process';
+import { createPiModelCatalogEntry, type PiModelCatalogEntry } from '@/backends/pi/models/piModelCatalog';
 
-type PiProbedModelRow = Readonly<{
-  id: string;
-  name: string;
-  description?: string;
-  supportsThinking?: boolean;
-}>;
-
-function parsePiListModelsOutput(textRaw: string): PiProbedModelRow[] | null {
+function parsePiListModelsOutput(textRaw: string): PiModelCatalogEntry[] | null {
   const text = typeof textRaw === 'string' ? textRaw : '';
   if (!text.trim()) return null;
 
@@ -22,7 +16,7 @@ function parsePiListModelsOutput(textRaw: string): PiProbedModelRow[] | null {
     .filter(Boolean);
   if (lines.length === 0) return null;
 
-  const parsed: PiProbedModelRow[] = [];
+  const parsed: PiModelCatalogEntry[] = [];
   for (const line of lines) {
     const normalized = line.trim();
     if (!normalized) continue;
@@ -48,12 +42,13 @@ function parsePiListModelsOutput(textRaw: string): PiProbedModelRow[] | null {
       : thinkingRaw === 'no' ? false
       : undefined;
 
-    parsed.push({
-      id: `${provider}/${model}`,
+    const entry = createPiModelCatalogEntry({
+      provider,
+      modelId: model,
       name: model,
-      description: provider,
-      ...(typeof supportsThinking === 'boolean' ? { supportsThinking } : {}),
+      supportsThinking,
     });
+    if (entry) parsed.push(entry);
   }
 
   return parsed.length > 0 ? parsed : null;
@@ -63,7 +58,7 @@ async function probePiListModels(params: Readonly<{
   cwd: string;
   timeoutMs: number;
   processEnv?: NodeJS.ProcessEnv;
-}>): Promise<PiProbedModelRow[] | null> {
+}>): Promise<PiModelCatalogEntry[] | null> {
   const timeoutMs = Math.max(250, params.timeoutMs);
   const command =
     resolveProviderCliCommand('pi', { processEnv: params.processEnv ?? process.env })?.command
@@ -76,7 +71,7 @@ async function probePiListModels(params: Readonly<{
     let stderr = '';
     let settled = false;
 
-    const finish = (result: PiProbedModelRow[] | null) => {
+    const finish = (result: PiModelCatalogEntry[] | null) => {
       if (settled) return;
       settled = true;
       resolve(result);
@@ -142,24 +137,6 @@ export const piPreflightModelsProbeAdapter: PreflightSessionControlsProbeAdapter
   probeModelsRaw: async ({ cwd, timeoutMs, processEnv }) => {
     const models = await probePiListModels({ cwd, timeoutMs, processEnv });
     if (!models) return null;
-    return models.map((m) => ({
-      id: m.id,
-      name: m.name,
-      ...(typeof m.description === 'string' ? { description: m.description } : {}),
-      ...(m.supportsThinking === true ? {
-        modelOptions: [{
-          id: 'reasoning_effort',
-          name: 'Thinking',
-          type: 'select',
-          currentValue: 'medium',
-          options: [
-            { value: 'low', name: 'Low' },
-            { value: 'medium', name: 'Medium' },
-            { value: 'high', name: 'High' },
-            { value: 'xhigh', name: 'Max' },
-          ],
-        }],
-      } : {}),
-    }));
+    return models;
   },
 };

--- a/apps/cli/src/backends/pi/rpc/PiRpcBackend.promptFailure.test.ts
+++ b/apps/cli/src/backends/pi/rpc/PiRpcBackend.promptFailure.test.ts
@@ -68,7 +68,10 @@ rl.on('line', (line) => {
         type: 'response',
         command: 'get_available_models',
         success: true,
-        data: { models: [{ id: 'gpt-4o-mini', provider: 'openai', name: 'GPT-4o mini' }] }
+        data: { models: [
+          { id: 'gpt-4o-mini', provider: 'openai', name: 'GPT-4o mini' },
+          { id: 'unnamed-model', provider: 'local' }
+        ] }
       });
       break;
     case 'get_commands':
@@ -2267,7 +2270,10 @@ describe('PiRpcBackend prompt error handling', () => {
       const state = (backend as any).getSessionModelState?.() ?? null;
       expect(state).toEqual({
         currentModelId: 'openai/gpt-4o-mini',
-        availableModels: [{ id: 'openai/gpt-4o-mini', name: 'GPT-4o mini', description: 'openai' }],
+        availableModels: [
+          { id: 'openai/gpt-4o-mini', name: 'GPT-4o mini', description: 'openai' },
+          { id: 'local/unnamed-model', name: 'unnamed-model', description: 'local' },
+        ],
       });
     } finally {
       await backend.dispose();

--- a/apps/cli/src/backends/pi/rpc/PiRpcBackend.promptFailure.test.ts
+++ b/apps/cli/src/backends/pi/rpc/PiRpcBackend.promptFailure.test.ts
@@ -2266,8 +2266,8 @@ describe('PiRpcBackend prompt error handling', () => {
       await backend.startSession();
       const state = (backend as any).getSessionModelState?.() ?? null;
       expect(state).toEqual({
-        currentModelId: 'gpt-4o-mini',
-        availableModels: [{ id: 'gpt-4o-mini', name: 'GPT-4o mini', description: 'openai' }],
+        currentModelId: 'openai/gpt-4o-mini',
+        availableModels: [{ id: 'openai/gpt-4o-mini', name: 'GPT-4o mini', description: 'openai' }],
       });
     } finally {
       await backend.dispose();

--- a/apps/cli/src/backends/pi/rpc/PiRpcBackend.ts
+++ b/apps/cli/src/backends/pi/rpc/PiRpcBackend.ts
@@ -2663,13 +2663,13 @@ export class PiRpcBackend implements AgentBackend {
           const provider = asNonEmptyString(model?.provider);
           if (!id || !provider) return null;
           const qualifiedId = qualifyPiModelId(provider, id);
-          const name = asNonEmptyString(model?.name) ?? qualifiedId ?? id;
+          const name = asNonEmptyString(model?.name);
           this.modelProviderById.set(id, provider);
           if (qualifiedId) this.modelProviderById.set(qualifiedId, provider);
           return createPiModelCatalogEntry({
             provider,
             modelId: id,
-            name,
+            ...(name ? { name } : {}),
             supportsThinking: model?.reasoning === true,
             thinkingEffort: thinkingLevelFromState,
           });

--- a/apps/cli/src/backends/pi/rpc/PiRpcBackend.ts
+++ b/apps/cli/src/backends/pi/rpc/PiRpcBackend.ts
@@ -63,6 +63,11 @@ import type {
   PiRpcSessionStatsData,
   PiRpcStateData,
 } from './types';
+import {
+  createPiModelCatalogEntry,
+  normalizePiThinkingEffort,
+  qualifyPiModelId,
+} from '@/backends/pi/models/piModelCatalog';
 
 type PendingRpcRequest = {
   resolve: (response: PiRpcResponse) => void;
@@ -195,8 +200,6 @@ function isPromptResponseTimeoutError(error: Error): boolean {
   }
   return error.message.toLowerCase() === 'timed out waiting for pi rpc response (prompt)';
 }
-
-type PiThinkingEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
 const DEFAULT_PI_RPC_TURN_STALL_TIMEOUT_MS = 180_000;
 /** Existing Pi new-session command budget; also owns broker readiness for that session open. */
@@ -563,13 +566,6 @@ async function stopPiRpcProcess(child: ChildProcessWithoutNullStreams): Promise<
   });
   await killProcessTree(child, { graceMs: 2_000 });
   await closed;
-}
-
-function normalizePiThinkingEffort(raw: unknown): PiThinkingEffort | null {
-  const value = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
-  if (value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh') return value;
-  if (value === 'max') return 'xhigh';
-  return null;
 }
 
 export type PiRpcSpawnOptions = {
@@ -2639,8 +2635,11 @@ export class PiRpcBackend implements AgentBackend {
 
   private async publishRuntimeState(state: PiRpcStateData): Promise<void> {
     const modelRecord = asRecord(state.model);
-    const currentModelId = asNonEmptyString(modelRecord?.id) ?? '';
+    const currentModelIdRaw = asNonEmptyString(modelRecord?.id) ?? '';
     const currentModelProvider = asNonEmptyString(modelRecord?.provider);
+    const currentModelId = currentModelProvider
+      ? qualifyPiModelId(currentModelProvider, currentModelIdRaw) ?? currentModelIdRaw
+      : currentModelIdRaw;
     if (currentModelProvider) {
       this.currentModelProvider = currentModelProvider;
     }
@@ -2663,30 +2662,17 @@ export class PiRpcBackend implements AgentBackend {
           const id = asNonEmptyString(model?.id);
           const provider = asNonEmptyString(model?.provider);
           if (!id || !provider) return null;
-          const name = asNonEmptyString(model?.name) ?? `${provider}/${id}`;
+          const qualifiedId = qualifyPiModelId(provider, id);
+          const name = asNonEmptyString(model?.name) ?? qualifiedId ?? id;
           this.modelProviderById.set(id, provider);
-          this.modelProviderById.set(`${provider}/${id}`, provider);
-          const supportsThinking = model?.reasoning === true;
-          const modelOptions: unknown[] | undefined = supportsThinking
-            ? [{
-                id: 'reasoning_effort',
-                name: 'Thinking',
-                type: 'select',
-                currentValue: thinkingLevelFromState,
-                options: [
-                  { value: 'low', name: 'Low' },
-                  { value: 'medium', name: 'Medium' },
-                  { value: 'high', name: 'High' },
-                  { value: 'xhigh', name: 'Max' },
-                ],
-              }]
-            : undefined;
-          return {
-            id,
+          if (qualifiedId) this.modelProviderById.set(qualifiedId, provider);
+          return createPiModelCatalogEntry({
+            provider,
+            modelId: id,
             name,
-            description: provider,
-            ...(modelOptions ? { modelOptions } : {}),
-          };
+            supportsThinking: model?.reasoning === true,
+            thinkingEffort: thinkingLevelFromState,
+          });
         })
         .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
     } catch {

--- a/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
+++ b/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
@@ -22,16 +22,7 @@ const PI_PREFLIGHT_MODELS: PreflightModelList = {
     supportsFreeform: true,
 };
 
-type AgentCoreModelConfig = {
-    supportsSelection?: boolean;
-    supportsFreeform?: boolean;
-    dynamicProbe?: 'auto' | 'static-only';
-    nonAcpApplyScope?: string;
-};
-
 async function setupUseCreateNewSessionHarness(params: Readonly<{
-    agentModelConfigByAgentType?: Record<string, AgentCoreModelConfig>;
-    staticModelsByAgentType?: Record<string, readonly { id: string; name: string }[]>;
     publishModelsSeedError?: Error;
 }> = {}) {
     const publishModelsSeedSpy = vi.fn(async (..._args: unknown[]) => {
@@ -68,12 +59,6 @@ async function setupUseCreateNewSessionHarness(params: Readonly<{
             return createPartialStorageModuleMock(importOriginal, {});
         },
     });
-    if (params.staticModelsByAgentType) {
-        vi.doMock('@happier-dev/agents', async (importOriginal) => ({
-            ...(await importOriginal<Record<string, unknown>>()),
-            getAgentStaticModels: vi.fn((agentType: string) => params.staticModelsByAgentType?.[agentType] ?? []),
-        }));
-    }
     vi.doMock('@/modal', () => ({
         Modal: {
             alert: modalAlertSpy,
@@ -146,18 +131,8 @@ async function setupUseCreateNewSessionHarness(params: Readonly<{
         getMachineCapabilitiesSnapshot: getMachineCapabilitiesSnapshotSpy,
         prefetchMachineCapabilities: prefetchMachineCapabilitiesSpy,
     }));
-    vi.doMock('@/agents/catalog/catalog', () => ({
-        AGENT_IDS: ['codex', 'claude', 'pi'],
-        getAgentCore: vi.fn((agentType: string) => {
-            const overrides = params.agentModelConfigByAgentType?.[agentType];
-            return {
-                model: {
-                    supportsSelection: true,
-                    nonAcpApplyScope: 'next_prompt',
-                    ...overrides,
-                },
-            };
-        }),
+    vi.doMock('@/agents/catalog/catalog', async (importOriginal) => ({
+        ...(await importOriginal<Record<string, unknown>>()),
         buildSpawnEnvironmentVariablesFromUiState: vi.fn((opts: { environmentVariables?: Record<string, string> }) => opts.environmentVariables),
         buildSpawnSessionExtrasFromUiState: vi.fn(() => ({})),
         getAgentResumeExperimentsFromSettings: vi.fn(() => ({})),
@@ -352,32 +327,10 @@ describe('useCreateNewSession model list seeding', () => {
     });
 
     it('does not seed for static-only probe agents', async () => {
-        const harness = await setupUseCreateNewSessionHarness({
-            agentModelConfigByAgentType: {
-                pi: { dynamicProbe: 'static-only' },
-            },
-        });
+        const harness = await setupUseCreateNewSessionHarness();
 
         await runCreateSession(harness, {
-            agentType: 'pi',
-            preflightModels: PI_PREFLIGHT_MODELS,
-        });
-
-        expect(harness.publishModelsSeedSpy).not.toHaveBeenCalled();
-    });
-
-    it('does not seed for an agent with exactly one curated static model', async () => {
-        // Pins the eligibility boundary: a single real catalog entry (beyond the always-present
-        // `default` pseudo-entry) already populates the picker, so probe data must not seed over
-        // the curated catalog while waiting for the runtime publish.
-        const harness = await setupUseCreateNewSessionHarness({
-            staticModelsByAgentType: {
-                pi: [{ id: 'solo-model', name: 'Solo Model' }],
-            },
-        });
-
-        await runCreateSession(harness, {
-            agentType: 'pi',
+            agentType: 'qwen',
             preflightModels: PI_PREFLIGHT_MODELS,
         });
 

--- a/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
+++ b/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import renderer, { act } from 'react-test-renderer';
 import type { PermissionMode, ModelMode } from '@/sync/domains/permissions/permissionTypes';
 import type { Settings } from '@/sync/domains/settings/settings';
 import type { UseMachineEnvPresenceResult } from '@/hooks/machine/useMachineEnvPresence';
@@ -10,8 +9,9 @@ import { createTextModuleMock } from '@/dev/testkit/mocks/text';
 import { installNewSessionScreenModelCommonModuleMocks } from './newSessionScreenModelTestHelpers';
 import { createNewSessionPromptStore } from '@/components/sessions/new/hooks/screenModel/newSessionPromptStore';
 import type { PreflightModelList } from '@/sync/domains/models/modelOptions';
+import type { AgentId } from '@/agents/catalog/catalog';
 
-(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
 
 const PI_PREFLIGHT_MODELS: PreflightModelList = {
     availableModels: [
@@ -32,8 +32,12 @@ type AgentCoreModelConfig = {
 async function setupUseCreateNewSessionHarness(params: Readonly<{
     agentModelConfigByAgentType?: Record<string, AgentCoreModelConfig>;
     staticModelsByAgentType?: Record<string, readonly { id: string; name: string }[]>;
+    publishModelsSeedError?: Error;
 }> = {}) {
-    const publishModelsSeedSpy = vi.fn(async (..._args: unknown[]) => {});
+    const publishModelsSeedSpy = vi.fn(async (..._args: unknown[]) => {
+        if (params.publishModelsSeedError) throw params.publishModelsSeedError;
+    });
+    const captureExceptionSpy = vi.fn();
     const modalAlertSpy = vi.fn((..._args: unknown[]) => {});
     const modalConfirmSpy = vi.fn(async () => false);
     const applySettingsSpy = vi.fn((..._args: unknown[]) => {});
@@ -130,7 +134,7 @@ async function setupUseCreateNewSessionHarness(params: Readonly<{
         resolveLocalFeaturePolicyEnabled: vi.fn((_featureId: string, settings: { featureToggles?: Record<string, boolean> }) => settings.featureToggles?.[_featureId] === true),
     }));
     vi.doMock('@/utils/system/sentry', () => ({
-        captureExceptionIfEnabled: vi.fn(),
+        captureExceptionIfEnabled: captureExceptionSpy,
     }));
     vi.doMock('@/sync/runtime/orchestration/connectionManager', () => ({
         switchConnectionToActiveServer: vi.fn(async () => ({ token: 'next-token', secret: 'next-secret' })),
@@ -198,6 +202,7 @@ async function setupUseCreateNewSessionHarness(params: Readonly<{
     return {
         useCreateNewSession,
         publishModelsSeedSpy,
+        captureExceptionSpy,
         machineSpawnNewSessionSpy,
         modalAlertSpy,
     };
@@ -208,9 +213,10 @@ type Harness = Awaited<ReturnType<typeof setupUseCreateNewSessionHarness>>;
 async function runCreateSession(
     harness: Harness,
     params: Readonly<{
-        agentType: string;
+        agentType: AgentId;
         modelMode?: ModelMode;
         preflightModels?: PreflightModelList | null;
+        targetServerId?: string;
     }>,
 ): Promise<void> {
     let handleCreateSession: null | (() => Promise<void>) = null;
@@ -237,7 +243,7 @@ async function runCreateSession(
             selectedProfileId: null,
             profileMap: new Map(),
             recentMachinePaths: [],
-            agentType: params.agentType as any,
+            agentType: params.agentType,
             permissionMode: 'default' as PermissionMode,
             modelMode: params.modelMode ?? ('default' as ModelMode),
             promptStore: createNewSessionPromptStore(''),
@@ -249,8 +255,8 @@ async function runCreateSession(
             selectedSecretIdByProfileIdByEnvVarName: {},
             sessionOnlySecretValueByProfileIdByEnvVarName: {},
             selectedMachineCapabilities: null,
-            targetServerId: 'server-a',
-            allowedTargetServerIds: ['server-a'],
+            targetServerId: params.targetServerId ?? 'server-b',
+            allowedTargetServerIds: [params.targetServerId ?? 'server-b'],
             preflightModels: params.preflightModels,
         });
 
@@ -259,9 +265,6 @@ async function runCreateSession(
     }
 
     await renderScreen(React.createElement(Test));
-    // Keep the renderer reference alive until the act() run finishes.
-    void renderer;
-
     await act(async () => {
         await handleCreateSession?.();
     });
@@ -288,11 +291,26 @@ describe('useCreateNewSession model list seeding', () => {
         expect(harness.publishModelsSeedSpy).toHaveBeenCalledTimes(1);
         expect(harness.publishModelsSeedSpy).toHaveBeenCalledWith(expect.objectContaining({
             sessionId: 'sess_pi_1',
+            serverId: 'server-b',
             agentId: 'pi',
             currentModelId: 'lmstudio/hadees/lfm2.5-2.6b@q8_0',
             availableModels: PI_PREFLIGHT_MODELS.availableModels,
             updatedAt: expect.any(Number),
         }));
+    });
+
+    it('reports a best-effort seed failure without failing session creation', async () => {
+        const seedError = new Error('seed metadata unavailable');
+        const harness = await setupUseCreateNewSessionHarness({ publishModelsSeedError: seedError });
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        await runCreateSession(harness, {
+            agentType: 'pi',
+            preflightModels: PI_PREFLIGHT_MODELS,
+        });
+
+        expect(harness.captureExceptionSpy).toHaveBeenCalledWith(seedError);
+        expect(harness.modalAlertSpy).not.toHaveBeenCalled();
     });
 
     it('seeds with the default model marker when no model override was selected', async () => {

--- a/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
+++ b/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
@@ -31,12 +31,12 @@ type AgentCoreModelConfig = {
 
 async function setupUseCreateNewSessionHarness(params: Readonly<{
     agentModelConfigByAgentType?: Record<string, AgentCoreModelConfig>;
+    staticModelsByAgentType?: Record<string, readonly { id: string; name: string }[]>;
 }> = {}) {
     const publishModelsSeedSpy = vi.fn(async (..._args: unknown[]) => {});
     const modalAlertSpy = vi.fn((..._args: unknown[]) => {});
     const modalConfirmSpy = vi.fn(async () => false);
     const applySettingsSpy = vi.fn((..._args: unknown[]) => {});
-    const clearNewSessionDraftSpy = vi.fn();
     const refreshSessionsSpy = vi.fn(async () => {});
     const refreshAutomationsSpy = vi.fn(async () => {});
     const getMachineCapabilitiesSnapshotSpy = vi.fn(() => ({ supported: true, response: { protocolVersion: 1, results: {} } }));
@@ -59,23 +59,21 @@ async function setupUseCreateNewSessionHarness(params: Readonly<{
             createTextModuleMock({
                 translate: (key: string) => key,
             }),
+        storage: async (importOriginal) => {
+            const { createPartialStorageModuleMock } = await import('@/dev/testkit/mocks/storage');
+            return createPartialStorageModuleMock(importOriginal, {});
+        },
     });
+    if (params.staticModelsByAgentType) {
+        vi.doMock('@happier-dev/agents', async (importOriginal) => ({
+            ...(await importOriginal<Record<string, unknown>>()),
+            getAgentStaticModels: vi.fn((agentType: string) => params.staticModelsByAgentType?.[agentType] ?? []),
+        }));
+    }
     vi.doMock('@/modal', () => ({
         Modal: {
             alert: modalAlertSpy,
             confirm: modalConfirmSpy,
-        },
-    }));
-    vi.doMock('@/sync/domains/state/storage', () => ({
-        storage: {
-            getState: () => ({
-                settings: {},
-                machines: { m1: { id: 'm1' } },
-                sessions: {},
-                updateSessionPermissionMode: vi.fn(),
-                updateSessionModelMode: vi.fn(),
-                updateSessionDraft: vi.fn(),
-            }),
         },
     }));
     vi.doMock('@/sync/sync', () => ({
@@ -106,47 +104,6 @@ async function setupUseCreateNewSessionHarness(params: Readonly<{
             status: 200,
             json: async () => ({ mode: 'e2ee', updatedAt: 1 }),
         })),
-    }));
-    vi.doMock('@/sync/domains/state/persistence', () => ({
-        clearNewSessionDraft: clearNewSessionDraftSpy,
-        loadChangesCursor: () => null,
-        loadDeviceAnalyticsId: () => null,
-        loadLastChangesCursorByAccountId: () => ({}),
-        loadNewSessionDraft: () => null,
-        loadPendingSettings: () => ({}),
-        loadProfile: () => ({}),
-        loadSessionActionDrafts: () => ({}),
-        loadSessionDrafts: () => ({}),
-        loadSessionLastViewed: () => ({}),
-        loadSessionMaterializedMaxSeqById: () => ({}),
-        loadSessionModelModes: () => ({}),
-        loadSessionModelModeUpdatedAts: () => ({}),
-        loadSessionPermissionModes: () => ({}),
-        loadSessionPermissionModeUpdatedAts: () => ({}),
-        loadSessionReviewCommentsDrafts: () => ({}),
-        loadSettings: () => ({ settings: {}, version: null }),
-        loadThemePreference: () => 'adaptive',
-        saveChangesCursor: vi.fn(),
-        saveDeviceAnalyticsId: vi.fn(),
-        saveLastChangesCursorByAccountId: vi.fn(),
-        saveSettings: vi.fn(),
-        saveNewSessionDraft: vi.fn(),
-        loadLocalSettings: () => ({}),
-        saveLocalSettings: vi.fn(),
-        loadPurchases: () => ({}),
-        savePurchases: vi.fn(),
-        savePendingSettings: vi.fn(),
-        saveProfile: vi.fn(),
-        saveSessionActionDrafts: vi.fn(),
-        saveSessionDrafts: vi.fn(),
-        saveSessionLastViewed: vi.fn(),
-        saveSessionMaterializedMaxSeqById: vi.fn(),
-        saveSessionModelModes: vi.fn(),
-        saveSessionModelModeUpdatedAts: vi.fn(),
-        saveSessionPermissionModes: vi.fn(),
-        saveSessionPermissionModeUpdatedAts: vi.fn(),
-        saveSessionReviewCommentsDrafts: vi.fn(),
-        clearPersistence: vi.fn(),
     }));
     vi.doMock('@/sync/domains/server/serverRuntime', () => ({
         getActiveServerSnapshot: vi.fn(() => ({
@@ -380,6 +337,24 @@ describe('useCreateNewSession model list seeding', () => {
         const harness = await setupUseCreateNewSessionHarness({
             agentModelConfigByAgentType: {
                 pi: { dynamicProbe: 'static-only' },
+            },
+        });
+
+        await runCreateSession(harness, {
+            agentType: 'pi',
+            preflightModels: PI_PREFLIGHT_MODELS,
+        });
+
+        expect(harness.publishModelsSeedSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not seed for an agent with exactly one curated static model', async () => {
+        // Pins the eligibility boundary: a single real catalog entry (beyond the always-present
+        // `default` pseudo-entry) already populates the picker, so probe data must not seed over
+        // the curated catalog while waiting for the runtime publish.
+        const harness = await setupUseCreateNewSessionHarness({
+            staticModelsByAgentType: {
+                pi: [{ id: 'solo-model', name: 'Solo Model' }],
             },
         });
 

--- a/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
+++ b/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
@@ -1,0 +1,393 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import renderer, { act } from 'react-test-renderer';
+import type { PermissionMode, ModelMode } from '@/sync/domains/permissions/permissionTypes';
+import type { Settings } from '@/sync/domains/settings/settings';
+import type { UseMachineEnvPresenceResult } from '@/hooks/machine/useMachineEnvPresence';
+import { renderScreen } from '@/dev/testkit';
+import { createTextModuleMock } from '@/dev/testkit/mocks/text';
+
+import { installNewSessionScreenModelCommonModuleMocks } from './newSessionScreenModelTestHelpers';
+import { createNewSessionPromptStore } from '@/components/sessions/new/hooks/screenModel/newSessionPromptStore';
+import type { PreflightModelList } from '@/sync/domains/models/modelOptions';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const PI_PREFLIGHT_MODELS: PreflightModelList = {
+    availableModels: [
+        { id: 'default', name: 'Default' },
+        { id: 'zai/glm-5.3', name: 'GLM-5.3' },
+        { id: 'lmstudio/hadees/lfm2.5-2.6b@q8_0', name: 'LFM 2.5 2.6B' },
+    ],
+    supportsFreeform: true,
+};
+
+type AgentCoreModelConfig = {
+    supportsSelection?: boolean;
+    supportsFreeform?: boolean;
+    dynamicProbe?: 'auto' | 'static-only';
+    nonAcpApplyScope?: string;
+};
+
+async function setupUseCreateNewSessionHarness(params: Readonly<{
+    agentModelConfigByAgentType?: Record<string, AgentCoreModelConfig>;
+}> = {}) {
+    const publishModelsSeedSpy = vi.fn(async (..._args: unknown[]) => {});
+    const modalAlertSpy = vi.fn((..._args: unknown[]) => {});
+    const modalConfirmSpy = vi.fn(async () => false);
+    const applySettingsSpy = vi.fn((..._args: unknown[]) => {});
+    const clearNewSessionDraftSpy = vi.fn();
+    const refreshSessionsSpy = vi.fn(async () => {});
+    const refreshAutomationsSpy = vi.fn(async () => {});
+    const getMachineCapabilitiesSnapshotSpy = vi.fn(() => ({ supported: true, response: { protocolVersion: 1, results: {} } }));
+    const prefetchMachineCapabilitiesSpy = vi.fn(async () => {});
+    const syncSendMessageSpy = vi.fn<(...args: unknown[]) => Promise<void>>(async (..._args: unknown[]) => {});
+    const machineSpawnNewSessionSpy = vi.fn<(...args: unknown[]) => Promise<any>>(async () => ({
+        type: 'success',
+        sessionId: 'sess_pi_1',
+    }));
+    const materializeNewSessionCheckoutSpy = vi.fn(async () => ({
+        success: true as const,
+        path: '/tmp',
+        sessionPath: '/tmp',
+        repositoryRootPath: '/tmp',
+    }));
+    const followUpSpawnedSessionWithServerScopeSpy = vi.fn(async (..._args: unknown[]) => {});
+
+    installNewSessionScreenModelCommonModuleMocks({
+        text: () =>
+            createTextModuleMock({
+                translate: (key: string) => key,
+            }),
+    });
+    vi.doMock('@/modal', () => ({
+        Modal: {
+            alert: modalAlertSpy,
+            confirm: modalConfirmSpy,
+        },
+    }));
+    vi.doMock('@/sync/domains/state/storage', () => ({
+        storage: {
+            getState: () => ({
+                settings: {},
+                machines: { m1: { id: 'm1' } },
+                sessions: {},
+                updateSessionPermissionMode: vi.fn(),
+                updateSessionModelMode: vi.fn(),
+                updateSessionDraft: vi.fn(),
+            }),
+        },
+    }));
+    vi.doMock('@/sync/sync', () => ({
+        sync: {
+            applySettings: vi.fn(),
+            createAutomation: vi.fn(),
+            updateAutomation: vi.fn(),
+            getCredentials: vi.fn(() => ({ token: 't' })),
+            encryption: {
+                encryptRaw: vi.fn(async (value: unknown) => `cipher:${JSON.stringify(value)}`),
+                encryptAutomationTemplateRaw: vi.fn(async (value: unknown) => `cipher:${JSON.stringify(value)}`),
+            },
+            decryptSecretValue: vi.fn(),
+            refreshAutomations: refreshAutomationsSpy,
+            refreshSessions: refreshSessionsSpy,
+            ensureSessionVisibleForMessageRoute: vi.fn(async () => {}),
+            refreshMachines: vi.fn(async () => {}),
+            sendMessage: syncSendMessageSpy,
+            publishSessionModelsSeedToMetadata: publishModelsSeedSpy,
+        },
+    }));
+    vi.doMock('@/sync/store/settingsWriters', () => ({
+        useApplySettings: () => applySettingsSpy,
+    }));
+    vi.doMock('@/sync/http/client', () => ({
+        serverFetch: vi.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => ({ mode: 'e2ee', updatedAt: 1 }),
+        })),
+    }));
+    vi.doMock('@/sync/domains/state/persistence', () => ({
+        clearNewSessionDraft: clearNewSessionDraftSpy,
+        loadChangesCursor: () => null,
+        loadDeviceAnalyticsId: () => null,
+        loadLastChangesCursorByAccountId: () => ({}),
+        loadNewSessionDraft: () => null,
+        loadPendingSettings: () => ({}),
+        loadProfile: () => ({}),
+        loadSessionActionDrafts: () => ({}),
+        loadSessionDrafts: () => ({}),
+        loadSessionLastViewed: () => ({}),
+        loadSessionMaterializedMaxSeqById: () => ({}),
+        loadSessionModelModes: () => ({}),
+        loadSessionModelModeUpdatedAts: () => ({}),
+        loadSessionPermissionModes: () => ({}),
+        loadSessionPermissionModeUpdatedAts: () => ({}),
+        loadSessionReviewCommentsDrafts: () => ({}),
+        loadSettings: () => ({ settings: {}, version: null }),
+        loadThemePreference: () => 'adaptive',
+        saveChangesCursor: vi.fn(),
+        saveDeviceAnalyticsId: vi.fn(),
+        saveLastChangesCursorByAccountId: vi.fn(),
+        saveSettings: vi.fn(),
+        saveNewSessionDraft: vi.fn(),
+        loadLocalSettings: () => ({}),
+        saveLocalSettings: vi.fn(),
+        loadPurchases: () => ({}),
+        savePurchases: vi.fn(),
+        savePendingSettings: vi.fn(),
+        saveProfile: vi.fn(),
+        saveSessionActionDrafts: vi.fn(),
+        saveSessionDrafts: vi.fn(),
+        saveSessionLastViewed: vi.fn(),
+        saveSessionMaterializedMaxSeqById: vi.fn(),
+        saveSessionModelModes: vi.fn(),
+        saveSessionModelModeUpdatedAts: vi.fn(),
+        saveSessionPermissionModes: vi.fn(),
+        saveSessionPermissionModeUpdatedAts: vi.fn(),
+        saveSessionReviewCommentsDrafts: vi.fn(),
+        clearPersistence: vi.fn(),
+    }));
+    vi.doMock('@/sync/domains/server/serverRuntime', () => ({
+        getActiveServerSnapshot: vi.fn(() => ({
+            serverId: 'server-a',
+            serverUrl: 'https://server-a.example.test',
+            kind: 'custom',
+            generation: 1,
+        })),
+        setActiveServer: vi.fn(),
+    }));
+    vi.doMock('@/sync/domains/server/selection/serverSelectionResolver', () => ({
+        resolveNewSessionServerTarget: vi.fn((params: { requestedServerId?: string | null; allowedServerIds: string[] }) => ({
+            targetServerId:
+                params.requestedServerId && params.allowedServerIds.includes(params.requestedServerId)
+                    ? params.requestedServerId
+                    : params.allowedServerIds[0] ?? null,
+            rejectedRequestedServerId: null,
+        })),
+    }));
+    vi.doMock('@/sync/domains/profiles/profileUtils', () => ({
+        getBuiltInProfile: vi.fn(() => null),
+    }));
+    vi.doMock('@/sync/domains/features/featureLocalPolicy', () => ({
+        resolveLocalFeaturePolicyEnabled: vi.fn((_featureId: string, settings: { featureToggles?: Record<string, boolean> }) => settings.featureToggles?.[_featureId] === true),
+    }));
+    vi.doMock('@/utils/system/sentry', () => ({
+        captureExceptionIfEnabled: vi.fn(),
+    }));
+    vi.doMock('@/sync/runtime/orchestration/connectionManager', () => ({
+        switchConnectionToActiveServer: vi.fn(async () => ({ token: 'next-token', secret: 'next-secret' })),
+    }));
+    vi.doMock('@/sync/domains/settings/terminalSettings', () => ({
+        resolveTerminalSpawnOptions: vi.fn(() => null),
+    }));
+    vi.doMock('@/hooks/server/useMachineCapabilitiesCache', () => ({
+        getMachineCapabilitiesSnapshot: getMachineCapabilitiesSnapshotSpy,
+        prefetchMachineCapabilities: prefetchMachineCapabilitiesSpy,
+    }));
+    vi.doMock('@/agents/catalog/catalog', () => ({
+        AGENT_IDS: ['codex', 'claude', 'pi'],
+        getAgentCore: vi.fn((agentType: string) => {
+            const overrides = params.agentModelConfigByAgentType?.[agentType];
+            return {
+                model: {
+                    supportsSelection: true,
+                    nonAcpApplyScope: 'next_prompt',
+                    ...overrides,
+                },
+            };
+        }),
+        buildSpawnEnvironmentVariablesFromUiState: vi.fn((opts: { environmentVariables?: Record<string, string> }) => opts.environmentVariables),
+        buildSpawnSessionExtrasFromUiState: vi.fn(() => ({})),
+        getAgentResumeExperimentsFromSettings: vi.fn(() => ({})),
+        getNewSessionPreflightIssues: vi.fn(() => []),
+        buildResumeCapabilityOptionsFromUiState: vi.fn(() => ({})),
+    }));
+    vi.doMock('@/agents/runtime/resumeCapabilities', () => ({
+        canAgentResume: vi.fn(() => false),
+    }));
+    vi.doMock('@/components/sessions/new/modules/formatResumeSupportDetailCode', () => ({
+        formatResumeSupportDetailCode: vi.fn(() => ''),
+    }));
+    vi.doMock('@/sync/ops', () => ({
+        machineSpawnNewSession: (...args: unknown[]) => machineSpawnNewSessionSpy(...args),
+        machineBash: vi.fn(async () => ({ success: true, stderr: '', stdout: '', exitCode: 0 })),
+        completeMachineSpawnAttemptCustody: vi.fn(async () => true),
+        resetMachineSpawnAttemptCustody: vi.fn(async () => true),
+    }));
+    vi.doMock('@/components/sessions/new/modules/materializeNewSessionCheckout', () => ({
+        materializeNewSessionCheckout: materializeNewSessionCheckoutSpy,
+    }));
+    vi.doMock('@/sync/ops/workspaces', () => ({
+        deleteWorkspaceCheckout: vi.fn(async () => ({ success: true, workspace: { id: 'ws_generated', locationIds: ['loc_generated'], checkoutIds: [], defaultLocationId: 'loc_generated', defaultCheckoutId: null, displayName: 'workspace' } })),
+    }));
+    vi.doMock('@/sync/runtime/orchestration/serverScopedRpc/followUpSpawnedSession', () => ({
+        followUpSpawnedSessionWithServerScope: followUpSpawnedSessionWithServerScopeSpy,
+    }));
+    vi.doMock('@/sync/ops/sessionGoals', () => ({
+        sessionGoalSet: vi.fn(async () => ({ ok: true as const })),
+        sessionGoalClear: vi.fn(async () => ({ ok: true as const })),
+    }));
+    vi.doMock('@/sync/ops/actions/defaultActionExecutor', () => ({
+        createDefaultActionExecutor: vi.fn(() => ({
+            execute: vi.fn(async () => ({ ok: true as const })),
+        })),
+    }));
+    vi.doMock('@/sync/runtime/orchestration/serverScopedRpc/resolveServerIdForSessionIdFromLocalCache', () => ({
+        resolveServerIdForSessionIdFromLocalCache: vi.fn(() => 'server-a'),
+    }));
+
+    const { useCreateNewSession } = await import('./useCreateNewSession');
+    return {
+        useCreateNewSession,
+        publishModelsSeedSpy,
+        machineSpawnNewSessionSpy,
+        modalAlertSpy,
+    };
+}
+
+type Harness = Awaited<ReturnType<typeof setupUseCreateNewSessionHarness>>;
+
+async function runCreateSession(
+    harness: Harness,
+    params: Readonly<{
+        agentType: string;
+        modelMode?: ModelMode;
+        preflightModels?: PreflightModelList | null;
+    }>,
+): Promise<void> {
+    let handleCreateSession: null | (() => Promise<void>) = null;
+    const settings = { experiments: false } as unknown as Settings;
+    const machineEnvPresence: UseMachineEnvPresenceResult = {
+        isPreviewEnvSupported: false,
+        isLoading: false,
+        meta: {},
+        refreshedAt: null,
+        refresh: () => {},
+    };
+
+    function Test() {
+        const hook = harness.useCreateNewSession({
+            launchIntentSignature: 'test-launch-intent',
+            router: { push: vi.fn(), replace: vi.fn() },
+            selectedMachineId: 'm1',
+            selectedPath: '/tmp',
+            selectedMachine: { metadata: {} },
+            setIsCreating: vi.fn(),
+            setIsResumeSupportChecking: vi.fn(),
+            settings,
+            useProfiles: false,
+            selectedProfileId: null,
+            profileMap: new Map(),
+            recentMachinePaths: [],
+            agentType: params.agentType as any,
+            permissionMode: 'default' as PermissionMode,
+            modelMode: params.modelMode ?? ('default' as ModelMode),
+            promptStore: createNewSessionPromptStore(''),
+            resumeSessionId: '',
+            agentNewSessionOptions: null,
+            machineEnvPresence,
+            secrets: [],
+            secretBindingsByProfileId: {},
+            selectedSecretIdByProfileIdByEnvVarName: {},
+            sessionOnlySecretValueByProfileIdByEnvVarName: {},
+            selectedMachineCapabilities: null,
+            targetServerId: 'server-a',
+            allowedTargetServerIds: ['server-a'],
+            preflightModels: params.preflightModels,
+        });
+
+        handleCreateSession = hook.handleCreateSession as () => Promise<void>;
+        return React.createElement('View');
+    }
+
+    await renderScreen(React.createElement(Test));
+    // Keep the renderer reference alive until the act() run finishes.
+    void renderer;
+
+    await act(async () => {
+        await handleCreateSession?.();
+    });
+}
+
+describe('useCreateNewSession model list seeding', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('seeds sessionModelsV1 from the wizard preflight probe for a dynamic agent without static models', async () => {
+        const harness = await setupUseCreateNewSessionHarness();
+
+        await runCreateSession(harness, {
+            agentType: 'pi',
+            modelMode: 'lmstudio/hadees/lfm2.5-2.6b@q8_0' as ModelMode,
+            preflightModels: PI_PREFLIGHT_MODELS,
+        });
+
+        expect(harness.publishModelsSeedSpy).toHaveBeenCalledTimes(1);
+        expect(harness.publishModelsSeedSpy).toHaveBeenCalledWith(expect.objectContaining({
+            sessionId: 'sess_pi_1',
+            agentId: 'pi',
+            currentModelId: 'lmstudio/hadees/lfm2.5-2.6b@q8_0',
+            availableModels: PI_PREFLIGHT_MODELS.availableModels,
+            updatedAt: expect.any(Number),
+        }));
+    });
+
+    it('seeds with the default model marker when no model override was selected', async () => {
+        const harness = await setupUseCreateNewSessionHarness();
+
+        await runCreateSession(harness, {
+            agentType: 'pi',
+            modelMode: 'default' as ModelMode,
+            preflightModels: PI_PREFLIGHT_MODELS,
+        });
+
+        expect(harness.publishModelsSeedSpy).toHaveBeenCalledWith(expect.objectContaining({
+            currentModelId: 'default',
+        }));
+    });
+
+    it('does not seed when the wizard has no preflight model list', async () => {
+        const harness = await setupUseCreateNewSessionHarness();
+
+        await runCreateSession(harness, {
+            agentType: 'pi',
+            preflightModels: null,
+        });
+
+        expect(harness.publishModelsSeedSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not seed for agents whose curated static list already populates the picker', async () => {
+        // claude ships staticModels in the catalog, so its in-session picker is never empty
+        // before the runtime publishes.
+        const harness = await setupUseCreateNewSessionHarness();
+
+        await runCreateSession(harness, {
+            agentType: 'claude',
+            preflightModels: PI_PREFLIGHT_MODELS,
+        });
+
+        expect(harness.publishModelsSeedSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not seed for static-only probe agents', async () => {
+        const harness = await setupUseCreateNewSessionHarness({
+            agentModelConfigByAgentType: {
+                pi: { dynamicProbe: 'static-only' },
+            },
+        });
+
+        await runCreateSession(harness, {
+            agentType: 'pi',
+            preflightModels: PI_PREFLIGHT_MODELS,
+        });
+
+        expect(harness.publishModelsSeedSpy).not.toHaveBeenCalled();
+    });
+});

--- a/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
+++ b/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.modelListSeed.test.ts
@@ -10,6 +10,7 @@ import { installNewSessionScreenModelCommonModuleMocks } from './newSessionScree
 import { createNewSessionPromptStore } from '@/components/sessions/new/hooks/screenModel/newSessionPromptStore';
 import type { PreflightModelList } from '@/sync/domains/models/modelOptions';
 import type { AgentId } from '@/agents/catalog/catalog';
+import type { BackendTargetRefV1 } from '@happier-dev/protocol';
 
 vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
 
@@ -192,6 +193,7 @@ async function runCreateSession(
         modelMode?: ModelMode;
         preflightModels?: PreflightModelList | null;
         targetServerId?: string;
+        backendTarget?: BackendTargetRefV1;
     }>,
 ): Promise<void> {
     let handleCreateSession: null | (() => Promise<void>) = null;
@@ -219,6 +221,7 @@ async function runCreateSession(
             profileMap: new Map(),
             recentMachinePaths: [],
             agentType: params.agentType,
+            backendTarget: params.backendTarget,
             permissionMode: 'default' as PermissionMode,
             modelMode: params.modelMode ?? ('default' as ModelMode),
             promptStore: createNewSessionPromptStore(''),
@@ -334,6 +337,19 @@ describe('useCreateNewSession model list seeding', () => {
             preflightModels: PI_PREFLIGHT_MODELS,
         });
 
+        expect(harness.publishModelsSeedSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not seed configured ACP backend sessions', async () => {
+        const harness = await setupUseCreateNewSessionHarness();
+
+        await runCreateSession(harness, {
+            agentType: 'customAcp',
+            backendTarget: { kind: 'configuredAcpBackend', backendId: 'backend-1' },
+            preflightModels: PI_PREFLIGHT_MODELS,
+        });
+
+        expect(harness.machineSpawnNewSessionSpy).toHaveBeenCalledTimes(1);
         expect(harness.publishModelsSeedSpy).not.toHaveBeenCalled();
     });
 });

--- a/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.ts
+++ b/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.ts
@@ -49,6 +49,8 @@ import { resolveServerIdForSessionIdFromLocalCache } from '@/sync/runtime/orches
 import { sessionGoalClear, sessionGoalSet } from '@/sync/ops/sessionGoals';
 import { isSocketIoAckTimeoutError } from '@/sync/runtime/socketIoAckTimeout';
 import { readNonBlankSessionControlIdentifier } from '@/sync/domains/sessionControl/opaqueIdentifiers';
+import type { PreflightModelList } from '@/sync/domains/models/modelOptions';
+import { getModelOptionsForAgentType } from '@/sync/domains/models/modelOptions';
 
 function getActiveNewSessionDraftScope() {
     return storage.getState().profileScope ?? null;
@@ -241,6 +243,12 @@ export function useCreateNewSession(params: Readonly<{
      * dropped when the user leaves the chip attached.
      */
     sourceContext?: SessionSpawnSourceContextV1 | null;
+    /**
+     * Wizard preflight model list for the selected backend target. After a successful spawn it
+     * seeds `sessionModelsV1` for dynamic-probe agents without a static catalog (e.g. Pi), whose
+     * in-session picker would otherwise stay empty until the runtime publishes on first prompt.
+     */
+    preflightModels?: PreflightModelList | null;
 }>): Readonly<{
     handleCreateSession: (opts?: HandleCreateSessionOptions) => void;
 }> {
@@ -947,6 +955,31 @@ export function useCreateNewSession(params: Readonly<{
                 storage.getState().updateSessionPermissionMode(result.sessionId, current.permissionMode);
                 if (getAgentCore(current.agentType).model.supportsSelection && current.modelMode && current.modelMode !== 'default') {
                     storage.getState().updateSessionModelMode(result.sessionId, current.modelMode);
+                }
+
+                // Seed the session's model list from the wizard probe. Providers without a static
+                // catalog publish `sessionModelsV1` only once their runtime starts (first prompt),
+                // so without this seed the in-session model picker offers nothing but the current
+                // model, "Use CLI settings", and freeform custom until then. Best-effort and
+                // seed-only: the runtime publish stays authoritative, a lost race is a no-op, and
+                // a failed seed merely leaves the picker as it is today.
+                const preflightModelsForSeed = current.preflightModels;
+                const agentModelConfig = getAgentCore(current.agentType).model;
+                if (
+                    preflightModelsForSeed
+                    && preflightModelsForSeed.availableModels.length > 0
+                    && backendTarget.kind === 'builtInAgent'
+                    && agentModelConfig.supportsSelection === true
+                    && agentModelConfig.dynamicProbe !== 'static-only'
+                    && getModelOptionsForAgentType(current.agentType).length <= 1
+                ) {
+                    void sync.publishSessionModelsSeedToMetadata({
+                        sessionId: createdSessionId,
+                        agentId: current.agentType,
+                        currentModelId: spawnModelId ?? 'default',
+                        availableModels: preflightModelsForSeed.availableModels,
+                        updatedAt: spawnPermissionModeUpdatedAt,
+                    }).catch(() => undefined);
                 }
 
                 if (!postSpawnFollowUpError && opts?.afterCreated) {

--- a/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.ts
+++ b/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.ts
@@ -81,6 +81,7 @@ import {
     showDaemonUnavailableAlert,
 } from '@/utils/errors/daemonUnavailableAlert';
 import { captureExceptionIfEnabled } from '@/utils/system/sentry';
+import { fireAndForget } from '@/utils/system/fireAndForget';
 import { useMountedRef } from '@/hooks/ui/useMountedRef';
 import { buildScopedSessionRouteHref } from '@/hooks/session/sessionRouteServerScope';
 import type { SessionMcpSelectionV1 } from '@happier-dev/protocol';
@@ -978,13 +979,17 @@ export function useCreateNewSession(params: Readonly<{
                     && agentModelConfig.dynamicProbe !== 'static-only'
                     && !hasCuratedStaticModels
                 ) {
-                    void sync.publishSessionModelsSeedToMetadata({
+                    fireAndForget(sync.publishSessionModelsSeedToMetadata({
                         sessionId: createdSessionId,
+                        serverId: resolvedTargetServerId,
                         agentId: current.agentType,
                         currentModelId: spawnModelId ?? 'default',
                         availableModels: preflightModelsForSeed.availableModels,
                         updatedAt: spawnPermissionModeUpdatedAt,
-                    }).catch(() => undefined);
+                    }), {
+                        tag: 'new-session-model-list-seed',
+                        onError: captureExceptionIfEnabled,
+                    });
                 }
 
                 if (!postSpawnFollowUpError && opts?.afterCreated) {

--- a/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.ts
+++ b/apps/ui/sources/components/sessions/new/hooks/useCreateNewSession.ts
@@ -965,13 +965,18 @@ export function useCreateNewSession(params: Readonly<{
                 // a failed seed merely leaves the picker as it is today.
                 const preflightModelsForSeed = current.preflightModels;
                 const agentModelConfig = getAgentCore(current.agentType).model;
+                // `getModelOptionsForAgentType` always includes the `default` pseudo-entry, so
+                // "no option besides default" is exactly "no curated static catalog" — the
+                // agents whose picker would otherwise be empty until the runtime publishes.
+                const hasCuratedStaticModels = getModelOptionsForAgentType(current.agentType)
+                    .some((option) => option.value !== 'default');
                 if (
                     preflightModelsForSeed
                     && preflightModelsForSeed.availableModels.length > 0
                     && backendTarget.kind === 'builtInAgent'
                     && agentModelConfig.supportsSelection === true
                     && agentModelConfig.dynamicProbe !== 'static-only'
-                    && getModelOptionsForAgentType(current.agentType).length <= 1
+                    && !hasCuratedStaticModels
                 ) {
                     void sync.publishSessionModelsSeedToMetadata({
                         sessionId: createdSessionId,

--- a/apps/ui/sources/components/sessions/new/hooks/useNewSessionScreenModel.tsx
+++ b/apps/ui/sources/components/sessions/new/hooks/useNewSessionScreenModel.tsx
@@ -1782,6 +1782,7 @@ export function useNewSessionScreenModel(): NewSessionScreenModel {
         launchUserAttemptId,
         onLaunchUserAttemptIdChange,
         sourceContext: sourceContextState.sourceContext,
+        preflightModels,
     });
 
     const {

--- a/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.test.ts
+++ b/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Metadata } from '@/sync/domains/state/storageTypes';
+import { getModelOptionsForSession, type PreflightModelList } from '@/sync/domains/models/modelOptions';
+import { readSessionModelsState } from '@/sync/domains/sessionControl/readSessionControlMetadata';
+
+import {
+    computeNextSessionModelsSeedMetadata,
+    publishSessionModelsSeedToMetadata,
+} from './sessionModelsSeedPublish';
+
+const PROBED_MODELS = [
+    { id: 'default', name: 'Default' },
+    { id: 'zai/glm-5.3', name: 'GLM-5.3', description: 'Z.ai GLM' },
+    { id: 'lmstudio/hadees/lfm2.5-2.6b@q8_0', name: 'LFM 2.5 2.6B' },
+] as const;
+
+function buildSpawnMetadata(): Metadata {
+    return {
+        flavor: 'pi',
+        path: '/tmp/project',
+    } as unknown as Metadata;
+}
+
+describe('computeNextSessionModelsSeedMetadata', () => {
+    it('seeds sessionModelsV1 and its legacy alias when the session has no model list', () => {
+        const next = computeNextSessionModelsSeedMetadata({
+            metadata: buildSpawnMetadata(),
+            provider: 'pi',
+            currentModelId: 'lmstudio/hadees/lfm2.5-2.6b@q8_0',
+            availableModels: PROBED_MODELS,
+            updatedAt: 1234,
+        });
+
+        expect(next.sessionModelsV1).toEqual({
+            v: 1,
+            provider: 'pi',
+            updatedAt: 1234,
+            currentModelId: 'lmstudio/hadees/lfm2.5-2.6b@q8_0',
+            availableModels: PROBED_MODELS,
+        });
+        expect(next.acpSessionModelsV1).toEqual(next.sessionModelsV1);
+        // Spawn-time metadata the runner owns must survive the seed.
+        expect(next.flavor).toBe('pi');
+        expect(next.path).toBe('/tmp/project');
+    });
+
+    it('never replaces a runtime-published model list', () => {
+        const runtimePublished = buildSpawnMetadata();
+        (runtimePublished as Record<string, unknown>).sessionModelsV1 = {
+            v: 1,
+            provider: 'pi',
+            updatedAt: 9999,
+            currentModelId: 'zai/glm-5.3',
+            availableModels: [{ id: 'zai/glm-5.3', name: 'GLM-5.3' }],
+        };
+
+        const next = computeNextSessionModelsSeedMetadata({
+            metadata: runtimePublished,
+            provider: 'pi',
+            currentModelId: 'default',
+            availableModels: PROBED_MODELS,
+            updatedAt: 1234,
+        });
+
+        expect(next).toBe(runtimePublished);
+    });
+
+    it('returns the metadata unchanged when there is nothing to seed', () => {
+        const metadata = buildSpawnMetadata();
+
+        const next = computeNextSessionModelsSeedMetadata({
+            metadata,
+            provider: 'pi',
+            currentModelId: 'default',
+            availableModels: [],
+            updatedAt: 1234,
+        });
+
+        expect(next).toBe(metadata);
+    });
+
+    it('drops rows the session-models schema would reject', () => {
+        const next = computeNextSessionModelsSeedMetadata({
+            metadata: buildSpawnMetadata(),
+            provider: 'pi',
+            currentModelId: 'default',
+            availableModels: [
+                { id: 'zai/glm-5.3', name: 'GLM-5.3', description: '' },
+                { id: '', name: 'Missing id' },
+                // A model-scoped option row that fails the id/name requirement must be dropped.
+                { id: 'missing-name' } as unknown as PreflightModelList['availableModels'][number],
+                { id: 'zai/glm-5.3-air', name: 'GLM-5.3 Air', description: 'Fast variant' },
+            ],
+            updatedAt: 1234,
+        });
+
+        expect(next.sessionModelsV1?.availableModels).toEqual([
+            // Blank descriptions are omitted: the reader schema requires min(1) when present.
+            { id: 'zai/glm-5.3', name: 'GLM-5.3' },
+            { id: 'zai/glm-5.3-air', name: 'GLM-5.3 Air', description: 'Fast variant' },
+        ]);
+    });
+});
+
+describe('publishSessionModelsSeedToMetadata', () => {
+    it('writes through the session metadata CAS path with the seed updater', async () => {
+        const updateSessionMetadataWithRetry = vi.fn(async (_sessionId: string, updater: (metadata: Metadata) => Metadata) => {
+            const seeded = updater(buildSpawnMetadata());
+            expect(readSessionModelsState(seeded)?.provider).toBe('pi');
+        });
+
+        await publishSessionModelsSeedToMetadata({
+            sessionId: 'session-1',
+            provider: 'pi',
+            currentModelId: 'default',
+            availableModels: PROBED_MODELS,
+            updatedAt: 1234,
+            updateSessionMetadataWithRetry,
+        });
+
+        expect(updateSessionMetadataWithRetry).toHaveBeenCalledTimes(1);
+        expect(updateSessionMetadataWithRetry.mock.calls[0][0]).toBe('session-1');
+    });
+});
+
+describe('seeded metadata resolves through the in-session model options reader', () => {
+    it('surfaces the probed models in getModelOptionsForSession', () => {
+        const seeded = computeNextSessionModelsSeedMetadata({
+            metadata: buildSpawnMetadata(),
+            provider: 'pi',
+            currentModelId: 'default',
+            availableModels: PROBED_MODELS,
+            updatedAt: 1234,
+        });
+
+        const options = getModelOptionsForSession('pi', seeded);
+        const values = options.map((option) => option.value);
+
+        // The picker's localized "Use CLI settings" default plus every probed model.
+        expect(values).toContain('default');
+        expect(values).toContain('zai/glm-5.3');
+        expect(values).toContain('lmstudio/hadees/lfm2.5-2.6b@q8_0');
+        expect(options.find((option) => option.value === 'zai/glm-5.3')?.label).toBe('GLM-5.3');
+    });
+});

--- a/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.test.ts
+++ b/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.test.ts
@@ -90,7 +90,12 @@ describe('computeNextSessionModelsSeedMetadata', () => {
                 { id: '', name: 'Missing id' },
                 // A model-scoped option row that fails the id/name requirement must be dropped.
                 { id: 'missing-name' } as unknown as PreflightModelList['availableModels'][number],
-                { id: 'zai/glm-5.3-air', name: 'GLM-5.3 Air', description: 'Fast variant' },
+                {
+                    id: 'zai/glm-5.3-air',
+                    name: 'GLM-5.3 Air',
+                    description: 'Fast variant',
+                    extendedContextModelId: '  zai/glm-5.3-air-long  ',
+                },
             ],
             updatedAt: 1234,
         });
@@ -98,7 +103,12 @@ describe('computeNextSessionModelsSeedMetadata', () => {
         expect(next.sessionModelsV1?.availableModels).toEqual([
             // Blank descriptions are omitted: the reader schema requires min(1) when present.
             { id: 'zai/glm-5.3', name: 'GLM-5.3' },
-            { id: 'zai/glm-5.3-air', name: 'GLM-5.3 Air', description: 'Fast variant' },
+            {
+                id: 'zai/glm-5.3-air',
+                name: 'GLM-5.3 Air',
+                description: 'Fast variant',
+                extendedContextModelId: 'zai/glm-5.3-air-long',
+            },
         ]);
     });
 });

--- a/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.test.ts
+++ b/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.test.ts
@@ -83,15 +83,15 @@ describe('computeNextSessionModelsSeedMetadata', () => {
     it('drops rows the session-models schema would reject', () => {
         const next = computeNextSessionModelsSeedMetadata({
             metadata: buildSpawnMetadata(),
-            provider: 'pi',
-            currentModelId: 'default',
+            provider: '  pi  ',
+            currentModelId: '  default  ',
             availableModels: [
                 { id: 'zai/glm-5.3', name: 'GLM-5.3', description: '' },
                 { id: '', name: 'Missing id' },
                 // A model-scoped option row that fails the id/name requirement must be dropped.
                 { id: 'missing-name' } as unknown as PreflightModelList['availableModels'][number],
                 {
-                    id: 'zai/glm-5.3-air',
+                    id: '  zai/glm-5.3-air  ',
                     name: 'GLM-5.3 Air',
                     description: 'Fast variant',
                     extendedContextModelId: '  zai/glm-5.3-air-long  ',
@@ -110,6 +110,10 @@ describe('computeNextSessionModelsSeedMetadata', () => {
                 extendedContextModelId: 'zai/glm-5.3-air-long',
             },
         ]);
+        expect(next.sessionModelsV1).toMatchObject({
+            provider: 'pi',
+            currentModelId: 'default',
+        });
     });
 });
 

--- a/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.test.ts
+++ b/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.test.ts
@@ -105,7 +105,11 @@ describe('computeNextSessionModelsSeedMetadata', () => {
 
 describe('publishSessionModelsSeedToMetadata', () => {
     it('writes through the session metadata CAS path with the seed updater', async () => {
-        const updateSessionMetadataWithRetry = vi.fn(async (_sessionId: string, updater: (metadata: Metadata) => Metadata) => {
+        const updateSessionMetadataWithRetry = vi.fn(async (
+            _sessionId: string,
+            updater: (metadata: Metadata) => Metadata,
+            _options?: Readonly<{ serverId?: string | null }>,
+        ) => {
             const seeded = updater(buildSpawnMetadata());
             expect(readSessionModelsState(seeded)?.provider).toBe('pi');
         });
@@ -116,11 +120,13 @@ describe('publishSessionModelsSeedToMetadata', () => {
             currentModelId: 'default',
             availableModels: PROBED_MODELS,
             updatedAt: 1234,
+            serverId: 'server-b',
             updateSessionMetadataWithRetry,
         });
 
         expect(updateSessionMetadataWithRetry).toHaveBeenCalledTimes(1);
         expect(updateSessionMetadataWithRetry.mock.calls[0][0]).toBe('session-1');
+        expect(updateSessionMetadataWithRetry.mock.calls[0][2]).toEqual({ serverId: 'server-b' });
     });
 });
 

--- a/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.ts
+++ b/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.ts
@@ -3,6 +3,10 @@ import type { PreflightModelList } from '@/sync/domains/models/modelOptions';
 import { readSessionModelsState } from '@/sync/domains/sessionControl/readSessionControlMetadata';
 import { readNonBlankSessionControlIdentifier } from '@/sync/domains/sessionControl/opaqueIdentifiers';
 
+function readNormalizedSessionControlIdentifier(value: unknown): string | null {
+    return readNonBlankSessionControlIdentifier(value)?.trim() ?? null;
+}
+
 /**
  * Seed the session model list from the new-session wizard's preflight probe.
  *
@@ -25,17 +29,18 @@ export function computeNextSessionModelsSeedMetadata(params: Readonly<{
     // first runtime publish a no-op instead of overwriting it.
     if (readSessionModelsState(params.metadata) !== null) return params.metadata;
 
-    const provider = readNonBlankSessionControlIdentifier(params.provider);
-    const currentModelId = readNonBlankSessionControlIdentifier(params.currentModelId);
+    const provider = readNormalizedSessionControlIdentifier(params.provider);
+    const currentModelId = readNormalizedSessionControlIdentifier(params.currentModelId);
     if (!provider || !currentModelId) return params.metadata;
 
     const availableModels = params.availableModels.flatMap((model) => {
-        const id = readNonBlankSessionControlIdentifier(model.id);
+        const id = readNormalizedSessionControlIdentifier(model.id);
         const name = readNonBlankSessionControlIdentifier(model.name);
         if (!id || !name) return [];
         const description = typeof model.description === 'string' && model.description.trim().length > 0
             ? model.description
             : null;
+        const extendedContextModelId = readNormalizedSessionControlIdentifier(model.extendedContextModelId);
         return [{
             id,
             name,
@@ -43,9 +48,7 @@ export function computeNextSessionModelsSeedMetadata(params: Readonly<{
             ...(typeof model.contextWindowTokens === 'number' && Number.isFinite(model.contextWindowTokens) && model.contextWindowTokens > 0
                 ? { contextWindowTokens: model.contextWindowTokens }
                 : {}),
-            ...(readNonBlankSessionControlIdentifier(model.extendedContextModelId)
-                ? { extendedContextModelId: model.extendedContextModelId }
-                : {}),
+            ...(extendedContextModelId ? { extendedContextModelId } : {}),
             ...(Array.isArray(model.modelOptions) && model.modelOptions.length > 0
                 ? { modelOptions: model.modelOptions }
                 : {}),

--- a/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.ts
+++ b/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.ts
@@ -71,11 +71,16 @@ export function computeNextSessionModelsSeedMetadata(params: Readonly<{
 
 export async function publishSessionModelsSeedToMetadata(params: Readonly<{
     sessionId: string;
+    serverId?: string | null;
     provider: string;
     currentModelId: string;
     availableModels: PreflightModelList['availableModels'];
     updatedAt: number;
-    updateSessionMetadataWithRetry: (sessionId: string, updater: (metadata: Metadata) => Metadata) => Promise<void>;
+    updateSessionMetadataWithRetry: (
+        sessionId: string,
+        updater: (metadata: Metadata) => Metadata,
+        options?: Readonly<{ serverId?: string | null }>,
+    ) => Promise<void>;
 }>): Promise<void> {
     await params.updateSessionMetadataWithRetry(params.sessionId, (metadata) => computeNextSessionModelsSeedMetadata({
         metadata,
@@ -83,5 +88,5 @@ export async function publishSessionModelsSeedToMetadata(params: Readonly<{
         currentModelId: params.currentModelId,
         availableModels: params.availableModels,
         updatedAt: params.updatedAt,
-    }));
+    }), { serverId: params.serverId });
 }

--- a/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.ts
+++ b/apps/ui/sources/sync/engine/overrides/sessionModelsSeedPublish.ts
@@ -1,0 +1,87 @@
+import type { Metadata } from '@/sync/domains/state/storageTypes';
+import type { PreflightModelList } from '@/sync/domains/models/modelOptions';
+import { readSessionModelsState } from '@/sync/domains/sessionControl/readSessionControlMetadata';
+import { readNonBlankSessionControlIdentifier } from '@/sync/domains/sessionControl/opaqueIdentifiers';
+
+/**
+ * Seed the session model list from the new-session wizard's preflight probe.
+ *
+ * Providers without a static catalog (e.g. Pi) only publish `sessionModelsV1` once their runtime
+ * process starts, and runtime start is deferred until the first prompt. Seeding the freshly
+ * spawned session with the probe result the user just picked from keeps the in-session model
+ * picker populated during that window. The runtime publish stays authoritative: the seed only
+ * lands when no model list exists yet, so it can never mask or revert live runtime state.
+ */
+export function computeNextSessionModelsSeedMetadata(params: Readonly<{
+    metadata: Metadata;
+    provider: string;
+    currentModelId: string;
+    availableModels: PreflightModelList['availableModels'];
+    updatedAt: number;
+}>): Metadata {
+    // Seed-only: any existing models state (either metadata alias, any provider) was published by
+    // a runtime or inheritance path that owns the truth. The CAS updater re-runs against fresh
+    // metadata on version conflicts, so this check also makes a seed that lost the race to the
+    // first runtime publish a no-op instead of overwriting it.
+    if (readSessionModelsState(params.metadata) !== null) return params.metadata;
+
+    const provider = readNonBlankSessionControlIdentifier(params.provider);
+    const currentModelId = readNonBlankSessionControlIdentifier(params.currentModelId);
+    if (!provider || !currentModelId) return params.metadata;
+
+    const availableModels = params.availableModels.flatMap((model) => {
+        const id = readNonBlankSessionControlIdentifier(model.id);
+        const name = readNonBlankSessionControlIdentifier(model.name);
+        if (!id || !name) return [];
+        const description = typeof model.description === 'string' && model.description.trim().length > 0
+            ? model.description
+            : null;
+        return [{
+            id,
+            name,
+            ...(description ? { description } : {}),
+            ...(typeof model.contextWindowTokens === 'number' && Number.isFinite(model.contextWindowTokens) && model.contextWindowTokens > 0
+                ? { contextWindowTokens: model.contextWindowTokens }
+                : {}),
+            ...(readNonBlankSessionControlIdentifier(model.extendedContextModelId)
+                ? { extendedContextModelId: model.extendedContextModelId }
+                : {}),
+            ...(Array.isArray(model.modelOptions) && model.modelOptions.length > 0
+                ? { modelOptions: model.modelOptions }
+                : {}),
+        }];
+    });
+    if (availableModels.length === 0) return params.metadata;
+
+    const seed = {
+        v: 1 as const,
+        provider,
+        updatedAt: params.updatedAt,
+        currentModelId,
+        availableModels,
+    };
+    return {
+        ...params.metadata,
+        sessionModelsV1: seed,
+        // Runtime publishes write both aliases; keep the seed at parity so readers on
+        // either key observe the same list.
+        acpSessionModelsV1: seed,
+    };
+}
+
+export async function publishSessionModelsSeedToMetadata(params: Readonly<{
+    sessionId: string;
+    provider: string;
+    currentModelId: string;
+    availableModels: PreflightModelList['availableModels'];
+    updatedAt: number;
+    updateSessionMetadataWithRetry: (sessionId: string, updater: (metadata: Metadata) => Metadata) => Promise<void>;
+}>): Promise<void> {
+    await params.updateSessionMetadataWithRetry(params.sessionId, (metadata) => computeNextSessionModelsSeedMetadata({
+        metadata,
+        provider: params.provider,
+        currentModelId: params.currentModelId,
+        availableModels: params.availableModels,
+        updatedAt: params.updatedAt,
+    }));
+}

--- a/apps/ui/sources/sync/sync.ts
+++ b/apps/ui/sources/sync/sync.ts
@@ -395,6 +395,8 @@ import { socketEmitWithAckFallback } from './engine/socket/socketEmitWithAckFall
 import { publishPermissionModeToMetadata as publishPermissionModeToMetadataEngine } from './engine/overrides/permissionModePublish';
 import { publishAcpSessionModeOverrideToMetadata as publishAcpSessionModeOverrideToMetadataEngine } from './engine/overrides/acpSessionModeOverridePublish';
 import { publishModelOverrideToMetadata as publishModelOverrideToMetadataEngine } from './engine/overrides/modelOverridePublish';
+import { publishSessionModelsSeedToMetadata as publishSessionModelsSeedToMetadataEngine } from './engine/overrides/sessionModelsSeedPublish';
+import type { PreflightModelList } from '@/sync/domains/models/modelOptions';
 import { getModelScopedConfigTombstonesV1Supported } from './domains/state/agentStateCapabilities';
 import { publishAcpConfigOptionOverrideToMetadata as publishAcpConfigOptionOverrideToMetadataEngine, type AcpConfigOptionOverrideValueId } from './engine/overrides/acpConfigOptionOverridePublish';
 import { RPC_ERROR_CODES, SESSION_RPC_METHODS } from '@happier-dev/protocol/rpc';
@@ -3232,9 +3234,31 @@ class Sync {
             sessionId: params.sessionId,
             modelId: params.modelId,
             updatedAt: params.updatedAt,
-            retireModelScopedConfigOverrides: getModelScopedConfigTombstonesV1Supported(
+                retireModelScopedConfigOverrides: getModelScopedConfigTombstonesV1Supported(
                 storage.getState().sessions[params.sessionId]?.agentState?.capabilities,
             ),
+            updateSessionMetadataWithRetry: (sessionId, updater) => this.updateSessionMetadataWithRetry(sessionId, updater),
+        });
+    }
+
+    /**
+     * Seed `sessionModelsV1` from the new-session wizard's preflight probe. Best-effort and
+     * seed-only: providers without a static catalog publish the authoritative list once their
+     * runtime starts, and that publish overwrites this seed.
+     */
+    async publishSessionModelsSeedToMetadata(params: {
+        sessionId: string;
+        agentId: string;
+        currentModelId: string;
+        availableModels: PreflightModelList['availableModels'];
+        updatedAt: number;
+    }): Promise<void> {
+        await publishSessionModelsSeedToMetadataEngine({
+            sessionId: params.sessionId,
+            provider: params.agentId,
+            currentModelId: params.currentModelId,
+            availableModels: params.availableModels,
+            updatedAt: params.updatedAt,
             updateSessionMetadataWithRetry: (sessionId, updater) => this.updateSessionMetadataWithRetry(sessionId, updater),
         });
     }

--- a/apps/ui/sources/sync/sync.ts
+++ b/apps/ui/sources/sync/sync.ts
@@ -3248,6 +3248,7 @@ class Sync {
      */
     async publishSessionModelsSeedToMetadata(params: {
         sessionId: string;
+        serverId?: string | null;
         agentId: string;
         currentModelId: string;
         availableModels: PreflightModelList['availableModels'];
@@ -3255,11 +3256,12 @@ class Sync {
     }): Promise<void> {
         await publishSessionModelsSeedToMetadataEngine({
             sessionId: params.sessionId,
+            serverId: params.serverId,
             provider: params.agentId,
             currentModelId: params.currentModelId,
             availableModels: params.availableModels,
             updatedAt: params.updatedAt,
-            updateSessionMetadataWithRetry: (sessionId, updater) => this.updateSessionMetadataWithRetry(sessionId, updater),
+            updateSessionMetadataWithRetry: (sessionId, updater, options) => this.updateSessionMetadataWithRetry(sessionId, updater, options),
         });
     }
 

--- a/docs/agents-catalog.md
+++ b/docs/agents-catalog.md
@@ -159,6 +159,15 @@ active producer with its consumer gated off — the published list is silently d
 that flag is a user-visible change: the app switches to the dynamic row builder, which carries less
 per-model metadata than the static one, so audit what the dynamic path drops before flipping.
 
+Dynamic providers whose runtime starts lazily (Pi starts its process on the first prompt) publish
+`sessionModelsV1` only after that first prompt, so the in-session model picker would offer nothing
+but the current model and freeform custom until then. To close that window, the new-session screen
+seeds the server-persisted `sessionModelsV1` from the wizard's own preflight probe at spawn
+(`sync.publishSessionModelsSeedToMetadata`, wired in `useCreateNewSession`). The seed is
+deliberately seed-only: if the runtime has already published for this session, the write is a
+no-op, and the runtime re-publish stays authoritative. It only applies to `dynamicProbe !==
+'static-only'` agents with no curated static list, and to built-in-agents spawns (not ACP custom).
+
 A provider with both surfaces needs **one owner** for the model list. Claude's is
 `apps/cli/src/backends/claude/models/resolveClaudeModelCatalog.ts`: the preflight probe adapter and
 the in-session `sessionModelsV1` publisher both read it, so the two pickers cannot disagree about


### PR DESCRIPTION
## Problem

Pi (experimental) has no curated `staticModels` in `AGENT_MODEL_CONFIG`, so its in-session model list comes only from runtime-published `sessionModelsV1` metadata. But `runPi.ts` omits `startRuntimeBeforeFirstPrompt`, so the pi child process — and with it `PiRpcBackend.publishRuntimeState()` → `session_models_state` → `sessionModelsV1` — only starts on the first message turn.

A session that's created and never messaged therefore has no `sessionModelsV1` at all, and the in-session model picker degrades to exactly three options: the current model, "Use CLI settings" (`default`), and freeform Custom — even though the new-session wizard showed the full probed list seconds earlier.

Reproduced against a fresh daemon-spawned Pi session: `metadataVersion` stays at its create-time value, no `update-metadata` traffic, no pi child process, zero transcript events.

## Fix

The wizard already ran the preflight models probe (`piPreflightModelsProbeAdapter`) to show the list; the result was simply discarded at spawn. Now:

- `sync.publishSessionModelsSeedToMetadata` (new engine writer in `sync/engine/overrides/sessionModelsSeedPublish.ts`, wired alongside the existing `publishSession*ToMetadata` publishers) persists the wizard's preflight list as the session's `sessionModelsV1` after a successful spawn.
- The writer is **seed-only**: it no-ops whenever a fresher (or equal-`updatedAt`) `sessionModelsV1` already exists, so a lost race with the first runtime publish can never overwrite or downgrade live data. The runtime publish stays authoritative, and fork/inheritance semantics (which copy server-final state) are unaffected.
- Gated to: built-in-agent spawns (not ACP custom), `dynamicProbe !== 'static-only'`, and agents with no curated static catalog (via `getAgentStaticModels`). Claude/Codex and static-probe agents are untouched. Best-effort: a failed seed write leaves behavior exactly as before.

`docs/agents-catalog.md` documents the new owner in the *Dynamic model lists* section.

## Validation

- **RED → GREEN**: engine tests failed on missing module; hook focus assertions failed on `publishSessionModelsSeedToMetadata is not a function` before wiring. Load-bearing readers re-verified red when the behavior was broken (existing-finals flip, malformed-row dropping). 11/11 tests pass on `pi-system-prompt` and re-verified on the `origin/dev` baseline.
- **Typecheck**: no errors in touched files.
- **Live gate** (web UI → dev relay → real daemon): spawned a Pi session with a probed model selected; the server-persisted `sessionModelsV1` (318KB payload) landed at `metadataVersion` 1, ~5s before the pi process could publish (pi takes ~6–8s just to open a session — its re-publish arrived later as version 2). The in-session model chip then showed the full probed list instead of the 3-option fallback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789734004&installation_model_id=20481&pr_number=278&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F278&signature=9949b3a1d029ed663820790f1633c2653d69998b9849350be4678b5e112a3d13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed session model lists from wizard preflight probe for dynamic agents
> - Adds shared utilities `qualifyPiModelId`, `normalizePiThinkingEffort`, and `createPiModelCatalogEntry` in [piModelCatalog.ts](https://github.com/happier-dev/happier/pull/278/files#diff-daad2c38f330add45ff646bd738f517a45c18e88fac3826e012ca6bf3fc046cb) to standardize Pi model catalog entries with qualified `provider/modelId` identifiers and optional thinking-effort options.
> - The wizard preflight probe and `PiRpcBackend.publishRuntimeState` now produce standardized catalog entries instead of bespoke shapes, and `currentModelId` is qualified with provider when known.
> - The UI creation hook in [useCreateNewSession.ts](https://github.com/happier-dev/happier/pull/278/files#diff-8147ecddc3bd40d00a96b247892c485935f8948373d6b3faddf44b2eb7439664) seeds `sessionModelsV1` metadata from preflight results after spawn for built-in dynamic agents without curated static catalogs. Seeding is best-effort, async, and skips agents that already have static model options or are static-only probe agents.
> - New sync-engine functions in [sessionModelsSeedPublish.ts](https://github.com/happier-dev/happier/pull/278/files#diff-3ab32c23803699c75f928aa7511c113f26760c91cd7f6a73452202f23552a5bf) provide a non-overwriting, CAS-backed way to persist the seed, leaving existing runtime-published state intact.
> - Behavioral Change: runtime session state now publishes qualified model ids (e.g. `openai/gpt-4o-mini`) instead of bare ids; consumers expecting unqualified ids in `currentModelId` or `availableModels` entries need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c0d64f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New sessions can automatically include models detected during setup.
  * Model descriptions, context limits, provider-qualified identifiers, and options are preserved.
  * Runtime model lists take precedence over setup-time defaults.
  * Pi models now display consistent names and supported thinking options.

* **Bug Fixes**
  * Improved handling of invalid, incomplete, or duplicate model information during setup.

* **Documentation**
  * Updated agent catalog documentation to explain dynamic model-list behavior and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->