### PR TITLE
fix(ui-tools): render Pi-style content-array bash results

### DIFF
--- a/apps/ui/sources/components/tools/normalization/parse/stdStreams.test.ts
+++ b/apps/ui/sources/components/tools/normalization/parse/stdStreams.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractStdStreams } from './stdStreams';
+
+describe('extractStdStreams', () => {
+    it('unwraps ACP-style content arrays (Pi) into stdout', () => {
+        expect(extractStdStreams({
+            content: [{ type: 'text', text: 'line one\nline two' }],
+            details: { exit_code: 0 },
+            isError: false,
+        })).toEqual({ stdout: 'line one\nline two' });
+    });
+
+    it('joins multiple text blocks in a content array', () => {
+        expect(extractStdStreams({
+            content: [
+                { type: 'text', text: 'out\n' },
+                { type: 'image', data: 'aGk=', mimeType: 'image/png' },
+                { type: 'text', text: 'more' },
+            ],
+        })).toEqual({ stdout: 'out\nmore' });
+    });
+
+    it('returns null for a content array with no text blocks', () => {
+        expect(extractStdStreams({
+            content: [{ type: 'image', data: 'aGk=', mimeType: 'image/png' }],
+        })).toBeNull();
+    });
+
+    it('prefers explicit stdout over the content array when both exist', () => {
+        expect(extractStdStreams({
+            stdout: 'explicit',
+            content: [{ type: 'text', text: 'from content' }],
+        })).toEqual({ stdout: 'explicit' });
+    });
+
+    it('still accepts plain stream envelopes and raw strings', () => {
+        expect(extractStdStreams('raw string')).toEqual({ stdout: 'raw string' });
+        expect(extractStdStreams({ stdout: 'a', stderr: 'b' })).toEqual({ stdout: 'a', stderr: 'b' });
+        expect(extractStdStreams({ aggregated_output: 'c' })).toEqual({ stdout: 'c' });
+    });
+});

--- a/apps/ui/sources/components/tools/normalization/parse/stdStreams.ts
+++ b/apps/ui/sources/components/tools/normalization/parse/stdStreams.ts
@@ -5,6 +5,27 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     return value as Record<string, unknown>;
 }
 
+/**
+ * ACP-style tool results (Pi) carry output as text blocks in a `content` array with
+ * metadata beside it (`details.exit_code`, …) instead of stream keys. Joining by direct
+ * concatenation matches how those blocks were streamed.
+ */
+function readAcpContentText(value: unknown): string | undefined {
+    const record = asRecord(value);
+    const content = record?.content;
+    if (!Array.isArray(content)) return undefined;
+
+    let text = '';
+    for (const item of content) {
+        const entry = asRecord(item);
+        if (!entry || entry.type !== 'text') continue;
+        const chunk = typeof entry.text === 'string' ? entry.text : undefined;
+        if (chunk === undefined) continue;
+        text += chunk;
+    }
+    return text.length > 0 ? text : undefined;
+}
+
 export type StdStreams = { stdout?: string; stderr?: string };
 
 export function extractStdStreams(result: unknown): StdStreams | null {
@@ -22,7 +43,7 @@ export function extractStdStreams(result: unknown): StdStreams | null {
                 ? obj.aggregated_output
                 : typeof obj.formatted_output === 'string'
                     ? obj.formatted_output
-                    : undefined;
+                    : readAcpContentText(obj);
     const stderr = typeof obj.stderr === 'string' ? obj.stderr : undefined;
     if (!stdout && !stderr) return null;
 

--- a/apps/ui/sources/components/tools/renderers/system/BashView.test.tsx
+++ b/apps/ui/sources/components/tools/renderers/system/BashView.test.tsx
@@ -87,6 +87,34 @@ describe('BashView', () => {
         );
     });
 
+    it('renders Pi-style content-array results at default detail level', async () => {
+        commandViewSpy.mockClear();
+        codeViewSpy.mockClear();
+        const { BashView } = await import('./BashView');
+
+        // Pi delivers bash output as an ACP-style tool result: text blocks in `content`,
+        // metadata in `details`. No stream keys exist on this shape.
+        const tool = makeToolCall({
+            name: 'Bash',
+            state: 'completed',
+            input: { command: 'vitest run sources/components/tools' },
+            result: {
+                content: [{ type: 'text', text: 'Test Files  1 passed (1)' }],
+                details: { exit_code: 0, duration_ms: 6820, truncated: false },
+                isError: false,
+            },
+        });
+
+        const screen = await renderScreen(React.createElement(BashView, makeToolViewProps(tool)));
+
+        expect(screen.findAllByType('CommandView' as any)).toHaveLength(1);
+        expect(commandViewSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                stdout: 'Test Files  1 passed (1)',
+            }),
+        );
+    });
+
     it('does not dump structured JSON when stdout/stderr are empty', async () => {
         commandViewSpy.mockClear();
         codeViewSpy.mockClear();

--- a/apps/ui/sources/components/tools/renderers/system/BashView.test.tsx
+++ b/apps/ui/sources/components/tools/renderers/system/BashView.test.tsx
@@ -107,7 +107,7 @@ describe('BashView', () => {
 
         const screen = await renderScreen(React.createElement(BashView, makeToolViewProps(tool)));
 
-        expect(screen.findAllByType('CommandView' as any)).toHaveLength(1);
+        expect(commandViewSpy).toHaveBeenCalledTimes(1);
         expect(commandViewSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 stdout: 'Test Files  1 passed (1)',


### PR DESCRIPTION
## Problem

Bash tool call results from Pi sessions render no output at all — the row shows the command title and status, but expanding it reveals nothing.

Pi delivers tool results as ACP-style envelopes: output text lives in `content[{type:'text',text}]` with metadata in `details` (including `exit_code`), and there are no `stdout`/`stderr` keys. `extractStdStreams` only recognized plain strings or `{stdout | stderr | aggregated_output | formatted_output}` envelopes, so Pi results parsed to `null`, and the anti-dump guard then suppressed the object entirely except at `full` detail level.

Claude-style providers were unaffected because their results are strings or stream envelopes — which is why the parser only grew those shapes.

## Fix

Extend `extractStdStreams` — the canonical bash-output normalization point — to unwrap ACP-style `content[]` text blocks into `stdout`:

- explicit stream keys keep precedence over `content[]`
- non-text blocks are ignored; empty content still returns `null` (anti-dump behavior preserved)
- read-side only: no wire, persistence, or compatibility surface touched

Verified against live session data: Pi's persisted bash results carry exactly this shape (`content[].text` + `details.exit_code`).

## Testing

- RED→GREEN: new `BashView` test rendering a realistic Pi-shaped result at default detail level, plus focused `extractStdStreams` unit tests (unwrap, multi-block join, image-only content → null, explicit-stdout precedence, existing shapes)
- Broader validation: system-renderer + normalization lanes 22 files / 122 tests passing; typecheck clean for touched files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789916861&installation_model_id=20481&pr_number=290&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F290&signature=222c12543fb9951ca4b8af12c06457f9e6b673cdcaeda352d42d136e9573ce7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `extractStdStreams` to render Pi-style content-array bash results
> - Adds `readAcpContentText` helper in [stdStreams.ts](https://github.com/happier-dev/happier/pull/290/files#diff-618e40c6e4ab8c4967115aadb36ac97e5bc369b5b5144ad484f0a184871ec0ac) that concatenates `text` entries from a `content` array, skipping non-text items
> - Updates `extractStdStreams` to fall back to `readAcpContentText(obj)` after checking `stdout`, `aggregated_output`, and `formatted_output`, so bash results that use ACP-style content arrays now produce stdout output
> - Adds test coverage in [stdStreams.test.ts](https://github.com/happier-dev/happier/pull/290/files#diff-b7b77d314a74f91bf0517ebce83bf0082b4d3f7757c65102d52f9dc8ef779e2e) and [BashView.test.tsx](https://github.com/happier-dev/happier/pull/290/files#diff-35db2e7083a207d32bfb6a4152511918d70bf4117daa62c7377eb6e053c6a403)
> - Behavioral Change: `extractStdStreams` now returns stdout from concatenated `content` text blocks when explicit stream keys are absent; previously it returned null
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a829579.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of command results from ACP/Pi-style responses by combining text content into standard output.
  * Preserved existing output handling, including explicit standard output and plain text responses.
  * Non-text content is ignored when displaying command results.

* **Tests**
  * Added coverage for mixed content, multiple text blocks, empty results, and command output rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->