### PR TITLE
fix(cli): preserve session titles across forks

### DIFF
--- a/apps/cli/src/session/fork/resolveForkInheritedOverridesFromMetadata.test.ts
+++ b/apps/cli/src/session/fork/resolveForkInheritedOverridesFromMetadata.test.ts
@@ -7,7 +7,7 @@ import { resolveForkInheritedOverridesFromMetadata } from './resolveForkInherite
 describe('resolveForkInheritedOverridesFromMetadata', () => {
   it('returns spawn seeds plus metadata overrides for valid parent overrides', () => {
     const result = resolveForkInheritedOverridesFromMetadata({
-      name: 'Migrate Hermes Lite to Happier',
+      name: '  Migrate Hermes Lite to Happier  ',
       permissionMode: 'yolo',
       permissionModeUpdatedAt: 123,
       modelOverrideV1: { v: 1, updatedAt: 456, modelId: 'gpt-test' },
@@ -229,6 +229,7 @@ describe('resolveForkInheritedOverridesFromMetadata', () => {
 
   it('ignores invalid or cleared values while preserving valid override objects', () => {
     const result = resolveForkInheritedOverridesFromMetadata({
+      name: '   ',
       permissionMode: 'not-a-mode',
       permissionModeUpdatedAt: 123,
       modelOverrideV1: { v: 1, updatedAt: 456, modelId: 'default' },

--- a/apps/cli/src/session/fork/resolveForkInheritedOverridesFromMetadata.test.ts
+++ b/apps/cli/src/session/fork/resolveForkInheritedOverridesFromMetadata.test.ts
@@ -7,6 +7,7 @@ import { resolveForkInheritedOverridesFromMetadata } from './resolveForkInherite
 describe('resolveForkInheritedOverridesFromMetadata', () => {
   it('returns spawn seeds plus metadata overrides for valid parent overrides', () => {
     const result = resolveForkInheritedOverridesFromMetadata({
+      name: 'Migrate Hermes Lite to Happier',
       permissionMode: 'yolo',
       permissionModeUpdatedAt: 123,
       modelOverrideV1: { v: 1, updatedAt: 456, modelId: 'gpt-test' },
@@ -124,8 +125,10 @@ describe('resolveForkInheritedOverridesFromMetadata', () => {
       },
       connectedServicesUpdatedAt: 459,
     });
+    expect(result.metadata.name).toBe('Migrate Hermes Lite to Happier');
 
     expect(result.metadata).toEqual({
+      name: 'Migrate Hermes Lite to Happier',
       permissionMode: 'yolo',
       permissionModeUpdatedAt: 123,
       modelOverrideV1: { v: 1, updatedAt: 456, modelId: 'gpt-test' },

--- a/apps/cli/src/session/fork/resolveForkInheritedOverridesFromMetadata.ts
+++ b/apps/cli/src/session/fork/resolveForkInheritedOverridesFromMetadata.ts
@@ -29,7 +29,7 @@ type ForkInheritedMetadataOverrides = Pick<
   | 'acpConfigOptionOverridesV1'
   | 'connectedServices'
   | 'connectedServicesUpdatedAt'
->;
+> & { name?: string };
 
 export function resolveForkInheritedOverridesFromMetadata(
   metadata: Record<string, unknown> | null | undefined,
@@ -43,9 +43,13 @@ export function resolveForkInheritedOverridesFromMetadata(
     providerId,
     fields: CHILD_SESSION_INHERITANCE_FIELD_SETS.fork,
   });
+  const name = typeof metadata?.name === 'string' ? metadata.name.trim() : '';
 
   return {
     spawn: inherited.spawn,
-    metadata: inherited.metadata as Pick<Metadata, keyof ForkInheritedMetadataOverrides>,
+    metadata: {
+      ...inherited.metadata,
+      ...(name ? { name } : {}),
+    } as ForkInheritedMetadataOverrides,
   };
 }


### PR DESCRIPTION
## Why

Forking a session currently drops its title. This removes useful task context from the new session and the session list.

Refs #301

## What changed

- Copy a trimmed, non-empty parent title into inherited fork metadata.
- Keep the current behavior when the parent has no usable title.
- Add a focused unit assertion for title inheritance.

## Scope

This PR does not change fork transcript, workspace, or provider behavior. It does not generate or rewrite titles.

## Test evidence

```
yarn workspace @happier-dev/cli vitest run --config vitest.config.ts src/session/fork/resolveForkInheritedOverridesFromMetadata.test.ts
```

Result: 1 test file passed. 5 tests passed.

## AI assistance

I used Codex to inspect the fork metadata path, isolate this fix from another feature, rebase it onto current `dev`, and run the focused test. I reviewed the resulting diff and behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790065675&installation_model_id=20481&pr_number=303&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F303&signature=dbd16bb4395344a72aa603bfc90755bb3d1f26b7f150aaf8f6f1332cd9ac65af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve session `name` across forks in `resolveForkInheritedOverridesFromMetadata`
> - Extends `ForkInheritedMetadataOverrides` with an optional `name` field and returns a trimmed name when `metadata.name` is a non-empty string after trimming.
> - Whitespace-only or non-string names are omitted from the returned metadata.
> - Adds test coverage for trimmed names and whitespace-only name exclusion.
> - Risk: callers consuming `ForkInheritedMetadataOverrides` now see an additional optional `name` field; existing readers that destructure or spread the type unchanged are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ace1ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forked sessions now correctly preserve a non-empty, trimmed session name from their metadata.
  * Empty or missing session names continue to be ignored, leaving inherited metadata unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->