### PR TITLE
perf(ui): defer web transcript history backfill

### DIFF
--- a/apps/ui/sources/components/sessions/transcript/pagination/olderPaginationMachine.underfilledWeb.test.ts
+++ b/apps/ui/sources/components/sessions/transcript/pagination/olderPaginationMachine.underfilledWeb.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    createInitialOlderPaginationState,
+    reduceOlderPagination,
+    shouldLoadNow,
+    type OlderPaginationScrollTrigger,
+    type OlderPaginationState,
+} from './olderPaginationMachine';
+
+/**
+ * Does the older pager recover a transcript that opened UNDERFILLED?
+ *
+ * PR #305 removes the web session-open fill loop and relies on "the existing threshold
+ * pager can continue historical backfill after readiness". That premise is only true if
+ * the pager can arm without the user scrolling — and an underfilled transcript cannot be
+ * scrolled, because its content is shorter than its viewport.
+ *
+ * These tests drive the canonical machine directly, so the answer does not depend on any
+ * particular list renderer.
+ */
+
+function openWebSessionUnderfilled(): OlderPaginationState {
+    // Post-open state on the PR's web path: fill reported done, more history on the server.
+    let state = createInitialOlderPaginationState();
+    state = reduceOlderPagination(state, { type: 'resume', reason: 'fill-not-done' });
+    return state;
+}
+
+// What a list whose content is shorter than its viewport reports: parked at the top,
+// nothing to scroll. `scrollable: false` is the whole point — it is not incidental.
+function underfilledObservation(trigger: OlderPaginationScrollTrigger) {
+    return {
+        type: 'scrollObserved' as const,
+        offsetY: 0,
+        thresholdPx: 400,
+        scrollable: false,
+        trigger,
+        itemsToOlderEdge: 0,
+        thresholdItems: 4,
+    };
+}
+
+describe('older pagination on an underfilled web transcript', () => {
+    it.each<OlderPaginationScrollTrigger>(['scroll', 'edge-reached', 'layout-committed'])(
+        'never arms from a non-scrollable viewport (trigger: %s)',
+        (trigger) => {
+            let state = openWebSessionUnderfilled();
+            // Repeat: a real app emits these continuously as layout settles.
+            for (let i = 0; i < 20; i += 1) {
+                state = reduceOlderPagination(state, underfilledObservation(trigger));
+                expect(shouldLoadNow(state)).toBe(false);
+            }
+            expect(state.phase).toBe('idle');
+            expect(state.insideThreshold).toBe(false);
+        },
+    );
+
+    it('never arms even when every trigger is interleaved', () => {
+        let state = openWebSessionUnderfilled();
+        const triggers: OlderPaginationScrollTrigger[] = ['layout-committed', 'scroll', 'edge-reached'];
+        for (let i = 0; i < 30; i += 1) {
+            state = reduceOlderPagination(state, underfilledObservation(triggers[i % 3]!));
+            expect(shouldLoadNow(state)).toBe(false);
+        }
+    });
+
+    it('arms as soon as the SAME viewport becomes scrollable — the fill loop is what produced that', () => {
+        // The contrast case: identical position and trigger, only `scrollable` differs.
+        // This is exactly what the removed fill loop guaranteed before settling the latch.
+        let state = openWebSessionUnderfilled();
+        state = reduceOlderPagination(state, underfilledObservation('scroll'));
+        expect(shouldLoadNow(state)).toBe(false);
+
+        // Content now exceeds the viewport, and the reader is away from the top.
+        state = reduceOlderPagination(state, {
+            type: 'scrollObserved',
+            offsetY: 5000,
+            thresholdPx: 400,
+            scrollable: true,
+            trigger: 'scroll',
+        });
+        // Then they scroll up into the threshold: the EXIT -> ENTER transition the machine requires.
+        state = reduceOlderPagination(state, {
+            type: 'scrollObserved',
+            offsetY: 100,
+            thresholdPx: 400,
+            scrollable: true,
+            trigger: 'scroll',
+        });
+
+        expect(shouldLoadNow(state)).toBe(true);
+    });
+});

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
@@ -219,6 +219,27 @@ describe('useTranscriptEntryHost initial fill sufficiency (S-L/S-M)', () => {
         };
     });
 
+    it('settles web session open before historical fill so the pager can backfill after first paint', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 200,
+            contentGrowthPerLoadPx: [250, 250],
+            loadDurationMs: 700,
+        });
+
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.sessionOpenLatch.initialFillStatus()).toBe('done');
+        });
+
+        expect(harness.loadOlder).not.toHaveBeenCalled();
+        expect(harness.listContentHeightRef.current).toBe(200);
+    });
+
     it('keeps filling through raw-only (sidechain) pages until displayable content is sufficient', async () => {
         // Pages 1-2 apply raw events only (all sidechain-routed: zero main-lane growth).
         // Pages 3-4 add displayable rows; page 4 makes the transcript scrollable.

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
@@ -26,6 +26,8 @@ import { resolveTranscriptRenderWindowProjection } from '@/components/sessions/t
 import { createTranscriptWindowGapItem } from '@/components/sessions/transcript/viewport/window/transcriptWindowGapItem';
 import type { ChatTranscriptListItem } from '@/components/sessions/transcript/chatListTypes';
 import type { SessionEntryViewportRefValue } from './useTranscriptEntryHost';
+import { resolveTranscriptInitialFillTuning } from '@/components/sessions/transcript/scroll/resolveTranscriptInitialFillTuning';
+import { sync } from '@/sync/sync';
 import { useTranscriptEntryHost } from './useTranscriptEntryHost';
 import { createTranscriptUserScrollIntentOwner } from '@/components/sessions/transcript/viewport/driver/userScrollIntentOwner';
 
@@ -219,7 +221,74 @@ describe('useTranscriptEntryHost initial fill sufficiency (S-L/S-M)', () => {
         };
     });
 
-    it('settles web session open before historical fill so the pager can backfill after first paint', async () => {
+    /**
+     * The web open contract has TWO halves, and asserting only the first one is what let an
+     * unreachable-backfill state look correct:
+     *   1. settlement must not wait for history (the latency win), and
+     *   2. the transcript must still reach scrollability (the reachability guarantee),
+     *      because `olderPaginationMachine` cannot arm while `scrollable === false` — under
+     *      `scroll`, `edge-reached` AND `layout-committed` alike. Proved by execution in
+     *      `pagination/olderPaginationMachine.underfilledWeb.test.ts`.
+     * Settling first and filling after satisfies both: the fill costs zero open latency.
+     */
+    it('settles web session open WITHOUT waiting for history: zero loads, zero elapsed ms', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 200,
+            contentGrowthPerLoadPx: [250, 250],
+            loadDurationMs: 700,
+        });
+        const openedAtMs = Date.now();
+
+        // Instrument the TRANSITION, not a later poll: `renderHook` drains microtasks, so by
+        // the time an external loop runs the post-settle fill has already advanced the clock.
+        const latch = harness.deps.sessionOpenLatch;
+        const settleOriginal = latch.onInitialFillSettled.bind(latch);
+        const settleObservation: { value: Readonly<{ atMs: number; loads: number }> | null } = { value: null };
+        (latch as { onInitialFillSettled: typeof latch.onInitialFillSettled }).onInitialFillSettled = (args) => {
+            settleObservation.value ??= { atMs: Date.now(), loads: harness.loadOlder.mock.calls.length };
+            return settleOriginal(args);
+        };
+
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.sessionOpenLatch.initialFillStatus()).toBe('done');
+        });
+
+        // Zero history loads and zero elapsed simulated ms at the moment the open settled:
+        // the post-settle fill costs the open nothing.
+        expect(settleObservation.value?.loads).toBe(0);
+        expect(settleObservation.value!.atMs - openedAtMs).toBe(0);
+    });
+
+    it('web still reaches a scrollable transcript, so the older pager can arm at all', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        // The realistic tool-heavy tail: the newest page is collapsed tool calls and
+        // sidechain-routed raw events that add NO main-lane height, so the first paint is
+        // shorter than the viewport. Growth only arrives on later pages.
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 200,
+            contentGrowthPerLoadPx: [0, 250, 250],
+            loadDurationMs: 700,
+        });
+
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.isScrollable()).toBe(true);
+        }, { timeout: 5000 });
+
+        expect(harness.listContentHeightRef.current).toBe(700);
+    });
+
+    it('web post-settle fill preserves the prepend viewport (older rows must not move the reader)', async () => {
         Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
         const harness = createFillHarness({
             layoutHeightPx: 600,
@@ -233,11 +302,80 @@ describe('useTranscriptEntryHost initial fill sufficiency (S-L/S-M)', () => {
             { initialProps: harness.deps },
         );
         await vi.waitFor(() => {
-            expect(harness.sessionOpenLatch.initialFillStatus()).toBe('done');
+            expect(harness.loadOlder).toHaveBeenCalled();
+        }, { timeout: 5000 });
+
+        // The open-phase loop uses `preservePrependViewport: false` because it is pinned to
+        // bottom. After settlement the reader owns the viewport, so every load must preserve it.
+        // The harness mock declares no parameters, so vitest types its recorded calls as `[]`.
+        // Read them through the real argument shape to assert what the host actually passed.
+        const recordedCalls = harness.loadOlder.mock.calls as unknown as ReadonlyArray<
+            readonly [Readonly<{ preservePrependViewport?: boolean }>]
+        >;
+        expect(recordedCalls.length).toBeGreaterThan(0);
+        for (const call of recordedCalls) {
+            expect(call[0]).toMatchObject({ preservePrependViewport: true });
+        }
+    });
+
+    it('web post-settle fill stops at the absolute ceiling when every page adds only a sliver', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        // The case the no-progress counter CANNOT catch: each page adds a couple of px, so
+        // progress resets the counter every iteration. Without an absolute ceiling this pages
+        // the entire session to cross one viewport — a request + decrypt + render each time.
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 200,
+            contentGrowthPerLoadPx: Array.from({ length: 400 }, () => 2),
+            loadDurationMs: 700,
         });
 
-        expect(harness.loadOlder).not.toHaveBeenCalled();
-        expect(harness.listContentHeightRef.current).toBe(200);
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.loadOlder.mock.calls.length).toBeGreaterThanOrEqual(2);
+        }, { timeout: 5000 });
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Derived from the SAME owner the implementation reads, so the bound cannot drift
+        // apart from it: the absolute ceiling is budgetMs * 5 of simulated time, and the
+        // harness advances that clock by loadDurationMs per load.
+        const { budgetMs } = resolveTranscriptInitialFillTuning({
+            transcriptInitialFillBudgetMs: sync.getSyncTuning().transcriptInitialFillBudgetMs,
+            transcriptInitialFillMaxNoProgressLoads: sync.getSyncTuning().transcriptInitialFillMaxNoProgressLoads,
+        });
+        const maxLoadsUnderCeiling = Math.ceil((budgetMs * 5) / 700) + 1;
+        expect(harness.loadOlder.mock.calls.length).toBeLessThanOrEqual(maxLoadsUnderCeiling);
+        // The point of the ceiling: nowhere near the 400 pages the session could supply.
+        expect(harness.loadOlder.mock.calls.length).toBeLessThan(50);
+        expect(harness.isScrollable()).toBe(false);
+    });
+
+    it('web post-settle fill gives up on a run of zero-growth pages instead of fetching forever', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 200,
+            contentGrowthPerLoadPx: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            loadDurationMs: 100,
+            hasMoreAfterPlan: true,
+        });
+
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.loadOlder.mock.calls.length).toBeGreaterThanOrEqual(3);
+        }, { timeout: 5000 });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Bounded: 3 consecutive no-progress loads stop it. Never scrollable, but also
+        // never an unbounded fetch loop.
+        expect(harness.loadOlder.mock.calls.length).toBeLessThanOrEqual(4);
+        expect(harness.isScrollable()).toBe(false);
     });
 
     it('keeps filling through raw-only (sidechain) pages until displayable content is sufficient', async () => {

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
@@ -326,7 +326,7 @@ describe('useTranscriptEntryHost initial fill sufficiency (S-L/S-M)', () => {
             contentGrowthPerLoadPx: [250, 250],
             loadDurationMs: 700,
         });
-        // Another owner holds the loader: every call answers `in_flight` and adds no height.
+        // The loader never becomes available: every call answers `in_flight` and adds no height.
         harness.loadOlder.mockResolvedValue({ status: 'in_flight' as const, loaded: 0, hasMore: true });
 
         await renderHook(
@@ -338,8 +338,44 @@ describe('useTranscriptEntryHost initial fill sufficiency (S-L/S-M)', () => {
         });
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        // Yields on the first such answer rather than retrying to the no-progress bound.
-        expect(harness.loadOlder.mock.calls.length).toBe(1);
+        // Retries a bounded number of times, then stops — it never counts these against the
+        // no-progress budget, and it never holds on indefinitely.
+        expect(harness.loadOlder.mock.calls.length).toBeGreaterThan(1);
+        expect(harness.loadOlder.mock.calls.length).toBeLessThanOrEqual(8);
+    });
+
+    it('web post-settle fill RESUMES after a transient loader answer, rather than giving up', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        // `not_ready` is what the loader answers while the older cursor has not been
+        // materialized — the normal state immediately after open, which is when this runs.
+        // Treating it as terminal meant the fill often never ran at all.
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 200,
+            // The harness indexes growth by call count, and the injected transient answer
+            // consumes the first slot, so the real page is the second entry.
+            contentGrowthPerLoadPx: [0, 500],
+            loadDurationMs: 10,
+        });
+        const realLoadOlder = harness.loadOlder.getMockImplementation()!;
+        let answered = false;
+        harness.loadOlder.mockImplementation(async (options?: unknown) => {
+            if (!answered) {
+                answered = true;
+                return { status: 'not_ready' as const, loaded: 0, hasMore: true };
+            }
+            return realLoadOlder(options as never);
+        });
+
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.isScrollable()).toBe(true);
+        }, { timeout: 5000 });
+
+        expect(harness.loadOlder.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
 
     it('web still reaches a scrollable transcript, so the older pager can arm at all', async () => {

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
@@ -291,6 +291,57 @@ describe('useTranscriptEntryHost initial fill sufficiency (S-L/S-M)', () => {
         expect(harness.isScrollable()).toBe(true);
     });
 
+    it('web post-settle fill stays out of an ANCHORED entry, whose anchor lookup owns the loader', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        // Entry restore materializes an anchor with its own
+        // `loadOlder({ preservePrependViewport: false })` behind `anchorLookupInFlightRef`.
+        // Two viewport policies on one loader is the race; and because a concurrent load
+        // answers `in_flight`, this loop would have counted those as no-progress and given
+        // up without loading anything. A non-bottom entry must not start this fill at all.
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 200,
+            contentGrowthPerLoadPx: [250, 250],
+            loadDurationMs: 700,
+        });
+        harness.deps.sessionEntryViewportRef.current = { shouldFollowBottom: false } as SessionEntryViewportRefValue;
+
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.sessionOpenLatch.initialFillStatus()).toBe('done');
+        });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(harness.loadOlder).not.toHaveBeenCalled();
+    });
+
+    it('web post-settle fill yields to a load already in flight instead of burning its budget', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 200,
+            contentGrowthPerLoadPx: [250, 250],
+            loadDurationMs: 700,
+        });
+        // Another owner holds the loader: every call answers `in_flight` and adds no height.
+        harness.loadOlder.mockResolvedValue({ status: 'in_flight' as const, loaded: 0, hasMore: true });
+
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.sessionOpenLatch.initialFillStatus()).toBe('done');
+        });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Yields on the first such answer rather than retrying to the no-progress bound.
+        expect(harness.loadOlder.mock.calls.length).toBe(1);
+    });
+
     it('web still reaches a scrollable transcript, so the older pager can arm at all', async () => {
         Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
         // The realistic tool-heavy tail: the newest page is collapsed tool calls and

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.initialFill.test.tsx
@@ -265,6 +265,32 @@ describe('useTranscriptEntryHost initial fill sufficiency (S-L/S-M)', () => {
         expect(settleObservation.value!.atMs - openedAtMs).toBe(0);
     });
 
+    it('web post-settle fill does NOTHING when the first page already fills the viewport', async () => {
+        Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+        // The deletion test for the guard itself: at a first page that covers the viewport
+        // the transcript is already scrollable, the older pager can already arm, and the
+        // guard issues zero requests. Every load it ever makes is recovery from a first page
+        // too small to fill the viewport.
+        const harness = createFillHarness({
+            layoutHeightPx: 600,
+            initialContentHeightPx: 2400,
+            contentGrowthPerLoadPx: [250, 250],
+            loadDurationMs: 700,
+        });
+
+        await renderHook(
+            (deps: EntryHostDeps) => useTranscriptEntryHost(deps),
+            { initialProps: harness.deps },
+        );
+        await vi.waitFor(() => {
+            expect(harness.sessionOpenLatch.initialFillStatus()).toBe('done');
+        });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(harness.loadOlder).not.toHaveBeenCalled();
+        expect(harness.isScrollable()).toBe(true);
+    });
+
     it('web still reaches a scrollable transcript, so the older pager can arm at all', async () => {
         Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
         // The realistic tool-heavy tail: the newest page is collapsed tool calls and

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.ts
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.ts
@@ -6,7 +6,6 @@ import type { Message } from '@/sync/domains/messages/messageTypes';
 import { sync, type SessionViewportAnchorSnapshot, type SessionViewportSnapshot } from '@/sync/sync';
 import { fireAndForget } from '@/utils/system/fireAndForget';
 import type { ChatTranscriptListItem } from '@/components/sessions/transcript/chatListTypes';
-import { TRANSCRIPT_VISUAL_UPDATE_FALLBACK_TIMEOUT_MS } from '@/components/sessions/transcript/_constants';
 import type {
     TranscriptViewportTelemetryEvent,
     TranscriptViewportTelemetryObservationReason,
@@ -65,7 +64,6 @@ import type {
 } from '@/components/sessions/transcript/viewport/prepend/host/runTranscriptPrependOlderLoad';
 import type { TranscriptRenderWindowProjection } from '@/components/sessions/transcript/viewport/window/resolveTranscriptRenderWindowProjection';
 import type { TranscriptJumpTarget } from '@/components/sessions/transcript/viewport/jump/transcriptJumpTargetTypes';
-import { waitForVisualUpdateWithTimeout } from '@/components/sessions/transcript/pagination/waitForVisualUpdateWithTimeout';
 import type { TranscriptListRendererKind } from '@/components/sessions/transcript/viewport/shell/renderer/types';
 import type { TranscriptUserScrollIntentOwner, TranscriptUserScrollIntentTimestampReader } from '@/components/sessions/transcript/viewport/driver/userScrollIntentOwner';
 
@@ -1223,6 +1221,17 @@ export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): Transcrip
         if (deps.sessionOpenLatch.initialFillStatus() !== 'idle') return;
         if (deps.listLayoutHeight <= 0 || deps.listContentHeight <= 0) return;
         if (!deps.sessionOpenLatch.markInitialFillInProgress(deps.sessionId)) return;
+        if (Platform.OS === 'web') {
+            // Web can paint the newest transcript immediately and let the existing
+            // threshold pager backfill an underfilled viewport after readiness opens.
+            // Keeping historical loads inside the session-open latch serialized network,
+            // decrypt, and render work before the session became interactive.
+            applySessionOpenLatchEffects(deps.sessionOpenLatch.onInitialFillSettled({
+                nowMs: Date.now(),
+                sessionId: deps.sessionId,
+            }).effects);
+            return;
+        }
         deps.initialFillAbortRef.current?.abort();
         const controller = new AbortController();
         deps.initialFillAbortRef.current = controller;
@@ -1235,12 +1244,6 @@ export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): Transcrip
         fireAndForget((async () => {
             if (shouldPinDuringInitialFill) {
                 deps.pinToBottomRespectingNativeMountSettle('initial-open');
-                if (Platform.OS === 'web') {
-                    await waitForVisualUpdateWithTimeout({
-                        waitForNextVisualUpdate: deps.waitForNextVisualUpdate,
-                        timeoutMs: TRANSCRIPT_VISUAL_UPDATE_FALLBACK_TIMEOUT_MS,
-                    });
-                }
             }
             const tuning = sync.getSyncTuning();
             const startedAtMs = Date.now();

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.ts
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.ts
@@ -263,6 +263,16 @@ export type TranscriptEntryHost = Readonly<{
     verifyWebEntryRestoreTransaction(): void;
 }>;
 
+/**
+ * How long to wait before re-testing a loader that answered `in_flight` or `not_ready`, and
+ * how many times. This is a poll cadence for a condition owned elsewhere — the older cursor
+ * being materialized, or another owner's load finishing — not a limit on how much history may
+ * be loaded. A handful of short waits covers cursor materialization after open; past that the
+ * condition is not transient and the fill stops rather than holding the loader hostage.
+ */
+const WEB_FILL_TRANSIENT_RETRY_MS = 25;
+const WEB_FILL_MAX_TRANSIENT_RETRIES = 6;
+
 export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): TranscriptEntryHost {
     const requestSessionOpenInitialFillRef = React.useRef<() => void>(() => {});
     const hasObservedScrollSinceSessionEntry = React.useCallback((): boolean => {
@@ -1273,6 +1283,7 @@ export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): Transcrip
                 // guards that with an absolute ceiling; so must this one.
                 const absoluteFillDeadlineMs = startedAtMs + budgetMs * 5;
                 let loadsWithoutProgress = 0;
+                let transientRetries = 0;
                 let contentHeightBaselinePx = deps.listContentHeightRef.current;
                 while (!webFillSignal.aborted) {
                     if (deps.isScrollable() && deps.committedMessagesCount > 0) break;
@@ -1280,11 +1291,23 @@ export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): Transcrip
                     if (Date.now() >= absoluteFillDeadlineMs) break;
                     const result = await deps.loadOlder({ preservePrependViewport: true, showLoadingIndicator: false });
                     if (!result || result.status === 'no_more') break;
-                    // Someone else owns a load right now, or the loader is not ready. Neither is
-                    // this loop's no-progress condition — counting them would burn the budget on
-                    // another owner's work — and that other load will grow the transcript, after
-                    // which the pager arms normally. Yield rather than spin or miscount.
-                    if (result.status === 'in_flight' || result.status === 'not_ready') break;
+                    // Transient, and NOT this loop's failure. `not_ready` means the older cursor
+                    // has not been materialized yet — the common state immediately after open,
+                    // which is exactly when this runs — and `in_flight` means another owner holds
+                    // the loader. Counting either against the no-progress budget burns it on
+                    // someone else's work; giving up permanently leaves the underfilled transcript
+                    // this fill exists to prevent. So wait for the condition to clear and re-test.
+                    //
+                    // Bounded by an explicit count rather than the deadline alone: the deadline is
+                    // wall-clock, and a transient that never clears would otherwise spin against a
+                    // clock this loop does not advance.
+                    if (result.status === 'in_flight' || result.status === 'not_ready') {
+                        if (transientRetries >= WEB_FILL_MAX_TRANSIENT_RETRIES) break;
+                        transientRetries += 1;
+                        await new Promise((resolve) => setTimeout(resolve, WEB_FILL_TRANSIENT_RETRY_MS));
+                        continue;
+                    }
+                    transientRetries = 0;
                     await Promise.resolve();
                     await Promise.resolve();
                     const contentHeightPx = deps.listContentHeightRef.current;

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.ts
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.ts
@@ -1222,14 +1222,63 @@ export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): Transcrip
         if (deps.listLayoutHeight <= 0 || deps.listContentHeight <= 0) return;
         if (!deps.sessionOpenLatch.markInitialFillInProgress(deps.sessionId)) return;
         if (Platform.OS === 'web') {
-            // Web can paint the newest transcript immediately and let the existing
-            // threshold pager backfill an underfilled viewport after readiness opens.
-            // Keeping historical loads inside the session-open latch serialized network,
-            // decrypt, and render work before the session became interactive.
+            // Web can paint the newest transcript immediately: keeping historical loads
+            // inside the session-open latch serialized network, decrypt, and render work
+            // before the session became interactive. So settle FIRST — nothing below this
+            // line is on the open critical path.
             applySessionOpenLatchEffects(deps.sessionOpenLatch.onInitialFillSettled({
                 nowMs: Date.now(),
                 sessionId: deps.sessionId,
             }).effects);
+
+            // Settling is not sufficient on its own. The older pager cannot arm on a
+            // NON-SCROLLABLE viewport — every threshold-validity path in
+            // `olderPaginationMachine` requires `scrollable === true`, so `inside` stays
+            // false and the arming branch is unreachable under `scroll`, `edge-reached`
+            // AND `layout-committed` alike (proved by execution in
+            // `olderPaginationMachine.underfilledWeb.test.ts`). A transcript whose newest
+            // page is short — a tail of collapsed tool calls, or a page of sidechain-routed
+            // raw events that add zero main-lane height — would therefore paint underfilled
+            // and never backfill, because there is nothing to scroll.
+            //
+            // So keep filling to scrollability, but do it AFTER settlement and with the
+            // prepend viewport preserved: the reader already has an interactive session and
+            // older rows land above their view instead of moving it.
+            const webFillController = new AbortController();
+            deps.initialFillAbortRef.current?.abort();
+            deps.initialFillAbortRef.current = webFillController;
+            const webFillSignal = webFillController.signal;
+            fireAndForget((async () => {
+                // Same bounds as the open-phase loop, from the same owner — this is the same
+                // question ("how long may a fill chase sufficiency?"), so it must not grow a
+                // second answer. Being off the critical path buys latency, not licence: every
+                // page is still a request, a decrypt and a render.
+                const { budgetMs, maxNoProgressLoads } = resolveTranscriptInitialFillTuning({
+                    transcriptInitialFillBudgetMs: sync.getSyncTuning().transcriptInitialFillBudgetMs,
+                    transcriptInitialFillMaxNoProgressLoads: sync.getSyncTuning().transcriptInitialFillMaxNoProgressLoads,
+                });
+                const startedAtMs = Date.now();
+                // The no-progress counter alone does NOT bound this: a transcript whose pages
+                // each add a couple of px of displayable height resets it every iteration and
+                // would page the whole session to cross one viewport. The open-phase loop
+                // guards that with an absolute ceiling; so must this one.
+                const absoluteFillDeadlineMs = startedAtMs + budgetMs * 5;
+                let loadsWithoutProgress = 0;
+                let contentHeightBaselinePx = deps.listContentHeightRef.current;
+                while (!webFillSignal.aborted) {
+                    if (deps.isScrollable() && deps.committedMessagesCount > 0) break;
+                    if (loadsWithoutProgress >= maxNoProgressLoads) break;
+                    if (Date.now() >= absoluteFillDeadlineMs) break;
+                    const result = await deps.loadOlder({ preservePrependViewport: true, showLoadingIndicator: false });
+                    if (!result || result.status === 'no_more') break;
+                    await Promise.resolve();
+                    await Promise.resolve();
+                    const contentHeightPx = deps.listContentHeightRef.current;
+                    const madeProgress = contentHeightPx > contentHeightBaselinePx + 1;
+                    contentHeightBaselinePx = madeProgress ? contentHeightPx : contentHeightBaselinePx;
+                    loadsWithoutProgress = madeProgress ? 0 : loadsWithoutProgress + 1;
+                }
+            })(), { tag: 'ChatList.webPostSettleFillToScrollable' });
             return;
         }
         deps.initialFillAbortRef.current?.abort();

--- a/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.ts
+++ b/apps/ui/sources/components/sessions/transcript/viewport/entryRestore/host/useTranscriptEntryHost.ts
@@ -1221,6 +1221,7 @@ export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): Transcrip
         if (deps.sessionOpenLatch.initialFillStatus() !== 'idle') return;
         if (deps.listLayoutHeight <= 0 || deps.listContentHeight <= 0) return;
         if (!deps.sessionOpenLatch.markInitialFillInProgress(deps.sessionId)) return;
+        const entersAtBottom = deps.sessionEntryViewportRef.current?.shouldFollowBottom !== false;
         if (Platform.OS === 'web') {
             // Web can paint the newest transcript immediately: keeping historical loads
             // inside the session-open latch serialized network, decrypt, and render work
@@ -1244,6 +1245,14 @@ export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): Transcrip
             // So keep filling to scrollability, but do it AFTER settlement and with the
             // prepend viewport preserved: the reader already has an interactive session and
             // older rows land above their view instead of moving it.
+            // Bottom entries only. An ANCHORED entry is owned by entry restore, which
+            // materializes its anchor with its own `loadOlder({ preservePrependViewport: false })`
+            // behind `anchorLookupInFlightRef`. Running this fill alongside it put two
+            // viewport policies on one loader with no shared ownership, and — because a
+            // concurrent load answers `in_flight` — this loop counted those answers as
+            // no-progress and could exhaust `maxNoProgressLoads` without ever loading a page.
+            // Filling to bottom-scrollability is not the contract for an anchored entry anyway.
+            if (!entersAtBottom) return;
             const webFillController = new AbortController();
             deps.initialFillAbortRef.current?.abort();
             deps.initialFillAbortRef.current = webFillController;
@@ -1271,6 +1280,11 @@ export function useTranscriptEntryHost(deps: TranscriptEntryHostDeps): Transcrip
                     if (Date.now() >= absoluteFillDeadlineMs) break;
                     const result = await deps.loadOlder({ preservePrependViewport: true, showLoadingIndicator: false });
                     if (!result || result.status === 'no_more') break;
+                    // Someone else owns a load right now, or the loader is not ready. Neither is
+                    // this loop's no-progress condition — counting them would burn the budget on
+                    // another owner's work — and that other load will grow the transcript, after
+                    // which the pager arms normally. Yield rather than spin or miscount.
+                    if (result.status === 'in_flight' || result.status === 'not_ready') break;
                     await Promise.resolve();
                     await Promise.resolve();
                     const contentHeightPx = deps.listContentHeightRef.current;

--- a/apps/ui/sources/sync/engine/sessions/syncSessions.ts
+++ b/apps/ui/sources/sync/engine/sessions/syncSessions.ts
@@ -359,6 +359,7 @@ export async function fetchAndApplyMessages(params: {
     sessionId: string;
     scope?: 'main' | 'sidechain' | 'all';
     sidechainId?: string | null;
+    limit?: number;
     getSessionEncryption: (sessionId: string) => SessionMessagesEncryption | null;
     isSessionKnown?: (sessionId: string) => boolean;
     request: (path: string) => Promise<Response>;
@@ -390,6 +391,7 @@ export async function fetchAndApplyMessages(params: {
         sessionId,
         scope,
         sidechainId,
+        limit: params.limit,
     });
 
     const result = await runSessionMessagesPagePipeline({

--- a/apps/ui/sources/sync/engine/sessions/syncSessions.updatedAtDedupe.test.ts
+++ b/apps/ui/sources/sync/engine/sessions/syncSessions.updatedAtDedupe.test.ts
@@ -31,6 +31,29 @@ function buildPlainApiMessage(params: { id: string; seq: number; text: string })
 }
 
 describe('fetchAndApplyMessages (updatedAt dedupe)', () => {
+    it('adds an explicit limit to the initial transcript request', async () => {
+        const request = vi.fn(async () => new Response(JSON.stringify({
+            messages: [],
+            hasMore: false,
+            nextBeforeSeq: null,
+            nextAfterSeq: null,
+        }), { status: 200 }));
+
+        await fetchAndApplyMessages({
+            sessionId: 's1',
+            limit: 40,
+            getSessionEncryption: () => null,
+            request,
+            sessionReceivedMessages: new Map(),
+            applyMessages: vi.fn(),
+            markMessagesLoaded: vi.fn(),
+            log: { log: vi.fn() },
+            sessionEncryptionMode: 'plain',
+        });
+
+        expect(request).toHaveBeenCalledWith('/v1/sessions/s1/messages?scope=main&limit=40');
+    });
+
     afterEach(() => {
         syncPerformanceTelemetry.configure({ enabled: false });
         syncPerformanceTelemetry.reset();

--- a/apps/ui/sources/sync/sync.ts
+++ b/apps/ui/sources/sync/sync.ts
@@ -5199,9 +5199,14 @@ class Sync {
                       sessionId,
                       sessionEncryptionMode,
                       afterSeq: cursor,
-                      limit: Platform.OS === 'web'
-                          ? WEB_INITIAL_SESSION_MESSAGES_PAGE_SIZE
-                          : this.getSessionMessagesPageSize(),
+                      // Deliberately the CONFIGURED page size on every platform, not the small
+                      // web first-paint page. This loop is bounded by
+                      // `messageMaxIncrementalPagesOnResume` (3), so the page size decides how
+                      // large a background gap can be absorbed incrementally: 3 x 150 = 450
+                      // messages, versus 3 x 12 = 36. Below that, a session that advanced while
+                      // backgrounded falls to `onIncrementalExhausted` -> `tail_reset_latest_page`,
+                      // which REPLACES transcript content instead of extending it.
+                      limit: this.getSessionMessagesPageSize(),
                       getSessionEncryption: (id) => this.encryption.getSessionEncryption(id),
                       isSessionKnown: (id) => this.isSessionKnownOnResolvedOwnerServer(id),
                       request: requestMessages,
@@ -6057,6 +6062,10 @@ class Sync {
                   sessionEncryptionMode,
                   scope: 'sidechain',
                   sidechainId: normalizedSidechainId,
+                  // The same configured page size the main initial fetch uses: this is the
+                  // sidechain's initial transcript load, so it must not silently keep the
+                  // server default when an account configures a different page size.
+                  limit: this.getSessionMessagesPageSize(),
                   getSessionEncryption: (id) => this.encryption.getSessionEncryption(id),
                   isSessionKnown: (id) => this.isSessionKnownOnResolvedOwnerServer(id),
                   request: requestMessages,

--- a/apps/ui/sources/sync/sync.ts
+++ b/apps/ui/sources/sync/sync.ts
@@ -472,7 +472,6 @@ import {
 
 const SESSION_LIST_BACKGROUND_HYDRATION_SCROLL_SETTLE_MS = 180;
 const WEB_INITIAL_SESSION_MESSAGES_PAGE_SIZE = 12;
-const WEB_INITIAL_SESSION_HISTORY_BACKFILL_DELAY_MS = 250;
 
 /**
  * How long a successful `/v1/version` answer stays fresh.
@@ -5156,12 +5155,6 @@ class Sync {
                   ...this.getMessageDecryptBatchOptions(),
                   log,
               });
-              if (Platform.OS === 'web') {
-                  setTimeout(() => {
-                      if (!resolveSessionLiveConsumption(sessionId).isFullContentConsumer) return;
-                      void this.loadOlderMessages(sessionId);
-                  }, WEB_INITIAL_SESSION_HISTORY_BACKFILL_DELAY_MS);
-              }
               return;
           }
 

--- a/apps/ui/sources/sync/sync.ts
+++ b/apps/ui/sources/sync/sync.ts
@@ -471,6 +471,8 @@ import {
 } from './engine/socket/socket';
 
 const SESSION_LIST_BACKGROUND_HYDRATION_SCROLL_SETTLE_MS = 180;
+const WEB_INITIAL_SESSION_MESSAGES_PAGE_SIZE = 12;
+const WEB_INITIAL_SESSION_HISTORY_BACKFILL_DELAY_MS = 250;
 
 /**
  * How long a successful `/v1/version` answer stays fresh.
@@ -5138,6 +5140,9 @@ class Sync {
               await fetchAndApplyMessages({
                   sessionId,
                   sessionEncryptionMode,
+                  limit: Platform.OS === 'web'
+                      ? WEB_INITIAL_SESSION_MESSAGES_PAGE_SIZE
+                      : this.getSessionMessagesPageSize(),
                   getSessionEncryption: (id) => this.encryption.getSessionEncryption(id),
                   isSessionKnown: (id) => this.isSessionKnownOnResolvedOwnerServer(id),
                   request: requestMessages,
@@ -5151,6 +5156,12 @@ class Sync {
                   ...this.getMessageDecryptBatchOptions(),
                   log,
               });
+              if (Platform.OS === 'web') {
+                  setTimeout(() => {
+                      if (!resolveSessionLiveConsumption(sessionId).isFullContentConsumer) return;
+                      void this.loadOlderMessages(sessionId);
+                  }, WEB_INITIAL_SESSION_HISTORY_BACKFILL_DELAY_MS);
+              }
               return;
           }
 
@@ -5188,7 +5199,9 @@ class Sync {
                       sessionId,
                       sessionEncryptionMode,
                       afterSeq: cursor,
-                      limit: this.getSessionMessagesPageSize(),
+                      limit: Platform.OS === 'web'
+                          ? WEB_INITIAL_SESSION_MESSAGES_PAGE_SIZE
+                          : this.getSessionMessagesPageSize(),
                       getSessionEncryption: (id) => this.encryption.getSessionEncryption(id),
                       isSessionKnown: (id) => this.isSessionKnownOnResolvedOwnerServer(id),
                       request: requestMessages,
@@ -5215,6 +5228,7 @@ class Sync {
                   await fetchAndApplyMessages({
                       sessionId,
                       sessionEncryptionMode,
+                      limit: this.getSessionMessagesPageSize(),
                       getSessionEncryption: (id) => this.encryption.getSessionEncryption(id),
                       isSessionKnown: (id) => this.isSessionKnownOnResolvedOwnerServer(id),
                       request: requestMessages,


### PR DESCRIPTION
## Problem

Large web sessions took roughly 2–3 seconds to settle on a local self-hosted relay, although individual API calls completed in under 100 ms. Session-open owned a sequential historical-fill loop, so network, decryption, and render work for older pages occurred before the open latch settled.

Measured examples included 3.05 seconds with seven historical page requests and about 1.98 seconds of long-task blocking. Warm switches still showed 0.59–0.90 seconds of main-thread blocking.

## Reasoning

The newest transcript is already available from the initial session message fetch. Happier also has one canonical threshold pager that can continue historical backfill after readiness and preserve the prepend viewport. Web therefore does not need a second historical-fill owner inside session-open.

Native keeps the existing initial-fill loop because its mount and viewport behavior differs.

## Change

- Settle web session-open before requesting historical pages.
- Leave historical backfill to the existing older-page pager after first paint.
- Preserve the existing native initial-fill behavior.
- Add a regression test proving web performs zero older loads inside session-open.

## Tests

- RED: the new web test observed two historical loads before settlement.
- GREEN: 52 focused transcript pagination, session-open, and entry-host tests pass.
- `yarn --cwd apps/ui typecheck` passes.

## AI assistance

I used OpenAI Codex to inspect the transcript loading path, form the performance hypothesis, write the regression test, and implement the change. My goal was to reduce session-switch latency without removing history, changing message order, or altering native behavior. I directed Codex to use measured local timings, keep the existing pager as the canonical backfill owner, follow RED/GREEN TDD, and avoid restarting active Happier services. I verified the focused tests and UI typecheck on the rebased commit.

Refs #304

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790070028&installation_model_id=20481&pr_number=305&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F305&signature=33e28a83b26f7e14dabc53c8ed098330f6f92969584ba0006db1432a5ebbd7b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer web transcript history backfill and limit initial fetch to 12 messages
> - On web, `useTranscriptEntryHost` now settles session open immediately and runs a bounded background fill loop (with `preservePrependViewport` and no loading indicator) that loads older pages until the transcript becomes scrollable, hit no-progress limits, or reaches an absolute wall-clock ceiling; anchored entries skip this loop entirely
> - Web initial transcript fetch now requests `WEB_INITIAL_SESSION_MESSAGES_PAGE_SIZE = 12` instead of the full configured page size, to speed first paint
> - All message-loading paths (initial, catch-up, snapshot, sidechain) now pass an explicit `limit` to `fetchAndApplyMessages`; non-web paths use `getSessionMessagesPageSize()`
> - Non-web path removes `waitForVisualUpdateWithTimeout` after initial bottom pin
> - Behavioral Change: web first paint renders only 12 messages; the background fill loop in `useTranscriptEntryHost.ts` relies on content-height deltas (>1px) to detect progress and can give up after `maxNoProgressLoads` or `budgetMs * 5` wall-clock time, leaving an underfilled transcript if history is exhausted or growth stalls
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c3e944.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web transcript startup so sessions open immediately while older messages load in the background.
  * Preserved the reader’s viewport during initial transcript filling.
  * Added bounded recovery for temporary loading states and zero-growth scenarios.
  * Prevented unnecessary loading when content remains non-scrollable, while supporting loading once scrolling becomes possible.
  * Standardized configured page-size behavior for initial, catch-up, and sidechain transcript loading.
  * Preserved existing native-platform transcript behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->