### PR TITLE
fix(cli): preserve Codex state across rematerialization

### DIFF
--- a/apps/cli/src/backends/codex/connectedServices/createCodexConnectedServicesMaterializer.ts
+++ b/apps/cli/src/backends/codex/connectedServices/createCodexConnectedServicesMaterializer.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import { requireConnectedServiceTokenCredentialRecord } from '@/daemon/connectedServices/shared/connectedServiceCredentialRecord';
 import type { ConnectedServicesProviderMaterializer } from '@/daemon/connectedServices/materialize/providerMaterializerTypes';
 import { materializeCodexConnectedServiceAuth } from './materializeCodexConnectedServiceAuth';
@@ -10,6 +12,9 @@ export function createCodexConnectedServicesMaterializer(): ConnectedServicesPro
     if (codex) {
       const materialized = await materializeCodexConnectedServiceAuth({
         rootDir: params.rootDir,
+        previousCodexHome: params.previousMaterializedRoot
+          ? join(params.previousMaterializedRoot, 'codex-home')
+          : null,
         record: codex,
         accountSettings: params.accountSettings ?? null,
         processEnv: params.processEnv ?? process.env,

--- a/apps/cli/src/backends/codex/connectedServices/materializeCodexConnectedServiceAuth.ts
+++ b/apps/cli/src/backends/codex/connectedServices/materializeCodexConnectedServiceAuth.ts
@@ -8,6 +8,7 @@ import { writeCodexAuthStoreFile } from './writeCodexAuthStoreFile';
 
 export async function materializeCodexConnectedServiceAuth(params: Readonly<{
   rootDir: string;
+  previousCodexHome?: string | null;
   record: ConnectedServiceCredentialRecordV1;
   accountSettings?: AccountSettings | Readonly<Record<string, unknown>> | null;
   processEnv?: NodeJS.ProcessEnv;
@@ -19,6 +20,7 @@ export async function materializeCodexConnectedServiceAuth(params: Readonly<{
   const codexHome = join(params.rootDir, 'codex-home');
   const syncResult = await syncCodexConnectedServiceHome({
     destinationCodexHome: codexHome,
+    previousCodexHome: params.previousCodexHome ?? null,
     accountSettings: params.accountSettings ?? null,
     processEnv: params.processEnv ?? process.env,
   });

--- a/apps/cli/src/backends/codex/connectedServices/reconcileCodexSharedJsonlState.ts
+++ b/apps/cli/src/backends/codex/connectedServices/reconcileCodexSharedJsonlState.ts
@@ -1,0 +1,99 @@
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+type CodexJsonlStateFile = Readonly<{
+  name: 'history.jsonl' | 'session_index.jsonl';
+  kind: 'history' | 'session_index';
+}>;
+
+const CODEX_JSONL_STATE_FILES = Object.freeze([
+  { name: 'history.jsonl', kind: 'history' },
+  { name: 'session_index.jsonl', kind: 'session_index' },
+] satisfies readonly CodexJsonlStateFile[]);
+
+type SessionIndexRecord = Readonly<{
+  id: string;
+  updatedAt: string;
+}>;
+
+async function readOptionalFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function nonEmptyLines(content: string | null): string[] {
+  return (content ?? '').split(/\r?\n/u).filter((line) => line.length > 0);
+}
+
+function parseSessionIndexRecord(line: string): SessionIndexRecord | null {
+  try {
+    const value = JSON.parse(line) as unknown;
+    if (!value || typeof value !== 'object') return null;
+    const record = value as Record<string, unknown>;
+    if (typeof record.id !== 'string' || typeof record.updated_at !== 'string') return null;
+    return { id: record.id, updatedAt: record.updated_at };
+  } catch {
+    return null;
+  }
+}
+
+function resolveMissingHistoryLines(current: string | null, incoming: string): string[] {
+  const seen = new Set(nonEmptyLines(current));
+  return nonEmptyLines(incoming).filter((line) => {
+    if (seen.has(line)) return false;
+    seen.add(line);
+    return true;
+  });
+}
+
+function resolveMissingSessionIndexLines(current: string | null, incoming: string): string[] {
+  const seen = new Set(nonEmptyLines(current));
+  const latestBySessionId = new Map<string, string>();
+  for (const line of seen) {
+    const record = parseSessionIndexRecord(line);
+    if (!record) continue;
+    const latest = latestBySessionId.get(record.id);
+    if (!latest || record.updatedAt > latest) latestBySessionId.set(record.id, record.updatedAt);
+  }
+  const missing: string[] = [];
+  for (const line of nonEmptyLines(incoming)) {
+    if (seen.has(line)) continue;
+    seen.add(line);
+    const record = parseSessionIndexRecord(line);
+    if (record) {
+      const latest = latestBySessionId.get(record.id);
+      if (latest && record.updatedAt <= latest) continue;
+      latestBySessionId.set(record.id, record.updatedAt);
+    }
+    missing.push(line);
+  }
+  return missing;
+}
+
+async function appendJsonlLines(path: string, current: string | null, lines: readonly string[]): Promise<void> {
+  if (lines.length === 0) return;
+  await mkdir(dirname(path), { recursive: true });
+  const separator = current && !current.endsWith('\n') ? '\n' : '';
+  await appendFile(path, `${separator}${lines.join('\n')}\n`, { encoding: 'utf8', mode: 0o600 });
+}
+
+export async function reconcileCodexSharedJsonlState(params: Readonly<{
+  previousCodexHome?: string | null;
+  sourceCodexHome: string;
+}>): Promise<void> {
+  if (!params.previousCodexHome) return;
+  for (const file of CODEX_JSONL_STATE_FILES) {
+    const incoming = await readOptionalFile(join(params.previousCodexHome, file.name));
+    if (incoming === null) continue;
+    const destinationPath = join(params.sourceCodexHome, file.name);
+    const current = await readOptionalFile(destinationPath);
+    const missing = file.kind === 'history'
+      ? resolveMissingHistoryLines(current, incoming)
+      : resolveMissingSessionIndexLines(current, incoming);
+    await appendJsonlLines(destinationPath, current, missing);
+  }
+}

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.test.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.test.ts
@@ -165,16 +165,21 @@ describe('syncCodexConnectedServiceHome', () => {
   it('degrades shared state to isolated when required symlinks are unavailable', async () => {
     const { root, sourceCodexHome, destinationCodexHome } = await createCodexHomePair();
     try {
+      const previousCodexHome = join(root, 'previous-codex-home');
       await mkdir(join(sourceCodexHome, 'sessions'), { recursive: true });
       await writeFile(join(sourceCodexHome, 'sessions', 'source-rollout.jsonl'), '{"id":"source"}\n');
       await mkdir(join(destinationCodexHome, 'sessions'), { recursive: true });
       await writeFile(join(destinationCodexHome, 'sessions', 'local-rollout.jsonl'), '{"id":"local"}\n');
+      await mkdir(join(previousCodexHome, 'memories'), { recursive: true });
+      await writeFile(join(previousCodexHome, 'history.jsonl'), '{"text":"previous prompt"}\n');
+      await writeFile(join(previousCodexHome, 'memories', 'raw_memories.md'), '# Previous memory\n');
 
       mockAllSymlinksFail();
       const syncCodexConnectedServiceHome = await loadSyncCodexConnectedServiceHome();
 
       const result = await syncCodexConnectedServiceHome({
         destinationCodexHome,
+        previousCodexHome,
         accountSettings: settings('linked', 'shared'),
         processEnv: { CODEX_HOME: sourceCodexHome },
       });
@@ -196,6 +201,8 @@ describe('syncCodexConnectedServiceHome', () => {
         targetSqliteHome: destinationCodexHome,
       });
       await expect(readFile(join(destinationCodexHome, 'sessions', 'local-rollout.jsonl'), 'utf8')).resolves.toBe('{"id":"local"}\n');
+      await expect(readFile(join(sourceCodexHome, 'history.jsonl'), 'utf8')).resolves.toBe('');
+      await expect(exists(join(sourceCodexHome, 'memories', 'raw_memories.md'))).resolves.toBe(false);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.test.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.test.ts
@@ -166,8 +166,6 @@ describe('syncCodexConnectedServiceHome', () => {
     const { root, sourceCodexHome, destinationCodexHome } = await createCodexHomePair();
     try {
       const previousCodexHome = join(root, 'previous-codex-home');
-      await mkdir(join(sourceCodexHome, 'sessions'), { recursive: true });
-      await writeFile(join(sourceCodexHome, 'sessions', 'source-rollout.jsonl'), '{"id":"source"}\n');
       await mkdir(join(destinationCodexHome, 'sessions'), { recursive: true });
       await writeFile(join(destinationCodexHome, 'sessions', 'local-rollout.jsonl'), '{"id":"local"}\n');
       await mkdir(join(previousCodexHome, 'memories'), { recursive: true });
@@ -201,8 +199,9 @@ describe('syncCodexConnectedServiceHome', () => {
         targetSqliteHome: destinationCodexHome,
       });
       await expect(readFile(join(destinationCodexHome, 'sessions', 'local-rollout.jsonl'), 'utf8')).resolves.toBe('{"id":"local"}\n');
-      await expect(readFile(join(sourceCodexHome, 'history.jsonl'), 'utf8')).resolves.toBe('');
+      await expect(exists(join(sourceCodexHome, 'history.jsonl'))).resolves.toBe(false);
       await expect(exists(join(sourceCodexHome, 'memories', 'raw_memories.md'))).resolves.toBe(false);
+      await expect(readdir(sourceCodexHome)).resolves.not.toContainEqual(expect.stringContaining('.happier-state-preflight-'));
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.test.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.test.ts
@@ -1,9 +1,13 @@
 import { lstat, mkdir, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createCodexHomePair, exists, loadSyncCodexConnectedServiceHome, mockAllSymlinksFail, mockSymlinkFailureForTempLink, settings, waitFor } from './syncCodexConnectedServiceHome.testUtils';
+
+function isSessionsTemporaryLink(path: unknown): boolean {
+  return basename(String(path)).startsWith('sessions.happier-link-');
+}
 
 describe('syncCodexConnectedServiceHome', () => {
   afterEach(async () => {
@@ -63,6 +67,36 @@ describe('syncCodexConnectedServiceHome', () => {
       });
 
       expect(result.targetSqliteHome).toBe(sourceSqliteHome);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('bootstraps a missing native sessions store before materializing shared Codex state', async () => {
+    const { root, sourceCodexHome, destinationCodexHome } = await createCodexHomePair();
+    try {
+      const syncCodexConnectedServiceHome = await loadSyncCodexConnectedServiceHome();
+
+      await syncCodexConnectedServiceHome({
+        destinationCodexHome,
+        accountSettings: settings('isolated', 'shared'),
+        processEnv: { CODEX_HOME: sourceCodexHome },
+      });
+
+      const nativeSessions = join(sourceCodexHome, 'sessions');
+      const materializedSessions = join(destinationCodexHome, 'sessions');
+      expect((await lstat(nativeSessions)).isDirectory()).toBe(true);
+      expect((await lstat(materializedSessions)).isSymbolicLink()).toBe(true);
+
+      await mkdir(join(materializedSessions, '2026', '08', '24'), { recursive: true });
+      await writeFile(
+        join(materializedSessions, '2026', '08', '24', 'rollout-new-session.jsonl'),
+        '{"type":"session"}\n',
+      );
+      await expect(readFile(
+        join(nativeSessions, '2026', '08', '24', 'rollout-new-session.jsonl'),
+        'utf8',
+      )).resolves.toBe('{"type":"session"}\n');
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -271,7 +305,7 @@ describe('syncCodexConnectedServiceHome', () => {
           ...actual,
           rename: vi.fn(async (...args: Parameters<typeof actual.rename>) => {
             const [sourcePath] = args;
-            if (String(sourcePath).includes('sessions.happier-link')) {
+            if (isSessionsTemporaryLink(sourcePath)) {
               const error = new Error('replace failed') as NodeJS.ErrnoException;
               error.code = 'EACCES';
               throw error;
@@ -455,7 +489,7 @@ describe('syncCodexConnectedServiceHome', () => {
           ...actual,
           symlink: vi.fn(async (...args: Parameters<typeof actual.symlink>) => {
             const [, destinationPath] = args;
-            if (String(destinationPath).includes('sessions.happier-link')) {
+            if (isSessionsTemporaryLink(destinationPath)) {
               symlinkCalls.push(String(destinationPath));
               if (symlinkCalls.length === 1) {
                 await firstSymlinkCanFinish;

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.test.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.test.ts
@@ -479,11 +479,11 @@ describe('syncCodexConnectedServiceHome', () => {
 
   it('serializes concurrent syncs for the same destination Codex home', async () => {
     const { root, sourceCodexHome, destinationCodexHome } = await createCodexHomePair();
+    let releaseFirstSymlink = () => {};
     try {
       await mkdir(join(sourceCodexHome, 'sessions'), { recursive: true });
       await writeFile(join(sourceCodexHome, 'sessions', 'source-rollout.jsonl'), '{"id":"source"}\n');
       const symlinkCalls: string[] = [];
-      let releaseFirstSymlink!: () => void;
       const firstSymlinkCanFinish = new Promise<void>((resolve) => {
         releaseFirstSymlink = resolve;
       });
@@ -512,7 +512,7 @@ describe('syncCodexConnectedServiceHome', () => {
         accountSettings: settings('linked', 'shared'),
         processEnv: { CODEX_HOME: sourceCodexHome },
       });
-      await waitFor(() => symlinkCalls.length === 1);
+      await waitFor(() => symlinkCalls.length === 1, 10_000);
       const secondSync = syncCodexConnectedServiceHome({
         destinationCodexHome,
         accountSettings: settings('linked', 'shared'),
@@ -530,6 +530,66 @@ describe('syncCodexConnectedServiceHome', () => {
       releaseFirstSymlink();
       await Promise.all([firstSync, secondSync]);
       expect(symlinkCalls).toHaveLength(4);
+    } finally {
+      releaseFirstSymlink();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reconciles fixed-name Codex state when different homes share one native source', async () => {
+    const { root, sourceCodexHome, destinationCodexHome } = await createCodexHomePair();
+    const secondDestinationCodexHome = join(root, 'materialized-codex-home-2');
+    const firstPreviousCodexHome = join(root, 'previous-codex-home-1');
+    const secondPreviousCodexHome = join(root, 'previous-codex-home-2');
+    try {
+      await mkdir(firstPreviousCodexHome, { recursive: true });
+      await mkdir(secondPreviousCodexHome, { recursive: true });
+      await writeFile(
+        join(firstPreviousCodexHome, 'history.jsonl'),
+        '{"session_id":"first","ts":1,"text":"first prompt"}\n',
+      );
+      await writeFile(
+        join(secondPreviousCodexHome, 'history.jsonl'),
+        '{"session_id":"second","ts":2,"text":"second prompt"}\n',
+      );
+      await writeFile(
+        join(firstPreviousCodexHome, 'session_index.jsonl'),
+        '{"id":"first","thread_name":"First","updated_at":"2026-08-24T10:00:00.000Z"}\n',
+      );
+      await writeFile(
+        join(secondPreviousCodexHome, 'session_index.jsonl'),
+        '{"id":"second","thread_name":"Second","updated_at":"2026-08-24T11:00:00.000Z"}\n',
+      );
+      const syncCodexConnectedServiceHome = await loadSyncCodexConnectedServiceHome();
+
+      await Promise.all([
+        syncCodexConnectedServiceHome({
+          destinationCodexHome,
+          previousCodexHome: firstPreviousCodexHome,
+          accountSettings: settings('linked', 'shared'),
+          processEnv: { CODEX_HOME: sourceCodexHome },
+        }),
+        syncCodexConnectedServiceHome({
+          destinationCodexHome: secondDestinationCodexHome,
+          previousCodexHome: secondPreviousCodexHome,
+          accountSettings: settings('linked', 'shared'),
+          processEnv: { CODEX_HOME: sourceCodexHome },
+        }),
+      ]);
+
+      const historyLines = (await readFile(join(sourceCodexHome, 'history.jsonl'), 'utf8')).trimEnd().split('\n');
+      expect(historyLines).toHaveLength(2);
+      expect(historyLines).toEqual(expect.arrayContaining([
+        '{"session_id":"first","ts":1,"text":"first prompt"}',
+        '{"session_id":"second","ts":2,"text":"second prompt"}',
+      ]));
+      const indexLines = (await readFile(join(sourceCodexHome, 'session_index.jsonl'), 'utf8')).trimEnd().split('\n');
+      expect(indexLines).toHaveLength(2);
+      expect(indexLines).toEqual(expect.arrayContaining([
+        '{"id":"first","thread_name":"First","updated_at":"2026-08-24T10:00:00.000Z"}',
+        '{"id":"second","thread_name":"Second","updated_at":"2026-08-24T11:00:00.000Z"}',
+      ]));
+      await expect(readdir(sourceCodexHome)).resolves.not.toContainEqual(expect.stringContaining('.happier-import-'));
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.testUtils.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.testUtils.ts
@@ -32,10 +32,11 @@ export async function createCodexHomePair(): Promise<{
   return { root, sourceCodexHome, destinationCodexHome };
 }
 
-export async function waitFor(condition: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
+export async function waitFor(condition: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadlineMs = Date.now() + timeoutMs;
+  while (Date.now() < deadlineMs) {
     if (condition()) return;
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
   }
   throw new Error('Timed out waiting for test condition');
 }

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
@@ -17,7 +17,10 @@ import {
   writeConnectedServiceStateSharingManifest,
 } from '@/daemon/connectedServices/stateSharing/connectedServiceStateSharingManifest';
 import { applyConnectedServiceStateSharingDescriptor } from '@/daemon/connectedServices/stateSharing/applyConnectedServiceStateSharingDescriptor';
-import type { ConnectedServiceSessionFileImportDetail } from '@/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles';
+import {
+  importConnectedServiceSessionFiles,
+  type ConnectedServiceSessionFileImportDetail,
+} from '@/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles';
 
 import { resolveConfiguredCodexSqliteHome } from './codexStateFileNames';
 
@@ -145,6 +148,24 @@ async function ensureNativeCodexSharedStateStore(sourceCodexHome: string): Promi
   }));
 }
 
+async function backfillPreviousCodexNonSessionState(params: Readonly<{
+  previousCodexHome?: string | null;
+  sourceCodexHome: string;
+}>): Promise<void> {
+  if (!params.previousCodexHome) return;
+  await importConnectedServiceSessionFiles({
+    roots: [{
+      sourceRoot: params.previousCodexHome,
+      destinationRoot: params.sourceCodexHome,
+      includeDirectory: (relativePath) =>
+        relativePath === 'memories' || relativePath.startsWith('memories/'),
+      includeFile: (relativePath) =>
+        relativePath.startsWith('memories/')
+        || (CODEX_SHARED_STATE_FILE_ENTRIES as readonly string[]).includes(relativePath),
+    }],
+  });
+}
+
 export async function syncCodexConnectedServiceHome(params: Readonly<{
   destinationCodexHome: string;
   previousCodexHome?: string | null;
@@ -173,6 +194,10 @@ export async function syncCodexConnectedServiceHome(params: Readonly<{
 
     await mkdir(params.destinationCodexHome, { recursive: true });
     if (settings.stateMode === 'shared') {
+      await backfillPreviousCodexNonSessionState({
+        previousCodexHome: params.previousCodexHome ?? null,
+        sourceCodexHome,
+      });
       await ensureNativeCodexSharedStateStore(sourceCodexHome);
     }
     const manifest = await readConnectedServiceStateSharingManifest(params.destinationCodexHome);

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
@@ -1,4 +1,4 @@
-import { mkdir, open, readdir } from 'node:fs/promises';
+import { lstat, mkdir, open, readdir, rm } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
 
 import {
@@ -41,6 +41,11 @@ const CODEX_SHARED_STATE_FILE_ENTRIES = Object.freeze([
 ] as const);
 
 type CodexStateMode = 'shared' | 'isolated';
+type CodexSharedStateFileEntry = (typeof CODEX_SHARED_STATE_FILE_ENTRIES)[number];
+
+type NativeCodexSharedStateBootstrap = Readonly<{
+  createdFileEntries: readonly CodexSharedStateFileEntry[];
+}>;
 
 export type CodexConnectedServiceStateSharingDiagnostic = Readonly<{
   code: 'state_symlink_unavailable';
@@ -137,33 +142,65 @@ function resolveVendorResumeIdFromImportedRollout(
   return null;
 }
 
-async function ensureNativeCodexSharedStateStore(sourceCodexHome: string): Promise<void> {
+async function ensureNativeCodexSharedStateStore(sourceCodexHome: string): Promise<NativeCodexSharedStateBootstrap> {
   await mkdir(sourceCodexHome, { recursive: true });
   await Promise.all(CODEX_SHARED_STATE_DIRECTORY_ENTRIES.map(async (entryName) => {
     await mkdir(join(sourceCodexHome, entryName), { recursive: true });
   }));
-  await Promise.all(CODEX_SHARED_STATE_FILE_ENTRIES.map(async (entryName) => {
-    const handle = await open(join(sourceCodexHome, entryName), 'a');
-    await handle.close();
-  }));
+  const createdFileEntries: CodexSharedStateFileEntry[] = [];
+  for (const entryName of CODEX_SHARED_STATE_FILE_ENTRIES) {
+    let handle;
+    try {
+      handle = await open(join(sourceCodexHome, entryName), 'wx');
+      createdFileEntries.push(entryName);
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err?.code === 'EEXIST') continue;
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+  return { createdFileEntries };
 }
 
 async function backfillPreviousCodexNonSessionState(params: Readonly<{
+  bootstrap: NativeCodexSharedStateBootstrap;
   previousCodexHome?: string | null;
   sourceCodexHome: string;
 }>): Promise<void> {
   if (!params.previousCodexHome) return;
-  await importConnectedServiceSessionFiles({
-    roots: [{
-      sourceRoot: params.previousCodexHome,
-      destinationRoot: params.sourceCodexHome,
-      includeDirectory: (relativePath) =>
-        relativePath === 'memories' || relativePath.startsWith('memories/'),
-      includeFile: (relativePath) =>
-        relativePath.startsWith('memories/')
-        || (CODEX_SHARED_STATE_FILE_ENTRIES as readonly string[]).includes(relativePath),
-    }],
-  });
+  // Link preflight needs these files to exist. Release only empty placeholders created by this
+  // sync so recovered files land at their canonical paths instead of becoming conflict copies.
+  await Promise.all(params.bootstrap.createdFileEntries.map(async (entryName) => {
+    const path = join(params.sourceCodexHome, entryName);
+    let stat;
+    try {
+      stat = await lstat(path);
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err?.code === 'ENOENT') return;
+      throw error;
+    }
+    if (stat.isFile() && stat.size === 0) {
+      await rm(path, { force: true });
+    }
+  }));
+  try {
+    await importConnectedServiceSessionFiles({
+      roots: [{
+        sourceRoot: params.previousCodexHome,
+        destinationRoot: params.sourceCodexHome,
+        includeDirectory: (relativePath) =>
+          relativePath === 'memories' || relativePath.startsWith('memories/'),
+        includeFile: (relativePath) =>
+          relativePath.startsWith('memories/')
+          || CODEX_SHARED_STATE_FILE_ENTRIES.some((entryName) => entryName === relativePath),
+      }],
+    });
+  } finally {
+    await ensureNativeCodexSharedStateStore(params.sourceCodexHome);
+  }
 }
 
 export async function syncCodexConnectedServiceHome(params: Readonly<{
@@ -193,13 +230,9 @@ export async function syncCodexConnectedServiceHome(params: Readonly<{
     }
 
     await mkdir(params.destinationCodexHome, { recursive: true });
-    if (settings.stateMode === 'shared') {
-      await backfillPreviousCodexNonSessionState({
-        previousCodexHome: params.previousCodexHome ?? null,
-        sourceCodexHome,
-      });
-      await ensureNativeCodexSharedStateStore(sourceCodexHome);
-    }
+    const sharedStateBootstrap = settings.stateMode === 'shared'
+      ? await ensureNativeCodexSharedStateStore(sourceCodexHome)
+      : null;
     const manifest = await readConnectedServiceStateSharingManifest(params.destinationCodexHome);
     const configEntryNames = await resolveCodexConfigEntryNames(sourceCodexHome);
     const stateEntryNames = codexConnectedServiceStateSharingDescriptor.state.entries.map((entry) => entry.path);
@@ -221,6 +254,13 @@ export async function syncCodexConnectedServiceHome(params: Readonly<{
       existingManifest: manifest,
       configEntryNames,
       stateEntryNames,
+      prepareSharedStateSource: sharedStateBootstrap ? async () => {
+        await backfillPreviousCodexNonSessionState({
+          bootstrap: sharedStateBootstrap,
+          previousCodexHome: params.previousCodexHome ?? null,
+          sourceCodexHome,
+        });
+      } : undefined,
       resolveStateSourceRoot: () => sourceCodexHome,
       mapStateSymlinkUnavailableDiagnostic: (error) => toStateSymlinkUnavailableDiagnostic(error),
       sessionImportRoots: settings.stateMode === 'shared'

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir } from 'node:fs/promises';
+import { mkdir, open, readdir } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
 
 import {
@@ -24,6 +24,17 @@ import { resolveConfiguredCodexSqliteHome } from './codexStateFileNames';
 const CODEX_IMPORTABLE_SESSION_HOME_ENTRIES = Object.freeze([
   'sessions',
   'archived_sessions',
+] as const);
+
+const CODEX_SHARED_STATE_DIRECTORY_ENTRIES = Object.freeze([
+  'sessions',
+  'archived_sessions',
+  'memories',
+] as const);
+
+const CODEX_SHARED_STATE_FILE_ENTRIES = Object.freeze([
+  'session_index.jsonl',
+  'history.jsonl',
 ] as const);
 
 type CodexStateMode = 'shared' | 'isolated';
@@ -123,8 +134,20 @@ function resolveVendorResumeIdFromImportedRollout(
   return null;
 }
 
+async function ensureNativeCodexSharedStateStore(sourceCodexHome: string): Promise<void> {
+  await mkdir(sourceCodexHome, { recursive: true });
+  await Promise.all(CODEX_SHARED_STATE_DIRECTORY_ENTRIES.map(async (entryName) => {
+    await mkdir(join(sourceCodexHome, entryName), { recursive: true });
+  }));
+  await Promise.all(CODEX_SHARED_STATE_FILE_ENTRIES.map(async (entryName) => {
+    const handle = await open(join(sourceCodexHome, entryName), 'a');
+    await handle.close();
+  }));
+}
+
 export async function syncCodexConnectedServiceHome(params: Readonly<{
   destinationCodexHome: string;
+  previousCodexHome?: string | null;
   accountSettings?: AccountSettings | Readonly<Record<string, unknown>> | null;
   processEnv?: NodeJS.ProcessEnv;
 }>): Promise<SyncCodexConnectedServiceHomeResult> {
@@ -149,6 +172,9 @@ export async function syncCodexConnectedServiceHome(params: Readonly<{
     }
 
     await mkdir(params.destinationCodexHome, { recursive: true });
+    if (settings.stateMode === 'shared') {
+      await ensureNativeCodexSharedStateStore(sourceCodexHome);
+    }
     const manifest = await readConnectedServiceStateSharingManifest(params.destinationCodexHome);
     const configEntryNames = await resolveCodexConfigEntryNames(sourceCodexHome);
     const stateEntryNames = codexConnectedServiceStateSharingDescriptor.state.entries.map((entry) => entry.path);
@@ -173,11 +199,14 @@ export async function syncCodexConnectedServiceHome(params: Readonly<{
       resolveStateSourceRoot: () => sourceCodexHome,
       mapStateSymlinkUnavailableDiagnostic: (error) => toStateSymlinkUnavailableDiagnostic(error),
       sessionImportRoots: settings.stateMode === 'shared'
-        ? CODEX_IMPORTABLE_SESSION_HOME_ENTRIES.map((entryName) => ({
-          sourceRoot: join(params.destinationCodexHome, entryName),
+        ? dedupeEntries([
+          resolve(params.destinationCodexHome),
+          ...(params.previousCodexHome ? [resolve(params.previousCodexHome)] : []),
+        ]).flatMap((sessionSourceHome) => CODEX_IMPORTABLE_SESSION_HOME_ENTRIES.map((entryName) => ({
+          sourceRoot: join(sessionSourceHome, entryName),
           destinationRoot: join(sourceCodexHome, entryName),
           includeFile: (relativePath: string) => relativePath.toLowerCase().endsWith('.jsonl'),
-        }))
+        })))
         : [],
       resolveVendorResumeIdFromImportedFile: resolveVendorResumeIdFromImportedRollout,
       providerLabel: 'Codex',

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, open, readdir, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, open, readdir, rm } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
 
 import {
@@ -41,11 +41,6 @@ const CODEX_SHARED_STATE_FILE_ENTRIES = Object.freeze([
 ] as const);
 
 type CodexStateMode = 'shared' | 'isolated';
-type CodexSharedStateFileEntry = (typeof CODEX_SHARED_STATE_FILE_ENTRIES)[number];
-
-type NativeCodexSharedStateBootstrap = Readonly<{
-  createdFileEntries: readonly CodexSharedStateFileEntry[];
-}>;
 
 export type CodexConnectedServiceStateSharingDiagnostic = Readonly<{
   code: 'state_symlink_unavailable';
@@ -142,64 +137,54 @@ function resolveVendorResumeIdFromImportedRollout(
   return null;
 }
 
-async function ensureNativeCodexSharedStateStore(sourceCodexHome: string): Promise<NativeCodexSharedStateBootstrap> {
+async function ensureNativeCodexSharedStateStore(sourceCodexHome: string): Promise<void> {
   await mkdir(sourceCodexHome, { recursive: true });
   await Promise.all(CODEX_SHARED_STATE_DIRECTORY_ENTRIES.map(async (entryName) => {
     await mkdir(join(sourceCodexHome, entryName), { recursive: true });
   }));
-  const createdFileEntries: CodexSharedStateFileEntry[] = [];
-  for (const entryName of CODEX_SHARED_STATE_FILE_ENTRIES) {
-    let handle;
-    try {
-      handle = await open(join(sourceCodexHome, entryName), 'wx');
-      createdFileEntries.push(entryName);
-    } catch (error) {
-      const err = error as NodeJS.ErrnoException;
-      if (err?.code === 'EEXIST') continue;
-      throw error;
-    } finally {
-      await handle?.close();
-    }
-  }
-  return { createdFileEntries };
+  await Promise.all(CODEX_SHARED_STATE_FILE_ENTRIES.map(async (entryName) => {
+    const handle = await open(join(sourceCodexHome, entryName), 'a');
+    await handle.close();
+  }));
 }
 
 async function backfillPreviousCodexNonSessionState(params: Readonly<{
-  bootstrap: NativeCodexSharedStateBootstrap;
   previousCodexHome?: string | null;
   sourceCodexHome: string;
 }>): Promise<void> {
   if (!params.previousCodexHome) return;
-  // Link preflight needs these files to exist. Release only empty placeholders created by this
-  // sync so recovered files land at their canonical paths instead of becoming conflict copies.
-  await Promise.all(params.bootstrap.createdFileEntries.map(async (entryName) => {
-    const path = join(params.sourceCodexHome, entryName);
-    let stat;
-    try {
-      stat = await lstat(path);
-    } catch (error) {
-      const err = error as NodeJS.ErrnoException;
-      if (err?.code === 'ENOENT') return;
-      throw error;
-    }
-    if (stat.isFile() && stat.size === 0) {
-      await rm(path, { force: true });
-    }
-  }));
+  await importConnectedServiceSessionFiles({
+    roots: [{
+      sourceRoot: params.previousCodexHome,
+      destinationRoot: params.sourceCodexHome,
+      includeDirectory: (relativePath) =>
+        relativePath === 'memories' || relativePath.startsWith('memories/'),
+      includeFile: (relativePath) =>
+        relativePath.startsWith('memories/')
+        || CODEX_SHARED_STATE_FILE_ENTRIES.some((entryName) => entryName === relativePath),
+    }],
+  });
+}
+
+async function withCodexSharedStatePreflightSource<T>(params: Readonly<{
+  enabled: boolean;
+  sourceCodexHome: string;
+  run: (preflightSourceCodexHome: string | null) => Promise<T>;
+}>): Promise<T> {
+  if (!params.enabled) return await params.run(null);
+  await mkdir(params.sourceCodexHome, { recursive: true });
+  const preflightSourceCodexHome = await mkdtemp(join(params.sourceCodexHome, '.happier-state-preflight-'));
   try {
-    await importConnectedServiceSessionFiles({
-      roots: [{
-        sourceRoot: params.previousCodexHome,
-        destinationRoot: params.sourceCodexHome,
-        includeDirectory: (relativePath) =>
-          relativePath === 'memories' || relativePath.startsWith('memories/'),
-        includeFile: (relativePath) =>
-          relativePath.startsWith('memories/')
-          || CODEX_SHARED_STATE_FILE_ENTRIES.some((entryName) => entryName === relativePath),
-      }],
-    });
+    await Promise.all(CODEX_SHARED_STATE_DIRECTORY_ENTRIES.map(async (entryName) => {
+      await mkdir(join(preflightSourceCodexHome, entryName), { recursive: true });
+    }));
+    await Promise.all(CODEX_SHARED_STATE_FILE_ENTRIES.map(async (entryName) => {
+      const handle = await open(join(preflightSourceCodexHome, entryName), 'w');
+      await handle.close();
+    }));
+    return await params.run(preflightSourceCodexHome);
   } finally {
-    await ensureNativeCodexSharedStateStore(params.sourceCodexHome);
+    await rm(preflightSourceCodexHome, { recursive: true, force: true });
   }
 }
 
@@ -230,51 +215,55 @@ export async function syncCodexConnectedServiceHome(params: Readonly<{
     }
 
     await mkdir(params.destinationCodexHome, { recursive: true });
-    const sharedStateBootstrap = settings.stateMode === 'shared'
-      ? await ensureNativeCodexSharedStateStore(sourceCodexHome)
-      : null;
     const manifest = await readConnectedServiceStateSharingManifest(params.destinationCodexHome);
     const configEntryNames = await resolveCodexConfigEntryNames(sourceCodexHome);
     const stateEntryNames = codexConnectedServiceStateSharingDescriptor.state.entries.map((entry) => entry.path);
 
-    const applyResult = await applyConnectedServiceStateSharingDescriptor({
-      descriptor: codexConnectedServiceStateSharingDescriptor,
-      nativeSourceContext: {
-        sourceRoot: sourceCodexHome,
-        sourceEnv: processEnv as Record<string, string>,
-      },
-      target: {
-        targetMaterializedRoot: params.destinationCodexHome,
-        targetMaterializedEnv: {},
-      },
-      configMode: settings.configMode,
-      requestedStateMode: settings.stateMode,
-      effectiveStateMode: settings.stateMode,
-      cwd: process.cwd(),
-      existingManifest: manifest,
-      configEntryNames,
-      stateEntryNames,
-      prepareSharedStateSource: sharedStateBootstrap ? async () => {
-        await backfillPreviousCodexNonSessionState({
-          bootstrap: sharedStateBootstrap,
-          previousCodexHome: params.previousCodexHome ?? null,
-          sourceCodexHome,
-        });
-      } : undefined,
-      resolveStateSourceRoot: () => sourceCodexHome,
-      mapStateSymlinkUnavailableDiagnostic: (error) => toStateSymlinkUnavailableDiagnostic(error),
-      sessionImportRoots: settings.stateMode === 'shared'
-        ? dedupeEntries([
-          resolve(params.destinationCodexHome),
-          ...(params.previousCodexHome ? [resolve(params.previousCodexHome)] : []),
-        ]).flatMap((sessionSourceHome) => CODEX_IMPORTABLE_SESSION_HOME_ENTRIES.map((entryName) => ({
-          sourceRoot: join(sessionSourceHome, entryName),
-          destinationRoot: join(sourceCodexHome, entryName),
-          includeFile: (relativePath: string) => relativePath.toLowerCase().endsWith('.jsonl'),
-        })))
-        : [],
-      resolveVendorResumeIdFromImportedFile: resolveVendorResumeIdFromImportedRollout,
-      providerLabel: 'Codex',
+    const applyResult = await withCodexSharedStatePreflightSource({
+      enabled: settings.stateMode === 'shared',
+      sourceCodexHome,
+      run: async (preflightSourceCodexHome) => await applyConnectedServiceStateSharingDescriptor({
+        descriptor: codexConnectedServiceStateSharingDescriptor,
+        nativeSourceContext: {
+          sourceRoot: sourceCodexHome,
+          sourceEnv: processEnv as Record<string, string>,
+        },
+        target: {
+          targetMaterializedRoot: params.destinationCodexHome,
+          targetMaterializedEnv: {},
+        },
+        configMode: settings.configMode,
+        requestedStateMode: settings.stateMode,
+        effectiveStateMode: settings.stateMode,
+        cwd: process.cwd(),
+        existingManifest: manifest,
+        configEntryNames,
+        stateEntryNames,
+        prepareSharedStateSource: preflightSourceCodexHome ? async () => {
+          await backfillPreviousCodexNonSessionState({
+            previousCodexHome: params.previousCodexHome ?? null,
+            sourceCodexHome,
+          });
+          await ensureNativeCodexSharedStateStore(sourceCodexHome);
+        } : undefined,
+        resolveStatePreflightSourceRoot: preflightSourceCodexHome
+          ? () => preflightSourceCodexHome
+          : undefined,
+        resolveStateSourceRoot: () => sourceCodexHome,
+        mapStateSymlinkUnavailableDiagnostic: (error) => toStateSymlinkUnavailableDiagnostic(error),
+        sessionImportRoots: settings.stateMode === 'shared'
+          ? dedupeEntries([
+            resolve(params.destinationCodexHome),
+            ...(params.previousCodexHome ? [resolve(params.previousCodexHome)] : []),
+          ]).flatMap((sessionSourceHome) => CODEX_IMPORTABLE_SESSION_HOME_ENTRIES.map((entryName) => ({
+            sourceRoot: join(sessionSourceHome, entryName),
+            destinationRoot: join(sourceCodexHome, entryName),
+            includeFile: (relativePath: string) => relativePath.toLowerCase().endsWith('.jsonl'),
+          })))
+          : [],
+        resolveVendorResumeIdFromImportedFile: resolveVendorResumeIdFromImportedRollout,
+        providerLabel: 'Codex',
+      }),
     });
 
     await writeConnectedServiceStateSharingManifest(params.destinationCodexHome, applyResult.manifest);

--- a/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
+++ b/apps/cli/src/backends/codex/connectedServices/syncCodexConnectedServiceHome.ts
@@ -10,7 +10,7 @@ import {
 import { codexConnectedServiceStateSharingDescriptor } from '@/backends/codex/connectedServices/codexConnectedServiceStateSharingDescriptor';
 import { resolveConfiguredCodexHome } from '@/backends/codex/utils/resolveConfiguredCodexHome';
 import { ConnectedServiceSharedStateLinkUnavailableError } from '@/daemon/connectedServices/stateSharing/createSharedStateLink';
-import { withConnectedServiceStateSharingDestinationLock } from '@/daemon/connectedServices/stateSharing/connectedServiceStateSharingLock';
+import { withConnectedServiceStateSharingLocks } from '@/daemon/connectedServices/stateSharing/connectedServiceStateSharingLock';
 import {
   readConnectedServiceStateSharingManifest,
   removeLegacyConnectedServiceStateSharingManifest,
@@ -23,6 +23,7 @@ import {
 } from '@/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles';
 
 import { resolveConfiguredCodexSqliteHome } from './codexStateFileNames';
+import { reconcileCodexSharedJsonlState } from './reconcileCodexSharedJsonlState';
 
 const CODEX_IMPORTABLE_SESSION_HOME_ENTRIES = Object.freeze([
   'sessions',
@@ -160,10 +161,10 @@ async function backfillPreviousCodexNonSessionState(params: Readonly<{
       includeDirectory: (relativePath) =>
         relativePath === 'memories' || relativePath.startsWith('memories/'),
       includeFile: (relativePath) =>
-        relativePath.startsWith('memories/')
-        || CODEX_SHARED_STATE_FILE_ENTRIES.some((entryName) => entryName === relativePath),
+        relativePath.startsWith('memories/'),
     }],
   });
+  await reconcileCodexSharedJsonlState(params);
 }
 
 async function withCodexSharedStatePreflightSource<T>(params: Readonly<{
@@ -194,14 +195,17 @@ export async function syncCodexConnectedServiceHome(params: Readonly<{
   accountSettings?: AccountSettings | Readonly<Record<string, unknown>> | null;
   processEnv?: NodeJS.ProcessEnv;
 }>): Promise<SyncCodexConnectedServiceHomeResult> {
-  return await withConnectedServiceStateSharingDestinationLock(params.destinationCodexHome, async () => {
-    const settings = resolveCodexHomeSharingSettings(params.accountSettings ?? null);
-    const processEnv = params.processEnv ?? process.env;
+  const settings = resolveCodexHomeSharingSettings(params.accountSettings ?? null);
+  const processEnv = params.processEnv ?? process.env;
+  const sourceCodexHome = resolveSourceCodexHome({
+    destinationCodexHome: params.destinationCodexHome,
+    processEnv,
+  });
+  const lockRoots = settings.stateMode === 'shared' && sourceCodexHome
+    ? [params.destinationCodexHome, sourceCodexHome]
+    : [params.destinationCodexHome];
+  return await withConnectedServiceStateSharingLocks(lockRoots, async () => {
     const sourceSqliteHome = resolve(resolveConfiguredCodexSqliteHome(processEnv));
-    const sourceCodexHome = resolveSourceCodexHome({
-      destinationCodexHome: params.destinationCodexHome,
-      processEnv,
-    });
     if (!sourceCodexHome) {
       return {
         providerId: 'codex',

--- a/apps/cli/src/daemon/connectedServices/materialize/materializeConnectedServicesForSpawn.ts
+++ b/apps/cli/src/daemon/connectedServices/materialize/materializeConnectedServicesForSpawn.ts
@@ -20,8 +20,11 @@ import {
   serializeConnectedServiceMaterializedEnvKeys,
   serializeConnectedServiceChildSelections,
 } from '../connectedServiceChildEnvironment';
-import type { ConnectedServicesMaterializeResult } from './providerMaterializerTypes';
-import type { ConnectedServicesProviderMaterializerInput } from './providerMaterializerTypes';
+import type {
+  ConnectedServicesMaterializationDiagnostic,
+  ConnectedServicesMaterializeResult,
+  ConnectedServicesProviderMaterializerInput,
+} from './providerMaterializerTypes';
 import { resolveConnectedServiceMaterializedRootDir } from './resolveConnectedServiceMaterializedRootDir';
 import { resolveConnectedServiceTargetMaterializedRoot } from './resolveConnectedServiceTargetMaterializedRoot';
 
@@ -281,6 +284,12 @@ export async function materializeConnectedServicesForSpawn(params: Readonly<{
   vendorResumeId?: string | null;
   candidatePersistedSessionFile?: string | null;
   validateGroupMutationCurrentness?: ConnectedServicesProviderMaterializerInput['validateGroupMutationCurrentness'];
+  validatePromotedMaterialization?: (input: Readonly<{
+    env: Readonly<Record<string, string>>;
+    targetMaterializedRoot: string | null;
+    materializationRoot: string;
+    diagnostics: readonly ConnectedServicesMaterializationDiagnostic[] | undefined;
+  }>) => Promise<void> | void;
 }>): Promise<(ConnectedServicesMaterializeResult & Readonly<{
   materializationRoot: string;
   cleanupMaterializationRoot: () => void;
@@ -316,6 +325,7 @@ export async function materializeConnectedServicesForSpawn(params: Readonly<{
       agentId: params.agentId,
       activeServerDir: params.activeServerDir,
       rootDir: attemptRoot,
+      previousMaterializedRoot: rootDir,
       sessionDirectory: params.sessionDirectory ?? null,
       recordsByServiceId: freshMaterial.recordsByServiceId,
       selectionsByServiceId: freshMaterial.selectionsByServiceId,
@@ -349,6 +359,18 @@ export async function materializeConnectedServicesForSpawn(params: Readonly<{
     agentId: params.agentId,
     targetMaterializedEnv: materializedEnv,
   }) ?? (materialized.cleanupOnFailure ? rootDir : null);
+  const buildPromotedEnv = (): Record<string, string> => ({
+    ...materializedEnv,
+    ...(targetMaterializedRoot
+      ? { [HAPPIER_CONNECTED_SERVICE_TARGET_MATERIALIZED_ROOT_ENV_KEY]: targetMaterializedRoot }
+      : null),
+    ...(serializedSelections
+      ? { [HAPPIER_CONNECTED_SERVICE_SELECTIONS_ENV_KEY]: serializedSelections }
+      : null),
+    ...(serializedMaterializedEnvKeys
+      ? { [HAPPIER_CONNECTED_SERVICE_MATERIALIZED_ENV_KEYS_ENV_KEY]: serializedMaterializedEnvKeys }
+      : null),
+  });
   try {
     await runSerializedPromotion(rootDir, async () => {
       assertActiveAttempt({ rootDir, attemptId, cleanupRoot });
@@ -360,6 +382,13 @@ export async function materializeConnectedServicesForSpawn(params: Readonly<{
             env: materializedEnv,
             targetMaterializedRoot,
             finalRootDir: rootDir,
+          });
+          assertActiveAttempt({ rootDir, attemptId, cleanupRoot });
+          await params.validatePromotedMaterialization?.({
+            env: buildPromotedEnv(),
+            targetMaterializedRoot,
+            materializationRoot: rootDir,
+            diagnostics: materialized.diagnostics,
           });
           assertActiveAttempt({ rootDir, attemptId, cleanupRoot });
         },
@@ -376,19 +405,16 @@ export async function materializeConnectedServicesForSpawn(params: Readonly<{
       cleanupMaterializationRoot: cleanupFinalRoot,
       cleanupOnFailure,
       cleanupOnExit,
-      env: {
-        ...materializedEnv,
-        ...(targetMaterializedRoot
-          ? { [HAPPIER_CONNECTED_SERVICE_TARGET_MATERIALIZED_ROOT_ENV_KEY]: targetMaterializedRoot }
-          : null),
-        ...(serializedSelections
-          ? { [HAPPIER_CONNECTED_SERVICE_SELECTIONS_ENV_KEY]: serializedSelections }
-          : null),
-        ...(serializedMaterializedEnvKeys
-          ? { [HAPPIER_CONNECTED_SERVICE_MATERIALIZED_ENV_KEYS_ENV_KEY]: serializedMaterializedEnvKeys }
-          : null),
-      },
+      env: buildPromotedEnv(),
     };
+  } catch (error) {
+    try {
+      materialized.cleanupOnFailure?.();
+    } catch {
+      // Preserve the validation or promotion failure as the actionable error.
+    }
+    cleanupRoot();
+    throw error;
   } finally {
     forgetActiveAttemptIfCurrent(rootDir, attemptId);
   }

--- a/apps/cli/src/daemon/connectedServices/materialize/providerMaterializerTypes.ts
+++ b/apps/cli/src/daemon/connectedServices/materialize/providerMaterializerTypes.ts
@@ -67,6 +67,7 @@ export type ConnectedServicesProviderMaterializerInput = Readonly<{
   agentId: CatalogAgentId;
   activeServerDir: string;
   rootDir: string;
+  previousMaterializedRoot?: string | null;
   sessionDirectory?: string | null;
   recordsByServiceId: ReadonlyMap<ConnectedServiceId, ConnectedServiceCredentialRecordV1>;
   selectionsByServiceId?: ReadonlyMap<ConnectedServiceId, ConnectedServiceResolvedSelection>;

--- a/apps/cli/src/daemon/connectedServices/resolveConnectedServiceAuthForSpawn.resumeReachability.test.ts
+++ b/apps/cli/src/daemon/connectedServices/resolveConnectedServiceAuthForSpawn.resumeReachability.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
@@ -167,6 +167,129 @@ async function expectPathRemoved(path: string): Promise<void> {
 }
 
 describe('resolveConnectedServiceAuthForSpawn post-materialization resume reachability gate', () => {
+  it('recovers a rollout from the previous Codex materialization when the native sessions store was missing', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-recovery-base-'));
+    const activeServerDir = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-recovery-server-'));
+    const sourceCodexHome = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-recovery-source-home-'));
+    const fakeHome = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-recovery-home-'));
+    const originalHome = process.env.HOME;
+    const now = 1_000_000;
+    const cwd = '/tmp/reverify-codex-recovery-project';
+    const vendorResumeId = '00000000-0000-4000-8000-000000000002';
+    const relativeRolloutPath = join(
+      'sessions',
+      '2026',
+      '08',
+      '24',
+      `rollout-2026-08-24T12-00-00-${vendorResumeId}.jsonl`,
+    );
+    const materializedRoot = resolveConnectedServiceMaterializedRootDir({
+      baseDir,
+      agentId: 'codex',
+      materializationKey: 'codex-session-recovery',
+      materializationIdentity: null,
+    });
+
+    const credentials = makeLegacyCredentials();
+    const api = makeCodexApi(now, credentials);
+    try {
+      process.env.HOME = fakeHome;
+      await mkdir(join(materializedRoot, 'codex-home', 'sessions', '2026', '08', '24'), { recursive: true });
+      await writeFile(
+        join(materializedRoot, 'codex-home', relativeRolloutPath),
+        '{"type":"session"}\n',
+      );
+
+      const connectedServiceAuth = await resolveConnectedServiceAuthForSpawn({
+        agentId: 'codex',
+        sessionDirectory: cwd,
+        connectedServicesBindingsRaw: PI_CONNECTED_BINDINGS,
+        materializationKey: 'codex-session-recovery',
+        activeServerDir,
+        baseDir,
+        credentials,
+        api,
+        nowMs: () => now,
+        accountSettings: sharedStateAccountSettings(),
+        processEnv: {
+          CODEX_HOME: sourceCodexHome,
+          CODEX_SQLITE_HOME: sourceCodexHome,
+          HOME: fakeHome,
+        } as NodeJS.ProcessEnv,
+        vendorResumeId,
+        resumeReachabilityRequired: true,
+      });
+
+      expect(connectedServiceAuth).not.toBeNull();
+      await expect(readFile(join(sourceCodexHome, relativeRolloutPath), 'utf8')).resolves.toBe('{"type":"session"}\n');
+      await expect(readFile(join(connectedServiceAuth!.env.CODEX_HOME!, relativeRolloutPath), 'utf8')).resolves.toBe('{"type":"session"}\n');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      await rm(baseDir, { recursive: true, force: true });
+      await rm(activeServerDir, { recursive: true, force: true });
+      await rm(sourceCodexHome, { recursive: true, force: true });
+      await rm(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  it('restores the previous Codex materialization when resume validation fails', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-rollback-base-'));
+    const activeServerDir = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-rollback-server-'));
+    const sourceCodexHome = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-rollback-source-home-'));
+    const fakeHome = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-rollback-home-'));
+    const originalHome = process.env.HOME;
+    const now = 1_000_000;
+    const cwd = '/tmp/reverify-codex-rollback-project';
+    const materializedRoot = resolveConnectedServiceMaterializedRootDir({
+      baseDir,
+      agentId: 'codex',
+      materializationKey: 'codex-session-rollback',
+      materializationIdentity: null,
+    });
+    const sentinelPath = join(materializedRoot, 'codex-home', 'previous-session.jsonl');
+
+    const credentials = makeLegacyCredentials();
+    const api = makeCodexApi(now, credentials);
+    try {
+      process.env.HOME = fakeHome;
+      await mkdir(join(materializedRoot, 'codex-home'), { recursive: true });
+      await writeFile(sentinelPath, '{"previous":true}\n');
+
+      await expect(resolveConnectedServiceAuthForSpawn({
+        agentId: 'codex',
+        sessionDirectory: cwd,
+        connectedServicesBindingsRaw: PI_CONNECTED_BINDINGS,
+        materializationKey: 'codex-session-rollback',
+        activeServerDir,
+        baseDir,
+        credentials,
+        api,
+        nowMs: () => now,
+        accountSettings: sharedStateAccountSettings(),
+        processEnv: {
+          CODEX_HOME: sourceCodexHome,
+          CODEX_SQLITE_HOME: sourceCodexHome,
+          HOME: fakeHome,
+        } as NodeJS.ProcessEnv,
+        vendorResumeId: '00000000-0000-4000-8000-000000000003',
+        resumeReachabilityRequired: true,
+      })).rejects.toMatchObject({
+        name: 'ConnectedServiceSpawnResumeUnreachableError',
+        reason: 'codex_session_file_not_found',
+      });
+
+      await expect(readFile(sentinelPath, 'utf8')).resolves.toBe('{"previous":true}\n');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      await rm(baseDir, { recursive: true, force: true });
+      await rm(activeServerDir, { recursive: true, force: true });
+      await rm(sourceCodexHome, { recursive: true, force: true });
+      await rm(fakeHome, { recursive: true, force: true });
+    }
+  });
+
   it('cleans up a Codex materialized root when post-materialization resume reachability fails without a provider cleanup hook', async () => {
     const baseDir = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-miss-base-'));
     const activeServerDir = await mkdtemp(join(tmpdir(), 'happier-reverify-codex-miss-server-'));

--- a/apps/cli/src/daemon/connectedServices/resolveConnectedServiceAuthForSpawn.resumeReachability.test.ts
+++ b/apps/cli/src/daemon/connectedServices/resolveConnectedServiceAuthForSpawn.resumeReachability.test.ts
@@ -199,6 +199,19 @@ describe('resolveConnectedServiceAuthForSpawn post-materialization resume reacha
         join(materializedRoot, 'codex-home', relativeRolloutPath),
         '{"type":"session"}\n',
       );
+      await writeFile(
+        join(materializedRoot, 'codex-home', 'history.jsonl'),
+        '{"text":"previous prompt"}\n',
+      );
+      await writeFile(
+        join(materializedRoot, 'codex-home', 'session_index.jsonl'),
+        '{"id":"previous session"}\n',
+      );
+      await mkdir(join(materializedRoot, 'codex-home', 'memories'), { recursive: true });
+      await writeFile(
+        join(materializedRoot, 'codex-home', 'memories', 'raw_memories.md'),
+        '# Previous memory\n',
+      );
 
       const connectedServiceAuth = await resolveConnectedServiceAuthForSpawn({
         agentId: 'codex',
@@ -223,6 +236,10 @@ describe('resolveConnectedServiceAuthForSpawn post-materialization resume reacha
       expect(connectedServiceAuth).not.toBeNull();
       await expect(readFile(join(sourceCodexHome, relativeRolloutPath), 'utf8')).resolves.toBe('{"type":"session"}\n');
       await expect(readFile(join(connectedServiceAuth!.env.CODEX_HOME!, relativeRolloutPath), 'utf8')).resolves.toBe('{"type":"session"}\n');
+      await expect(readFile(join(sourceCodexHome, 'history.jsonl'), 'utf8')).resolves.toBe('{"text":"previous prompt"}\n');
+      await expect(readFile(join(sourceCodexHome, 'session_index.jsonl'), 'utf8')).resolves.toBe('{"id":"previous session"}\n');
+      await expect(readFile(join(sourceCodexHome, 'memories', 'raw_memories.md'), 'utf8')).resolves.toBe('# Previous memory\n');
+      await expect(readFile(join(connectedServiceAuth!.env.CODEX_HOME!, 'memories', 'raw_memories.md'), 'utf8')).resolves.toBe('# Previous memory\n');
     } finally {
       if (originalHome === undefined) delete process.env.HOME;
       else process.env.HOME = originalHome;

--- a/apps/cli/src/daemon/connectedServices/resolveConnectedServiceAuthForSpawn.ts
+++ b/apps/cli/src/daemon/connectedServices/resolveConnectedServiceAuthForSpawn.ts
@@ -1122,30 +1122,23 @@ async function materializeAndVerifyConnectedServiceAuthForSpawn(params: Readonly
     vendorResumeId: params.vendorResumeId,
     candidatePersistedSessionFile: params.candidatePersistedSessionFile,
     validateGroupMutationCurrentness: params.validateGroupMutationCurrentness,
+    validatePromotedMaterialization: async ({ env, diagnostics }) => {
+      assertNoBlockingMaterializationDiagnostics({
+        agentId: params.agentId,
+        diagnostics,
+      });
+      await assertSpawnResumeReachable({
+        agentId: params.agentId,
+        materializedEnv: env,
+        vendorResumeId: params.vendorResumeId,
+        cwd: params.sessionDirectory,
+        resumeReachabilityRequired: params.resumeReachabilityRequired,
+        candidatePersistedSessionFile: params.candidatePersistedSessionFile,
+      });
+    },
   });
 
-  if (!materialized) return null;
-
-  try {
-    assertNoBlockingMaterializationDiagnostics({
-      agentId: params.agentId,
-      diagnostics: materialized.diagnostics,
-    });
-    await assertSpawnResumeReachable({
-      agentId: params.agentId,
-      materializedEnv: materialized.env,
-      vendorResumeId: params.vendorResumeId,
-      cwd: params.sessionDirectory,
-      resumeReachabilityRequired: params.resumeReachabilityRequired,
-      candidatePersistedSessionFile: params.candidatePersistedSessionFile,
-    });
-    return materialized;
-  } catch (error) {
-    const cleanupOnFailure = materialized.cleanupOnFailure
-      ?? materialized.cleanupMaterializationRoot;
-    cleanupOnFailure?.();
-    throw error;
-  }
+  return materialized;
 }
 
 export async function resolveConnectedServiceAuthForSpawn(params: Readonly<{

--- a/apps/cli/src/daemon/connectedServices/stateSharing/applyConnectedServiceStateSharingDescriptor.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/applyConnectedServiceStateSharingDescriptor.ts
@@ -56,6 +56,8 @@ export type ApplyConnectedServiceStateSharingDescriptorInput = Readonly<{
   mapStateSymlinkUnavailableDiagnostic?: (error: ConnectedServiceSharedStateLinkUnavailableError) => ConnectedServicesMaterializationDiagnostic;
   copyTransformByEntry?: Readonly<Record<string, (content: string) => string>>;
   forceCopiedEntries?: readonly string[];
+  /** Runs after shared-state link preflight succeeds and before state is imported or linked. */
+  prepareSharedStateSource?: () => Promise<void>;
   sessionImportRoots?: readonly ConnectedServiceSessionFileImportRoot[];
   resolveVendorResumeIdFromImportedFile?: (detail: ConnectedServiceSessionFileImportDetail) => string | null;
   providerLabel?: string;
@@ -525,6 +527,7 @@ export async function applyConnectedServiceStateSharingDescriptor(
   }
 
   if (input.requestedStateMode === 'shared' && effectiveStateMode === 'shared') {
+    await input.prepareSharedStateSource?.();
     if (input.sessionImportRoots && input.sessionImportRoots.length > 0) {
       const importResult = await importConnectedServiceSessionFiles({ roots: input.sessionImportRoots });
       importedSessionFileMappings = buildSessionFileMappings({

--- a/apps/cli/src/daemon/connectedServices/stateSharing/applyConnectedServiceStateSharingDescriptor.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/applyConnectedServiceStateSharingDescriptor.ts
@@ -49,6 +49,8 @@ export type ApplyConnectedServiceStateSharingDescriptorInput = Readonly<{
   existingManifest?: ConnectedServiceStateSharingManifestV1;
   configEntryNames?: readonly string[];
   stateEntryNames?: readonly string[];
+  /** Overrides the source root only for link preflight; actual state links use resolveStateSourceRoot. */
+  resolveStatePreflightSourceRoot?: (entryName: string) => string;
   resolveStateSourceRoot?: (entryName: string) => string;
   allowHardLinkFallbackForStateEntry?: (entryName: string) => boolean;
   preserveDestinationWhenStateSourceMissing?: (entryName: string) => boolean;
@@ -495,6 +497,7 @@ export async function applyConnectedServiceStateSharingDescriptor(
 
   if (input.requestedStateMode === 'shared' && effectiveStateMode === 'shared') {
     const resolveStateSourceRoot = input.resolveStateSourceRoot ?? (() => sourceRoot);
+    const resolveStatePreflightSourceRoot = input.resolveStatePreflightSourceRoot ?? resolveStateSourceRoot;
     const degradePolicy = input.symlinkUnavailableDegradePolicy ?? input.descriptor.state.symlinkUnavailableDegradePolicy;
     try {
       for (const entryName of stateEntryNames) {
@@ -503,7 +506,7 @@ export async function applyConnectedServiceStateSharingDescriptor(
         await preflightStateLink({
           providerLabel,
           entryName,
-          sourcePath: join(resolve(resolveStateSourceRoot(entryName)), entryName),
+          sourcePath: join(resolve(resolveStatePreflightSourceRoot(entryName)), entryName),
           destinationPath: join(targetRoot, entryName),
           allowHardLinkFallback:
             input.allowHardLinkFallbackForStateEntry?.(entryName)

--- a/apps/cli/src/daemon/connectedServices/stateSharing/connectedServiceStateSharingLock.test.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/connectedServiceStateSharingLock.test.ts
@@ -11,6 +11,7 @@ import { withJsonOwnerFileLock } from '@/utils/fs/jsonOwnerFileLock';
 import {
   ConnectedServiceStateSharingLockError,
   withConnectedServiceStateSharingDestinationLock,
+  withConnectedServiceStateSharingLocks,
 } from './connectedServiceStateSharingLock';
 
 async function waitFor(condition: () => boolean): Promise<void> {
@@ -67,6 +68,36 @@ describe('connectedServiceStateSharingLock', () => {
         events.push('first:end');
       });
       const second = withConnectedServiceStateSharingDestinationLock(destination, async () => {
+        events.push('second:start');
+      });
+
+      await waitFor(() => events.length === 1);
+      expect(events).toEqual(['first:start']);
+      releaseFirst();
+      await Promise.all([first, second]);
+      expect(events).toEqual(['first:start', 'first:end', 'second:start']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('acquires overlapping root sets in one stable order', async () => {
+    const root = join(tmpdir(), `happier-state-sharing-lock-roots-${Date.now()}`);
+    const firstRoot = join(root, 'a');
+    const secondRoot = join(root, 'b');
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    try {
+      const first = withConnectedServiceStateSharingLocks([secondRoot, firstRoot], async () => {
+        events.push('first:start');
+        await firstCanFinish;
+        events.push('first:end');
+      });
+      const second = withConnectedServiceStateSharingLocks([firstRoot, secondRoot], async () => {
         events.push('second:start');
       });
 

--- a/apps/cli/src/daemon/connectedServices/stateSharing/connectedServiceStateSharingLock.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/connectedServiceStateSharingLock.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 
 import { withJsonOwnerFileLock } from '@/utils/fs/jsonOwnerFileLock';
 
-const destinationLocks = new Map<string, Promise<void>>();
+const rootLocks = new Map<string, Promise<void>>();
 
 export class ConnectedServiceStateSharingLockError extends Error {
   readonly code = 'state_sharing_lock_unavailable';
@@ -40,33 +40,33 @@ type LockOptions = Readonly<{
   staleLockTimeoutMs?: number;
 }>;
 
-async function withInProcessDestinationLock<T>(destinationHome: string, fn: () => Promise<T>): Promise<T> {
-  const key = resolve(destinationHome);
-  const previous = destinationLocks.get(key) ?? Promise.resolve();
+async function withInProcessRootLock<T>(rootHome: string, fn: () => Promise<T>): Promise<T> {
+  const key = resolve(rootHome);
+  const previous = rootLocks.get(key) ?? Promise.resolve();
   let release!: () => void;
   const current = new Promise<void>((resolvePromise) => {
     release = resolvePromise;
   });
   const queued = previous.catch(() => undefined).then(() => current);
-  destinationLocks.set(key, queued);
+  rootLocks.set(key, queued);
   await previous.catch(() => undefined);
   try {
     return await fn();
   } finally {
     release();
-    if (destinationLocks.get(key) === queued) {
-      destinationLocks.delete(key);
+    if (rootLocks.get(key) === queued) {
+      rootLocks.delete(key);
     }
   }
 }
 
-export async function withConnectedServiceStateSharingDestinationLock<T>(
-  destinationHome: string,
+async function withConnectedServiceStateSharingRootLock<T>(
+  rootHome: string,
   fn: () => Promise<T>,
   options: LockOptions = {},
 ): Promise<T> {
-  return await withInProcessDestinationLock(destinationHome, async () => {
-    const lockPath = `${resolve(destinationHome)}.happier-state-sharing.lock`;
+  return await withInProcessRootLock(rootHome, async () => {
+    const lockPath = `${resolve(rootHome)}.happier-state-sharing.lock`;
     try {
       return await withJsonOwnerFileLock({
         lockPath,
@@ -75,17 +75,42 @@ export async function withConnectedServiceStateSharingDestinationLock<T>(
         staleAfterMs: options.staleLockTimeoutMs ?? 5 * 60_000,
         errorCode: 'state_sharing_lock_unavailable',
       }, async () => {
-        await mkdir(destinationHome, { recursive: true });
+        await mkdir(rootHome, { recursive: true });
         return await fn();
       });
     } catch (error) {
       if ((error as Error | null)?.message?.startsWith('state_sharing_lock_unavailable')) {
         throw new ConnectedServiceStateSharingLockError({
           providerId: options.providerId ?? null,
-          destinationHome,
+          destinationHome: rootHome,
         });
       }
       throw error;
     }
   });
+}
+
+export async function withConnectedServiceStateSharingLocks<T>(
+  rootHomes: readonly string[],
+  fn: () => Promise<T>,
+  options: LockOptions = {},
+): Promise<T> {
+  const roots = [...new Set(rootHomes.map((rootHome) => resolve(rootHome)))].sort();
+  const acquire = async (index: number): Promise<T> => {
+    if (index >= roots.length) return await fn();
+    return await withConnectedServiceStateSharingRootLock(
+      roots[index],
+      async () => await acquire(index + 1),
+      options,
+    );
+  };
+  return await acquire(0);
+}
+
+export async function withConnectedServiceStateSharingDestinationLock<T>(
+  destinationHome: string,
+  fn: () => Promise<T>,
+  options: LockOptions = {},
+): Promise<T> {
+  return await withConnectedServiceStateSharingLocks([destinationHome], fn, options);
 }

--- a/apps/cli/src/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles.test.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles.test.ts
@@ -33,6 +33,35 @@ describe('importConnectedServiceSessionFiles', () => {
     await expect(readdir(join(destinationRoot, '2026', '05', '21'))).resolves.not.toContain('state.sqlite');
   });
 
+  it('does not traverse directory trees excluded by the root filter', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'happier-session-import-directory-filter-'));
+    const sourceRoot = join(root, 'source');
+    const destinationRoot = join(root, 'destination');
+    await mkdir(join(sourceRoot, 'memories'), { recursive: true });
+    await mkdir(join(sourceRoot, 'sessions', '2026', '05', '21'), { recursive: true });
+    await writeFile(join(sourceRoot, 'history.jsonl'), '{"text":"previous prompt"}\n');
+    await writeFile(join(sourceRoot, 'memories', 'raw_memories.md'), '# Previous memory\n');
+    await writeFile(join(sourceRoot, 'sessions', '2026', '05', '21', 'rollout.jsonl'), '{"id":"session"}\n');
+
+    const result = await importConnectedServiceSessionFiles({
+      roots: [{
+        sourceRoot,
+        destinationRoot,
+        includeDirectory: (relativePath) =>
+          relativePath === 'memories' || relativePath.startsWith('memories/'),
+      }],
+    });
+
+    expect(result).toMatchObject({
+      imported: 2,
+      skippedIdentical: 0,
+      conflicted: 0,
+    });
+    await expect(readFile(join(destinationRoot, 'history.jsonl'), 'utf8')).resolves.toBe('{"text":"previous prompt"}\n');
+    await expect(readFile(join(destinationRoot, 'memories', 'raw_memories.md'), 'utf8')).resolves.toBe('# Previous memory\n');
+    await expect(readdir(destinationRoot)).resolves.not.toContain('sessions');
+  });
+
   it('preserves conflicting destination files and is idempotent for existing imported conflicts', async () => {
     const root = await mkdtemp(join(tmpdir(), 'happier-session-import-conflict-'));
     const sourceRoot = join(root, 'source');

--- a/apps/cli/src/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles.ts
@@ -12,6 +12,7 @@ export type ConnectedServiceSessionFileImportDetail = Readonly<{
 export type ConnectedServiceSessionFileImportRoot = Readonly<{
   sourceRoot: string;
   destinationRoot: string;
+  includeDirectory?: (relativePath: string) => boolean;
   includeFile?: (relativePath: string) => boolean;
 }>;
 
@@ -40,7 +41,7 @@ export async function importConnectedServiceSessionFiles(params: Readonly<{
       resolvePhysicalRoot(destinationRoot),
     ]);
     if (physicalSourceRoot === physicalDestinationRoot) continue;
-    for (const sourcePath of await listImportableFiles(sourceRoot)) {
+    for (const sourcePath of await listImportableFiles(sourceRoot, root.includeDirectory)) {
       const relativePath = normalizeRelativePath(relative(sourceRoot, sourcePath));
       if (!isSafeRelativePath(relativePath)) continue;
       if (root.includeFile && !root.includeFile(relativePath)) continue;
@@ -62,7 +63,10 @@ export async function importConnectedServiceSessionFiles(params: Readonly<{
   };
 }
 
-async function listImportableFiles(root: string): Promise<readonly string[]> {
+async function listImportableFiles(
+  root: string,
+  includeDirectory?: (relativePath: string) => boolean,
+): Promise<readonly string[]> {
   let rootStat;
   try {
     rootStat = await lstat(root);
@@ -81,6 +85,8 @@ async function listImportableFiles(root: string): Promise<readonly string[]> {
     for (const entry of entries) {
       const path = join(dir, entry.name);
       if (entry.isDirectory()) {
+        const relativePath = normalizeRelativePath(relative(root, path));
+        if (includeDirectory && !includeDirectory(relativePath)) continue;
         queue.push(path);
       } else if (entry.isFile()) {
         files.push(path);

--- a/apps/cli/src/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/importConnectedServiceSessionFiles.ts
@@ -12,6 +12,10 @@ export type ConnectedServiceSessionFileImportDetail = Readonly<{
 export type ConnectedServiceSessionFileImportRoot = Readonly<{
   sourceRoot: string;
   destinationRoot: string;
+  /**
+   * Receives normalized relative directory paths; false prunes that directory and every descendant.
+   * Root-level files remain eligible for includeFile.
+   */
   includeDirectory?: (relativePath: string) => boolean;
   includeFile?: (relativePath: string) => boolean;
 }>;


### PR DESCRIPTION
When shared Codex state starts without `~/.codex/sessions`, materialization skips the link, so rollouts remain only in the replaceable materialized home. A failed Resume then validates after the previous home has already been deleted.

This bootstraps native Codex state entries, recovers sessions, history, session index, and memories from the previous materialization only after shared-state link preflight succeeds, and runs spawn validation while atomic rollback can still restore the previous root.

Tested with the CLI typecheck, 73 targeted tests, and the import-cycle guard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790186277&installation_model_id=20481&pr_number=313&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F313&signature=508ef0b2be8d74ac08dbf27baa772f0ed8cf252c5f0163eacf1ac95e56ee981f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve Codex state across rematerialization by importing prior home and serializing locks
> - Passes `previousMaterializedRoot` through the materializer pipeline so that `syncCodexConnectedServiceHome` receives the prior Codex home path and can reconcile non-session state (`memories/**`, `history.jsonl`, `session_index.jsonl`) plus import sessions from both the current destination and the previous root.
> - Adds `withConnectedServiceStateSharingLocks` to acquire multiple root locks in a stable sorted order, preventing deadlocks when destination and source roots overlap.
> - Isolates link preflight checks in a temporary source directory (`withCodexSharedStatePreflightSource`) that is always cleaned up, avoiding leftover artifacts in the native store.
> - Moves post-materialization validation into a `validatePromotedMaterialization` hook invoked during atomic promotion; on failure, `cleanupOnFailure` and attempt-root cleanup run centrally before rethrowing.
> - Adds `includeDirectory` callback to `importConnectedServiceSessionFiles` so callers can prune entire directory subtrees during traversal.
> - Risk: `backfillPreviousCodexNonSessionState` appends missing lines to `history.jsonl` and `session_index.jsonl` in [syncCodexConnectedServiceHome.ts](https://github.com/happier-dev/happier/pull/313/files#diff-b832bfbb8a5aa896cc0dd69c6a8dd94c180398c81b66d648ab021678a0b11a62); if dedup logic misses an edge case, duplicate or stale entries may persist in the native store.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd15970.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connected-service session recovery when resuming from a previous materialization.
  * Restores related history, session indexes, memory data, and shared session files during recovery.
  * Automatically creates required native session storage when missing.
  * Preserves existing materialized state when resume validation fails.
  * Prevents incomplete or invalid materializations from being promoted.
  * Ensures state imports include relevant files while excluding unrelated session data.
  * Cleans up outdated shared state during fallback recovery.
  * Prevents conflicting state updates during concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->