### PR TITLE
fix(cli): avoid TDZ ReferenceError on synchronous stdin.write in nodeToWebStreams

### DIFF
--- a/apps/cli/src/agent/acp/__tests__/nodeToWebStreams.test.ts
+++ b/apps/cli/src/agent/acp/__tests__/nodeToWebStreams.test.ts
@@ -124,4 +124,17 @@ describe('nodeToWebStreams', () => {
             [4, 5, 6],
         ]);
     });
+
+    it('handles synchronous write callback without TDZ reference error', async () => {
+        const stdin = new FakeStdin((_chunk, cb) => {
+            cb(null);
+            return true;
+        });
+        const stdout = new Readable({ read() { } });
+
+        const { writable } = nodeToWebStreams(stdin as any, stdout);
+        const writer = writable.getWriter();
+        await expect(writer.write(new Uint8Array([1, 2, 3]))).resolves.toBeUndefined();
+        writer.releaseLock();
+    });
 });

--- a/apps/cli/src/agent/acp/nodeToWebStreams.ts
+++ b/apps/cli/src/agent/acp/nodeToWebStreams.ts
@@ -121,7 +121,8 @@ export function nodeToWebStreams(
                 // from custom Writable implementations (or odd edge cases).
                 stdin.once('drain', onDrain);
 
-                const ok = stdin.write(chunk, (err) => {
+                let ok = false;
+                ok = stdin.write(chunk, (err) => {
                     wrote = true;
                     if (err) {
                         onWriteError(err);
@@ -150,6 +151,11 @@ export function nodeToWebStreams(
                 if (ok) {
                     // No drain will be emitted for this write; remove the listener immediately.
                     stdin.off('drain', onDrain);
+                    if (wrote && !settled) {
+                        settled = true;
+                        clearActiveWriteErrorHandler();
+                        resolve();
+                    }
                 }
             });
         };


### PR DESCRIPTION
## Summary
Fixes an issue where `nodeToWebStreams` throws `ReferenceError: Cannot access 'ok' before initialization` (surfacing as `Cannot access 'ok3' before initialization` in bundled distributions) when `stdin.write` invokes its callback synchronously.

## Problem
In `apps/cli/src/agent/acp/nodeToWebStreams.ts`:
```typescript
const ok = stdin.write(chunk, (err) => {
    ...
    if (ok) {
        ...
    }
});
```
When `stdin.write` invokes the callback synchronously, `if (ok)` is evaluated inside the callback before the outer variable declaration finishes assignment. In JavaScript/TypeScript runtimes, accessing a `const` variable before initialization throws a TDZ `ReferenceError`. This causes ACP backend initialization to fail and close the connection immediately.

Additionally, if the callback completes synchronously during `stdin.write`, `wrote` is set to `true`, but the outer write promise was not settled if `ok === true` was returned after the callback returned.

## Solution
1. Pre-declare `let ok = false;` before calling `stdin.write(chunk, ...)`.
2. Settle the write promise (`resolve()`) when `stdin.write` returns `true` and the write has already synchronously completed (`wrote && !settled`).
3. Added unit test in `nodeToWebStreams.test.ts` verifying synchronous write callbacks execute and resolve cleanly without ReferenceErrors.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TDZ ReferenceError on synchronous `stdin.write` callback in `nodeToWebStreams`
> In [nodeToWebStreams.ts](https://github.com/happier-dev/happier/pull/280/files#diff-3419c335f972b19a9710fe5a57372c00754b61a2e0a1157ef0da417d03266558), the `ok` variable was declared as `const` after `stdin.write()` was called, so a synchronous write callback referencing `ok` would throw a TDZ `ReferenceError`. The fix pre-declares `ok` as `let` before the `stdin.write` call and immediately resolves the write promise when both `ok` is `true` and the callback has already fired synchronously.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26c18e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could interrupt successful standard-input writes with an internal error.
  * Improved handling of write completion so successful data transfers finish reliably.

* **Tests**
  * Added regression coverage for successful synchronous input writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->