### PR TITLE
fix(cli): stop stale sessions with missing runners

### DIFF
--- a/apps/cli/src/daemon/sessions/onChildExited.respawn.test.ts
+++ b/apps/cli/src/daemon/sessions/onChildExited.respawn.test.ts
@@ -58,6 +58,51 @@ describe('createOnChildExited', () => {
     expect(onUnexpectedExit).toHaveBeenCalledTimes(1);
   });
 
+  it('coalesces concurrent exit observations for the same tracked session', async () => {
+    const pid = 126;
+    const tracked = {
+      pid,
+      startedBy: 'daemon',
+      happySessionId: 'session-concurrent-exit',
+      activeTurnId: 'turn-concurrent-exit',
+    };
+    const pidToTrackedSession = new Map<number, any>([[pid, tracked]]);
+    let releaseStage = (): void => {
+      throw new Error('Stage release was not installed');
+    };
+    const stageGate = new Promise<void>((resolve) => {
+      releaseStage = resolve;
+    });
+    const stageObservedExitFn = vi.fn(async () => {
+      await stageGate;
+      return { status: 'staged' as const, markerPid: pid };
+    });
+    const onUnexpectedExit = vi.fn();
+    const onChildExited = createOnChildExited({
+      pidToTrackedSession,
+      spawnResourceCleanupByPid: new Map(),
+      sessionAttachCleanupByPid: new Map(),
+      getApiMachineForSessions: () => ({
+        enqueueDaemonTerminalExactTurnEnd: vi.fn(async () => {}),
+      }) as any,
+      stageObservedExitFn,
+      onUnexpectedExit,
+      isExitUnexpectedOverride: () => true,
+    });
+
+    const processExit = onChildExited(pid, { reason: 'process-exited', code: 0, signal: null });
+    const missingExit = onChildExited(pid, { reason: 'process-missing', code: null, signal: null });
+
+    await vi.waitFor(() => expect(stageObservedExitFn).toHaveBeenCalled());
+    expect(pidToTrackedSession.has(pid)).toBe(true);
+    releaseStage();
+    await Promise.all([processExit, missingExit]);
+
+    expect(stageObservedExitFn).toHaveBeenCalledTimes(1);
+    expect(onUnexpectedExit).toHaveBeenCalledTimes(1);
+    expect(pidToTrackedSession.has(pid)).toBe(false);
+  });
+
   it('retains marker and tracking after transient staging failure so the same daemon can retry', async () => {
     const pid = 124;
     const tracked = {

--- a/apps/cli/src/daemon/sessions/onChildExited.ts
+++ b/apps/cli/src/daemon/sessions/onChildExited.ts
@@ -79,7 +79,7 @@ export function createOnChildExited(params: Readonly<{
     stageObservedExitFn = stageObservedExit,
   } = params;
 
-  return async (pid: number, exit: ChildExit) => {
+  const observeChildExit = async (pid: number, exit: ChildExit): Promise<void> => {
     logger.debug(`[DAEMON RUN] Removing exited process PID ${pid} from tracking`);
     const tracked = pidToTrackedSession.get(pid);
     const runnerPid = tracked?.sessionRunnerPid;
@@ -220,6 +220,31 @@ export function createOnChildExited(params: Readonly<{
     pidToTrackedSession.delete(pid);
     if (!tracked) {
       void removeSessionMarkerFn(pid);
+    }
+  };
+
+  const inFlightByTrackedSession = new WeakMap<TrackedSession, Promise<void>>();
+  return async (pid: number, exit: ChildExit): Promise<void> => {
+    const trackedSession = pidToTrackedSession.get(pid);
+    if (!trackedSession) {
+      await observeChildExit(pid, exit);
+      return;
+    }
+
+    const existing = inFlightByTrackedSession.get(trackedSession);
+    if (existing) {
+      await existing;
+      return;
+    }
+
+    const observation = observeChildExit(pid, exit);
+    inFlightByTrackedSession.set(trackedSession, observation);
+    try {
+      await observation;
+    } finally {
+      if (inFlightByTrackedSession.get(trackedSession) === observation) {
+        inFlightByTrackedSession.delete(trackedSession);
+      }
     }
   };
 }

--- a/apps/cli/src/daemon/sessions/stopSession.test.ts
+++ b/apps/cli/src/daemon/sessions/stopSession.test.ts
@@ -355,6 +355,38 @@ describe('createStopSession', () => {
     expect(killSpy).not.toHaveBeenCalled();
   });
 
+  it('logs a failed exact runner-exit probe before continuing through the normal stop path', async () => {
+    const { createStopSession } = await import('./stopSession');
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true as any);
+    const probeError = new Error('process-state reader unavailable');
+    const logWarning = vi.fn();
+    const waitForTrackedRunnersExit = vi.fn(async () => true);
+    const stop = createStopSession({
+      pidToTrackedSession: new Map<number, any>([[
+        223,
+        {
+          startedBy: 'terminal',
+          pid: 223,
+          happySessionId: 'sess-probe-failure',
+          processCommandHash: 'expected-command',
+        },
+      ]]),
+      areTrackedRunnersExited: vi.fn(async () => {
+        throw probeError;
+      }),
+      waitForTrackedRunnersExit,
+      logWarning,
+    });
+
+    await expect(stop('sess-probe-failure')).resolves.toEqual({ status: 'stopped' });
+    expect(killSpy).toHaveBeenCalledWith(223, 'SIGTERM');
+    expect(waitForTrackedRunnersExit).toHaveBeenCalledTimes(1);
+    expect(logWarning).toHaveBeenCalledWith(
+      '[DAEMON RUN] Failed to check tracked runner exit for session sess-probe-failure',
+      probeError,
+    );
+  });
+
   it('keeps tracked in-flight attaches until exit is observed', async () => {
     const { createStopSession } = await import('./stopSession');
 

--- a/apps/cli/src/daemon/sessions/stopSession.ts
+++ b/apps/cli/src/daemon/sessions/stopSession.ts
@@ -403,12 +403,22 @@ export function createStopSession(params: Readonly<{
       }
     }
 
-    const runnersAlreadyExited = params.areTrackedRunnersExited
-      ? await params.areTrackedRunnersExited({
+    const haveTrackedRunnersExited = async (trackedPids: readonly number[]): Promise<boolean> => {
+      if (!params.areTrackedRunnersExited) return false;
+      try {
+        return await params.areTrackedRunnersExited({
           sessionId: normalizedSessionId,
-          trackedPids: pidsToStop,
-        }).catch(() => false)
-      : false;
+          trackedPids,
+        });
+      } catch (error) {
+        logWarning(
+          `[DAEMON RUN] Failed to check tracked runner exit for session ${normalizedSessionId}`,
+          error,
+        );
+        return false;
+      }
+    };
+    const runnersAlreadyExited = await haveTrackedRunnersExited(pidsToStop);
     let stoppedAny = false;
     const signaledPids: number[] = runnersAlreadyExited ? [...pidsToStop] : [];
     const confirmedExitedPids: number[] = runnersAlreadyExited ? [...pidsToStop] : [];
@@ -503,11 +513,7 @@ export function createStopSession(params: Readonly<{
     const unsignaledPids = pidsToStop.filter((pid) => !signaledPids.includes(pid));
     if (
       unsignaledPids.length > 0
-      && params.areTrackedRunnersExited
-      && await params.areTrackedRunnersExited({
-        sessionId: normalizedSessionId,
-        trackedPids: unsignaledPids,
-      }).catch(() => false)
+      && await haveTrackedRunnersExited(unsignaledPids)
     ) {
       confirmedExitedPids.push(...unsignaledPids);
     }
@@ -537,11 +543,7 @@ export function createStopSession(params: Readonly<{
       const exitedBeforeForcePids = new Set<number>();
       for (const pid of pidsToStop) {
         if (
-          params.areTrackedRunnersExited
-          && await params.areTrackedRunnersExited({
-            sessionId: normalizedSessionId,
-            trackedPids: [pid],
-          }).catch(() => false)
+          await haveTrackedRunnersExited([pid])
         ) {
           exitedBeforeForcePids.add(pid);
           continue;

--- a/apps/cli/src/daemon/startDaemon.spawnResume.integration.test.ts
+++ b/apps/cli/src/daemon/startDaemon.spawnResume.integration.test.ts
@@ -2804,7 +2804,7 @@ describe('startDaemon spawn resume wiring (integration)', () => {
     }
   });
 
-  it('waits for a stop-requested tracked runner to be observed exited before stop returns', async () => {
+  it('observes an already-missing tracked runner before stop attempts signaling', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
     const refreshEnvOriginal = process.env.HAPPIER_CONNECTED_SERVICES_REFRESH_ENABLED;
     process.env.HAPPIER_CONNECTED_SERVICES_REFRESH_ENABLED = 'false';
@@ -2841,6 +2841,7 @@ describe('startDaemon spawn resume wiring (integration)', () => {
       const stopSessionModule = await import('./sessions/stopSession');
       vi.mocked(stopSessionModule.createStopSession).mockImplementation(({
         pidToTrackedSession,
+        areTrackedRunnersExited,
         waitForTrackedRunnersExit,
         loadTerminalHostAdapters: injectedLoadTerminalHostAdapters,
       }) => {
@@ -2852,6 +2853,12 @@ describe('startDaemon spawn resume wiring (integration)', () => {
               trackedSession.stopRequestedAtMs = Date.now();
               trackedPids.push(trackedSession.pid);
             }
+          }
+          if (!areTrackedRunnersExited) {
+            throw new Error('Expected exact pre-signal runner exit observation');
+          }
+          if (await areTrackedRunnersExited({ sessionId, trackedPids })) {
+            return { status: 'stopped' as const };
           }
           const exited = await waitForTrackedRunnersExit?.({ sessionId, trackedPids });
           return exited
@@ -2875,9 +2882,7 @@ describe('startDaemon spawn resume wiring (integration)', () => {
 
       await expect(stopSession('sess-stop-6480')).resolves.toEqual({ status: 'stopped' });
 
-      expect(waitForExitSpy).toHaveBeenCalledWith(expect.objectContaining({
-        sessionId: 'sess-stop-6480',
-      }));
+      expect(waitForExitSpy).not.toHaveBeenCalled();
       expect(onChildExitedSpy).toHaveBeenCalledWith(6480, {
         reason: 'process-missing',
         code: null,

--- a/apps/cli/src/daemon/startDaemon.spawnResume.integration.test.ts
+++ b/apps/cli/src/daemon/startDaemon.spawnResume.integration.test.ts
@@ -2839,33 +2839,15 @@ describe('startDaemon spawn resume wiring (integration)', () => {
         });
 
       const stopSessionModule = await import('./sessions/stopSession');
-      vi.mocked(stopSessionModule.createStopSession).mockImplementation(({
-        pidToTrackedSession,
-        areTrackedRunnersExited,
-        waitForTrackedRunnersExit,
-        loadTerminalHostAdapters: injectedLoadTerminalHostAdapters,
-      }) => {
-        loadTerminalHostAdapters = injectedLoadTerminalHostAdapters;
-        return vi.fn(async (sessionId: string) => {
-          const trackedPids: number[] = [];
-          for (const trackedSession of pidToTrackedSession.values()) {
-            if (trackedSession.happySessionId === sessionId) {
-              trackedSession.stopRequestedAtMs = Date.now();
-              trackedPids.push(trackedSession.pid);
-            }
-          }
-          if (!areTrackedRunnersExited) {
-            throw new Error('Expected exact pre-signal runner exit observation');
-          }
-          if (await areTrackedRunnersExited({ sessionId, trackedPids })) {
-            return { status: 'stopped' as const };
-          }
-          const exited = await waitForTrackedRunnersExit?.({ sessionId, trackedPids });
-          return exited
-            ? { status: 'stopped' as const }
-            : { status: 'incomplete' as const, reason: 'runner_exit_timeout' as const };
-        }) as any;
+      const actualStopSessionModule = await vi.importActual<typeof import('./sessions/stopSession')>('./sessions/stopSession');
+      vi.mocked(stopSessionModule.createStopSession).mockImplementation((params) => {
+        loadTerminalHostAdapters = params.loadTerminalHostAdapters;
+        return actualStopSessionModule.createStopSession({
+          ...params,
+          readAttachmentState: async () => ({ status: 'absent' }),
+        });
       });
+      const killSpy = vi.spyOn(process, 'kill');
 
       const { startDaemon } = await import('./startDaemon');
       run = startDaemon();
@@ -2888,6 +2870,8 @@ describe('startDaemon spawn resume wiring (integration)', () => {
         code: null,
         signal: null,
       });
+      expect(killSpy).not.toHaveBeenCalledWith(6480, 'SIGTERM');
+      expect(killSpy).not.toHaveBeenCalledWith(-6480, 'SIGTERM');
       expect(loadTerminalHostAdapters).toEqual(expect.any(Function));
       const firstRegistry = await loadTerminalHostAdapters!();
       const secondRegistry = await loadTerminalHostAdapters!();

--- a/apps/cli/src/daemon/startDaemon.ts
+++ b/apps/cli/src/daemon/startDaemon.ts
@@ -2354,6 +2354,19 @@ export async function startDaemon(options: Readonly<{ takeover?: boolean }> = {}
               terminalMode: attachmentInfo.terminal.mode ?? attachmentInfo.handle.kind,
             });
           },
+          areTrackedRunnersExited: async ({ trackedPids }) => {
+            const exited = await waitForTrackedRunnerProcessesExit({
+              runners: trackedPids.map((pid) => ({ pid })),
+              timeoutMs: 0,
+              pollIntervalMs: 0,
+            });
+            if (!exited) return false;
+
+            for (const pid of trackedPids) {
+              await onChildExited(pid, { reason: 'process-missing', code: null, signal: null });
+            }
+            return true;
+          },
           waitForTrackedRunnersExit: async ({ sessionId, trackedPids }) => {
             await waitForExistingSessionExitIfStopRequested({
               sessionId,


### PR DESCRIPTION
## Summary

Teach the daemon stop path to check tracked runner state before signaling. When every tracked runner is already dead, the daemon records the normal child-exit lifecycle and completes Stop immediately.

## Why

A stale tracked PID can outlive its runner. PID safety then refuses SIGTERM, Stop returns runner_signal_incomplete, and Archive remains blocked until presence expires.

Related to #264.

## How to test

1. Run yarn workspace @happier-dev/cli vitest run --config vitest.integration.config.ts src/daemon/startDaemon.spawnResume.integration.test.ts.
2. Run the stopSession and waitForTrackedRunnerProcessesExit unit tests.
3. Run yarn workspace @happier-dev/cli typecheck and yarn workspace @happier-dev/cli build.

## Screenshots / recording (UI changes)

Not applicable. This changes daemon lifecycle behavior only.

## Notes (optional)

Live or reused PIDs remain fail-closed. The existing process-state helper only confirms dead or zombie processes.

AI-assisted by OpenAI Codex. Codex reproduced the regression, reviewed the affected stop corridor, and ran the checks above.

## Checklist

- [x] PR targets dev, not main
- [x] I linked a related issue
- [x] I added a regression test
- [x] No documentation update is required for this internal lifecycle fix
- [x] I disclosed AI assistance and listed the verification performed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790095095&installation_model_id=20481&pr_number=306&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F306&signature=2f6ea93b85b7ff52a6cf92aca3e6e251bdaa397da1bb0d5c0a0956c2c475ad55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale daemon sessions by probing for missing runners and coalescing exit observations
> - Adds a zero-timeout probe in `startDaemon` via `areTrackedRunnersExited`; when tracked PIDs already exited, it fires `onChildExited` with reason `'process-missing'` and skips SIGTERM.
> - Coalesces concurrent calls to `createOnChildExited` for the same tracked session using a `WeakMap` so staging, cleanup, and callbacks run only once.
> - Wraps `areTrackedRunnersExited` calls in `createStopSession` with a `haveTrackedRunnersExited` helper that logs a warning on failure and treats the probe as "not exited."
> - Risk: if the zero-timeout probe in `startDaemon` falsely reports a PID as exited, `onChildExited` is invoked with `'process-missing'` and the runner is never signaled; reviewers should check the `waitForTrackedRunnerProcessesExit` call with zero timeout/poll interval.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d36984.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session stopping when tracked runner processes have already exited.
  * Sessions now reach the correct stopped state without unnecessary waiting or termination attempts.
  * Missing runner processes are recorded accurately with their observed exit status.
  * Prevented duplicate handling when multiple exit events occur concurrently.
  * Exit-check failures now generate warnings while allowing session stopping to continue normally.

* **Tests**
  * Added coverage for missing runners, concurrent exit events, and exit-check failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->