### PR TITLE
feat(cli-pi): stream thinking deltas and reconcile the authoritative snapshot

### DIFF
--- a/apps/cli/src/agent/acp/runtime/__tests__/createAcpRuntime.thinkingStream.test.ts
+++ b/apps/cli/src/agent/acp/runtime/__tests__/createAcpRuntime.thinkingStream.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { MessageBuffer } from '@/ui/ink/messageBuffer';
+import type { ACPMessageData } from '@/api/session/sessionMessageTypes';
+import type { AgentMessage } from '@/agent';
+
+import { createTestAcpRuntime as createAcpRuntime } from '@/testkit/backends/acpRuntime';
+import { createFakeAcpRuntimeBackend } from '@/testkit/backends/acpRuntimeBackend';
+import { createApprovedPermissionHandler } from '@/testkit/backends/permissionHandler';
+import { createBasicSessionClientWithOverrides } from '@/testkit/backends/sessionFixtures';
+
+type ThinkingCommit = { body: ACPMessageData; segmentState: string };
+
+async function createRuntimeWithThinkingCommits(): Promise<{
+  backend: ReturnType<typeof createFakeAcpRuntimeBackend>;
+  thinkingCommits: () => ThinkingCommit[];
+  flushTurn: () => Promise<void>;
+}> {
+  const backend = createFakeAcpRuntimeBackend({ sessionId: 'sess_main' });
+  const durableCalls: Array<{ localId: string; body: ACPMessageData; meta?: Record<string, unknown> }> = [];
+  const session = createBasicSessionClientWithOverrides({
+    sendAgentMessageCommitted: async (_provider, body, opts) => {
+      durableCalls.push({ localId: opts.localId, body, meta: opts.meta });
+    },
+  });
+
+  const runtime = createAcpRuntime({
+    provider: 'pi',
+    directory: '/tmp',
+    session,
+    messageBuffer: new MessageBuffer(),
+    mcpServers: {},
+    permissionHandler: createApprovedPermissionHandler(),
+    onThinkingChange: () => {},
+    ensureBackend: async () => backend,
+  });
+
+  await runtime.startOrLoad({});
+  runtime.beginTurn();
+
+  return {
+    backend,
+    thinkingCommits: () => durableCalls
+      .filter((call) => call.body.type === 'thinking')
+      .map((call) => ({
+        body: call.body,
+        segmentState: String((call.meta as any)?.happierStreamSegmentV1?.segmentState ?? ''),
+      })),
+    flushTurn: () => runtime.flushTurn(),
+  };
+}
+
+function thinkingDelta(text: string): AgentMessage {
+  return { type: 'event', name: 'thinking', payload: { text } };
+}
+
+function thinkingSnapshot(fullText: string): AgentMessage {
+  return { type: 'event', name: 'thinking', payload: { fullText } };
+}
+
+function lastCommittedText(commits: ThinkingCommit[]): string {
+  const last = commits.at(-1);
+  expect(last).toBeDefined();
+  expect(last!.body).toMatchObject({ type: 'thinking' });
+  return (last!.body as { text: string }).text;
+}
+
+describe('createAcpRuntime (thinking stream reconciliation)', () => {
+  it('accumulates thinking deltas into one committed thinking segment', async () => {
+    const harness = await createRuntimeWithThinkingCommits();
+    harness.backend.emit(thinkingDelta('I should '));
+    harness.backend.emit(thinkingDelta('greet.'));
+    await harness.flushTurn();
+
+    const commits = harness.thinkingCommits();
+    expect(commits.length).toBeGreaterThan(0);
+    expect(lastCommittedText(commits)).toBe('I should greet.');
+    expect(commits.at(-1)!.segmentState).toBe('complete');
+  });
+
+  it('appends only the unstreamed suffix when an authoritative snapshot repeats streamed deltas', async () => {
+    const harness = await createRuntimeWithThinkingCommits();
+    harness.backend.emit(thinkingDelta('I should '));
+    harness.backend.emit(thinkingDelta('greet.'));
+    harness.backend.emit(thinkingSnapshot('I should greet.'));
+    await harness.flushTurn();
+
+    expect(lastCommittedText(harness.thinkingCommits())).toBe('I should greet.');
+  });
+
+  it('appends the full snapshot text when no deltas were streamed', async () => {
+    const harness = await createRuntimeWithThinkingCommits();
+    harness.backend.emit(thinkingSnapshot('final thought'));
+    await harness.flushTurn();
+
+    expect(lastCommittedText(harness.thinkingCommits())).toBe('final thought');
+  });
+
+  it('surfaces a divergent authoritative snapshot after diverging deltas', async () => {
+    const harness = await createRuntimeWithThinkingCommits();
+    harness.backend.emit(thinkingDelta('partial'));
+    harness.backend.emit(thinkingSnapshot('divergent authoritative text'));
+    await harness.flushTurn();
+
+    expect(lastCommittedText(harness.thinkingCommits())).toBe('partial\n\ndivergent authoritative text');
+  });
+
+  it('resets snapshot reconciliation between assistant messages in one turn', async () => {
+    const harness = await createRuntimeWithThinkingCommits();
+    harness.backend.emit(thinkingDelta('first '));
+    harness.backend.emit(thinkingSnapshot('first thought'));
+    harness.backend.emit(thinkingDelta('second '));
+    harness.backend.emit(thinkingSnapshot('second thought'));
+    await harness.flushTurn();
+
+    expect(lastCommittedText(harness.thinkingCommits())).toBe('first thoughtsecond thought');
+  });
+});

--- a/apps/cli/src/agent/acp/runtime/__tests__/createAcpRuntime.thinkingStream.test.ts
+++ b/apps/cli/src/agent/acp/runtime/__tests__/createAcpRuntime.thinkingStream.test.ts
@@ -11,6 +11,14 @@ import { createBasicSessionClientWithOverrides } from '@/testkit/backends/sessio
 
 type ThinkingCommit = { body: ACPMessageData; segmentState: string };
 
+/** Narrow `meta.happierStreamSegmentV1` to its typed shape (canonical writer: buildStreamedTranscriptSegmentSnapshot). */
+function readSegmentState(meta: Record<string, unknown> | undefined): string {
+  const segment = meta?.happierStreamSegmentV1;
+  if (!segment || typeof segment !== 'object' || Array.isArray(segment)) return '';
+  const state = (segment as Record<string, unknown>).segmentState;
+  return typeof state === 'string' ? state : '';
+}
+
 async function createRuntimeWithThinkingCommits(): Promise<{
   backend: ReturnType<typeof createFakeAcpRuntimeBackend>;
   thinkingCommits: () => ThinkingCommit[];
@@ -44,7 +52,7 @@ async function createRuntimeWithThinkingCommits(): Promise<{
       .filter((call) => call.body.type === 'thinking')
       .map((call) => ({
         body: call.body,
-        segmentState: String((call.meta as any)?.happierStreamSegmentV1?.segmentState ?? ''),
+        segmentState: readSegmentState(call.meta),
       })),
     flushTurn: () => runtime.flushTurn(),
   };

--- a/apps/cli/src/agent/acp/runtime/__tests__/createAcpRuntime.thinkingStream.test.ts
+++ b/apps/cli/src/agent/acp/runtime/__tests__/createAcpRuntime.thinkingStream.test.ts
@@ -12,12 +12,12 @@ import { createBasicSessionClientWithOverrides } from '@/testkit/backends/sessio
 type ThinkingCommit = { body: ACPMessageData; segmentState: string };
 
 /** Narrow `meta.happierStreamSegmentV1` to its typed shape (canonical writer: buildStreamedTranscriptSegmentSnapshot). */
-function readSegmentState(meta: Record<string, unknown> | undefined): string {
+const readSegmentState = (meta: Record<string, unknown> | undefined): string => {
   const segment = meta?.happierStreamSegmentV1;
   if (!segment || typeof segment !== 'object' || Array.isArray(segment)) return '';
   const state = (segment as Record<string, unknown>).segmentState;
   return typeof state === 'string' ? state : '';
-}
+};
 
 async function createRuntimeWithThinkingCommits(): Promise<{
   backend: ReturnType<typeof createFakeAcpRuntimeBackend>;

--- a/apps/cli/src/agent/acp/runtime/createAcpRuntime.ts
+++ b/apps/cli/src/agent/acp/runtime/createAcpRuntime.ts
@@ -571,6 +571,7 @@ export function createAcpRuntime(params: {
     observedAt: number;
   }> | null = null;
   let accumulatedResponse = '';
+  let accumulatedThinkingText = '';
   let isResponseInProgress = false;
   let taskStartedSent = false;
   let turnAborted = false;
@@ -807,6 +808,7 @@ export function createAcpRuntime(params: {
       });
     }
     accumulatedResponse = '';
+    accumulatedThinkingText = '';
     isResponseInProgress = false;
     taskStartedSent = false;
     turnAborted = false;
@@ -1744,10 +1746,30 @@ export function createAcpRuntime(params: {
           }
           if (name === 'thinking') {
             const payloadRecord = asRecord(msg.payload);
-            const textRaw = payloadRecord?.text;
-            const text = typeof textRaw === 'string' ? textRaw : '';
-            if (text) {
-              streamedTranscriptWriter.appendThinkingDelta(text);
+            const fullTextRaw = payloadRecord?.fullText;
+            if (typeof fullTextRaw === 'string' && fullTextRaw.length > 0) {
+              // Authoritative snapshot (e.g. pi message_end): append only what streamed deltas
+              // have not already delivered, mirroring the model-output fullText reconciliation.
+              if (accumulatedThinkingText && fullTextRaw.startsWith(accumulatedThinkingText)) {
+                const suffix = fullTextRaw.slice(accumulatedThinkingText.length);
+                if (suffix) {
+                  streamedTranscriptWriter.appendThinkingDelta(suffix);
+                }
+              } else if (!accumulatedThinkingText) {
+                streamedTranscriptWriter.appendThinkingDelta(fullTextRaw);
+              } else {
+                // Defensive: divergent authoritative text — surface it rather than lose reasoning.
+                streamedTranscriptWriter.appendThinkingDelta('\n\n');
+                streamedTranscriptWriter.appendThinkingDelta(fullTextRaw);
+              }
+              accumulatedThinkingText = '';
+            } else {
+              const textRaw = payloadRecord?.text;
+              const text = typeof textRaw === 'string' ? textRaw : '';
+              if (text) {
+                streamedTranscriptWriter.appendThinkingDelta(text);
+                accumulatedThinkingText += text;
+              }
             }
           }
           break;

--- a/apps/cli/src/backends/pi/rpc/eventMapping.test.ts
+++ b/apps/cli/src/backends/pi/rpc/eventMapping.test.ts
@@ -3,22 +3,29 @@ import { describe, expect, it } from 'vitest';
 import { mapPiRpcEventToAgentMessages } from './eventMapping';
 
 describe('mapPiRpcEventToAgentMessages', () => {
-  it('maps assistant message updates to model-output fullText', () => {
+  it('maps assistant text deltas from message_update to streaming model output', () => {
     const output = mapPiRpcEventToAgentMessages({
       type: 'message_update',
-      assistantMessageEvent: { type: 'text_delta', delta: 'hello' },
-      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'hello' },
     });
-    expect(output).toEqual([{ type: 'model-output', fullText: 'hello' }]);
+    expect(output).toEqual([{ type: 'model-output', textDelta: 'hello' }]);
   });
 
-  it('preserves leading whitespace in model output text', () => {
+  it('falls back to the cumulative message for message_update events that still carry one', () => {
     const output = mapPiRpcEventToAgentMessages({
       type: 'message_update',
-      assistantMessageEvent: { type: 'text_delta', delta: ' world' },
+      assistantMessageEvent: { type: 'text_end', contentIndex: 0, content: 'hello world' },
       message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
     });
     expect(output).toEqual([{ type: 'model-output', fullText: 'hello world' }]);
+  });
+
+  it('maps thinking deltas to thinking stream events', () => {
+    const output = mapPiRpcEventToAgentMessages({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'thinking_delta', contentIndex: 0, delta: 'I should ' },
+    });
+    expect(output).toEqual([{ type: 'event', name: 'thinking', payload: { text: 'I should ' } }]);
   });
 
   it('maps tool execution lifecycle events', () => {
@@ -107,6 +114,52 @@ describe('mapPiRpcEventToAgentMessages', () => {
       message: { role: 'assistant', content: [{ type: 'text', text: 'final' }] },
     });
     expect(output).toEqual([{ type: 'model-output', fullText: 'final' }]);
+  });
+
+  it('emits an authoritative thinking snapshot alongside text on message_end', () => {
+    const output = mapPiRpcEventToAgentMessages({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'I should greet the user.' },
+          { type: 'text', text: 'Hi!' },
+        ],
+      },
+    });
+    expect(output).toEqual([
+      { type: 'event', name: 'thinking', payload: { fullText: 'I should greet the user.' } },
+      { type: 'model-output', fullText: 'Hi!' },
+    ]);
+  });
+
+  it('emits the thinking snapshot for a thinking-only message_end', () => {
+    const output = mapPiRpcEventToAgentMessages({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'plan' },
+          { type: 'toolCall', id: 'call_1', name: 'bash', arguments: {} },
+        ],
+      },
+    });
+    expect(output).toEqual([{ type: 'event', name: 'thinking', payload: { fullText: 'plan' } }]);
+  });
+
+  it('joins multiple thinking blocks by concatenation to match the delta stream', () => {
+    const output = mapPiRpcEventToAgentMessages({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'first block' },
+          { type: 'toolCall', id: 'call_1', name: 'bash', arguments: {} },
+          { type: 'thinking', thinking: 'second block' },
+        ],
+      },
+    });
+    expect(output).toEqual([{ type: 'event', name: 'thinking', payload: { fullText: 'first blocksecond block' } }]);
   });
 
   it('maps agent lifecycle events to status messages and keeps terminal boundaries informational', () => {

--- a/apps/cli/src/backends/pi/rpc/eventMapping.ts
+++ b/apps/cli/src/backends/pi/rpc/eventMapping.ts
@@ -75,6 +75,33 @@ function extractAssistantText(message: unknown): string | null {
   return text;
 }
 
+/**
+ * Extract the authoritative thinking text of a finished assistant message. Pi streams
+ * thinking deltas live, but `message_end.message` is the authoritative snapshot; joining
+ * the thinking blocks here lets the consumer reconcile what the deltas already delivered.
+ * Blocks join by direct concatenation to match the delta stream, which carries no
+ * block-boundary separator either.
+ */
+function extractAssistantThinking(message: unknown): string | null {
+  const record = asRecord(message);
+  if (!record) return null;
+  if (record.role !== 'assistant') return null;
+  const content = record.content;
+  if (!Array.isArray(content)) return null;
+
+  let thinking = '';
+  for (const item of content) {
+    const entry = asRecord(item);
+    if (!entry) continue;
+    if (entry.type !== 'thinking') continue;
+    const chunk = asString(entry.thinking);
+    if (chunk === null) continue;
+    thinking += chunk;
+  }
+
+  return thinking.length > 0 ? thinking : null;
+}
+
 function extractTextFromToolResult(value: unknown): string | null {
   const record = asRecord(value);
   if (!record) return null;
@@ -158,7 +185,30 @@ export function mapPiRpcEventToAgentMessages(event: unknown): AgentMessage[] {
     if (!assistantMessageEvent) return [];
     const assistantType = asNonEmptyString(assistantMessageEvent.type);
     if (!assistantType) return [];
-    if (assistantType === 'text_start' || assistantType === 'text_delta' || assistantType === 'text_end') {
+    if (assistantType === 'text_start') {
+      return [];
+    }
+    if (assistantType === 'text_delta') {
+      // Current pi RPC carries the live delta and omits the cumulative `message`.
+      const delta = asString(assistantMessageEvent.delta);
+      if (delta !== null && delta.length > 0) {
+        return [{ type: 'model-output', textDelta: delta }];
+      }
+      // Older pi sent no delta field and still carried the cumulative message.
+      const fullText = extractAssistantText(record.message);
+      if (fullText !== null && fullText.length > 0) {
+        return [{ type: 'model-output', fullText }];
+      }
+      return [];
+    }
+    if (assistantType === 'thinking_delta') {
+      const delta = asString(assistantMessageEvent.delta);
+      if (delta === null || delta.length === 0) return [];
+      return [{ type: 'event', name: 'thinking', payload: { text: delta } }];
+    }
+    if (assistantType === 'text_end') {
+      // The authoritative per-block `content` was already delivered by the deltas; only
+      // older pi's cumulative `message` adds reconciliation value here.
       const fullText = extractAssistantText(record.message);
       if (fullText === null || fullText.length === 0) return [];
       return [{ type: 'model-output', fullText }];
@@ -167,9 +217,16 @@ export function mapPiRpcEventToAgentMessages(event: unknown): AgentMessage[] {
   }
 
   if (type === 'message_end') {
+    const thinking = extractAssistantThinking(record.message);
     const fullText = extractAssistantText(record.message);
-    if (fullText === null || fullText.length === 0) return [];
-    return [{ type: 'model-output', fullText }];
+    const messages: AgentMessage[] = [];
+    if (thinking !== null && thinking.length > 0) {
+      messages.push({ type: 'event', name: 'thinking', payload: { fullText: thinking } });
+    }
+    if (fullText !== null && fullText.length > 0) {
+      messages.push({ type: 'model-output', fullText });
+    }
+    return messages;
   }
 
   if (type === 'tool_execution_start') {


### PR DESCRIPTION
## Summary

Pi's RPC previously surfaced only cumulative assistant text on `message_update`/`message_end`; thinking (reasoning) blocks were dropped entirely. Current pi emits live `thinking_delta` and `text_delta` events (with the cumulative message omitted), so this maps them end-to-end:

- `text_delta` → streaming model-output `textDelta` (cumulative-message fallback kept for older pi that sends no delta field)
- `thinking_delta` → live thinking stream events
- on `message_end`, the message's thinking blocks are joined into one authoritative thinking snapshot (`fullText` payload) alongside the text, with the turn-scoped reconciliation reset per turn — no duplication across pi's multi-message turns

## Scope

Single focused commit on top of current `dev`. No dependencies on the pi direct-session work; the JSONL history-backfill prototype that grew on the integration branch is deliberately excluded here (it depends on the direct-sessions transcript corridor and will follow separately).

## Testing

- New owner-level suite `createAcpRuntime.thinkingStream.test.ts` covers streaming deltas, the authoritative snapshot at message end, and turn-scoped reset
- Existing lanes green on this branch: `PiRpcBackend.thinkingLevel` + `eventMapping` + the new suite — 20/20
- Validated standalone on top of `dev` @ `9a522f0a15`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789898263&installation_model_id=20481&pr_number=289&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F289&signature=9fb07fc9b603e6bb73fa3cfffd1b51b9d5b88a747a6bf245613d13a1a7367bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream thinking deltas and reconcile authoritative snapshots in `createAcpRuntime`
> - `mapPiRpcEventToAgentMessages` now emits streaming `text_delta` as model-output `textDelta` (instead of `fullText`), `thinking_delta` as `thinking` events with `payload.text`, and `message_end` emits an authoritative `thinking` snapshot (`payload.fullText`) concatenated from all thinking blocks.
> - `createAcpRuntime` accumulates thinking deltas in `accumulatedThinkingText` and reconciles authoritative snapshots: appends only the unstreamed suffix when deltas are a prefix, appends the full snapshot when no deltas were streamed, and inserts a blank line before divergent snapshots. State resets each turn via `resetTurnState()`.
> - Behavioral Change: `text_start` events now yield no messages; `text_end` only emits `fullText` for older legacy payloads. Downstream consumers expecting `fullText` on every `text_delta` will now receive incremental `textDelta` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2de351.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed assistant reasoning and text updates.
  * Prevented duplicate reasoning content when incremental updates and completed snapshots overlap.
  * Correctly reconciled completed reasoning with streamed content, including divergent updates.
  * Preserved reasoning alongside assistant responses, including reasoning-only messages.
  * Improved handling of multiple reasoning segments.
  * Ensured reasoning state resets between assistant messages.
  * Preserved the correct order of reasoning and response content in streamed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->