### PR TITLE
fix(cli-claude): advertise structured answer support for terminal dialogs

### DIFF
--- a/apps/cli/src/backends/claude/unifiedTerminal/dialogChoice/claudeUnifiedDialogChoiceBroker.test.ts
+++ b/apps/cli/src/backends/claude/unifiedTerminal/dialogChoice/claudeUnifiedDialogChoiceBroker.test.ts
@@ -166,6 +166,27 @@ describe('ClaudeUnifiedDialogChoiceBroker lifecycle', () => {
     });
   });
 
+  it('advertises structured answer support on the request it publishes', async () => {
+    // The request is published under the AskUserQuestion tool name, so a client that
+    // declines the ambiguous legacy downgrade gates submission on this capability.
+    // Without it the dialog is unanswerable remotely even though the broker accepts
+    // the modern structured answer, as the preceding test shows.
+    const { session, client } = createPermissionHandlerSessionStub('dialog-broker-capabilities');
+    const broker = new ClaudeUnifiedDialogChoiceBroker(session, { createRequestId: () => 'dialog-1' });
+    broker.activate();
+
+    const pending = broker.requestDialogChoice({ dialog: dialog(EFFORT_DIALOG) });
+    void pending.catch(() => {});
+    await vi.waitFor(() => expect(client.agentState.requests['dialog-1']).toBeDefined());
+
+    expect(client.agentState.capabilities).toMatchObject({
+      askUserQuestionAnswersInPermission: true,
+      structuredQuestionAnswersV1Supported: true,
+    });
+
+    await broker.dispose();
+  });
+
   it('does not finish disposal while a denied choice cancellation is still persisting', async () => {
     const { session, client } = createPermissionHandlerSessionStub('dialog-broker-denied-cleanup');
     const broker = new ClaudeUnifiedDialogChoiceBroker(session, { createRequestId: () => 'dialog-1' });

--- a/apps/cli/src/backends/claude/unifiedTerminal/dialogChoice/claudeUnifiedDialogChoiceBroker.ts
+++ b/apps/cli/src/backends/claude/unifiedTerminal/dialogChoice/claudeUnifiedDialogChoiceBroker.ts
@@ -259,6 +259,7 @@ export class ClaudeUnifiedDialogChoiceBroker {
           capabilities: {
             ...(state.capabilities && typeof state.capabilities === 'object' ? state.capabilities : {}),
             askUserQuestionAnswersInPermission: true,
+            structuredQuestionAnswersV1Supported: true,
           },
         }),
       }),


### PR DESCRIPTION
`ClaudeUnifiedDialogChoiceBroker` publishes its dialogs into `agentState` as `AskUserQuestion` permission requests, but advertises only `askUserQuestionAnswersInPermission`, never `structuredQuestionAnswersV1Supported`. The two sibling publication paths in `permissionHandler.ts` and `localPermissionBridge.ts` advertise both.

The path already accepts v1 answers: `ClaudePermissionRpcRouter` dispatches `session.structuredQuestion.respond.v1` through the same consumer fan-out as the legacy method, and `decodeDialogChoice` reads `payload.structuredAnswersV1`, as the neighbouring test asserts. It just never says so, so a client that declines the ambiguous legacy downgrade cannot answer any recognized terminal dialog (`trust_folder`, `safeguard_pause`, `resume_choice`, and the rest), even though this path would accept the answer. The first-party UI degrades to legacy when the capability is absent, which is why it never surfaced there.

Fix: one line in the broker's `updateState`, mirroring the siblings, plus a test asserting a published dialog request advertises both bits.

Validation: `yarn workspace @happier-dev/cli vitest run --config vitest.config.ts src/backends/claude/unifiedTerminal/dialogChoice/claudeUnifiedDialogChoiceBroker.test.ts` gives 9 passed. The new test is RED without the production line and GREEN with it, and a wider slice around the corridor shows no regressions.

If you would rather fix it structurally, the advertisement could be owned by the shared publication seam all three paths already call (`AgentStateRequestStore` or the permission coordinator), so no publisher can forget it. Happy to reshape.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824074&installation_model_id=20481&pr_number=284&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F284&signature=1ecba5982da3895482b857c42cb2a2ba6e7d9dbbb6d744a7d9c43013727c4f86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise structured answer support in `ClaudeUnifiedDialogChoiceBroker`
> Sets `structuredQuestionAnswersV1Supported: true` on the capabilities object when `ClaudeUnifiedDialogChoiceBroker` publishes a dialog choice request. Adds a test verifying `agentState.capabilities` includes both `structuredQuestionAnswersV1Supported` and `askUserQuestionAnswersInPermission`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16c05c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission requests now indicate support for structured answers to user questions.
  * Existing legacy answer support remains available for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


