### PR TITLE
fix(codex): page late child rollouts

### DIFF
--- a/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptBackwardCursor.ts
+++ b/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptBackwardCursor.ts
@@ -7,17 +7,34 @@ type CodexBackwardStreamCursorV3 = Readonly<{
   }>[];
 }>;
 
-export function encodeCodexDirectBackwardCursor(value: CodexBackwardStreamCursorV3): string {
+type CodexBackwardStreamCursorV4 = Readonly<{
+  v: 4;
+  kind: 'codexBackwardStreamVector';
+  streams: readonly Readonly<{
+    fileRelPath: string;
+    endOffsetBytes: number;
+    threadId: string;
+    sidechainId: string | null;
+    discoveredFrom?: Readonly<{
+      fileRelPath: string;
+      lineStartOffsetBytes: number;
+    }>;
+  }>[];
+}>;
+
+export type CodexDirectBackwardCursor = CodexBackwardStreamCursorV3 | CodexBackwardStreamCursorV4;
+
+export function encodeCodexDirectBackwardCursor(value: CodexDirectBackwardCursor): string {
   return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
 }
 
-export function decodeCodexDirectBackwardCursor(raw: string | undefined): CodexBackwardStreamCursorV3 | null {
+export function decodeCodexDirectBackwardCursor(raw: string | undefined): CodexDirectBackwardCursor | null {
   if (typeof raw !== 'string' || raw.trim().length === 0) return null;
   try {
     const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as unknown;
     if (!parsed || typeof parsed !== 'object') return null;
     const record = parsed as Record<string, unknown>;
-    if (record.v !== 3 || record.kind !== 'codexBackwardStreamVector') return null;
+    if ((record.v !== 3 && record.v !== 4) || record.kind !== 'codexBackwardStreamVector') return null;
     const rawStreams = Array.isArray(record.streams) ? record.streams : [];
     const streams = rawStreams
       .map((entry) => {
@@ -28,10 +45,43 @@ export function decodeCodexDirectBackwardCursor(raw: string | undefined): CodexB
           ? Math.trunc(streamRecord.endOffsetBytes)
           : NaN;
         if (!fileRelPath || !Number.isFinite(endOffsetBytes) || endOffsetBytes < 0) return null;
-        return { fileRelPath, endOffsetBytes };
+        if (record.v === 3) return { fileRelPath, endOffsetBytes };
+        const threadId = typeof streamRecord.threadId === 'string' ? streamRecord.threadId.trim() : '';
+        const sidechainId = streamRecord.sidechainId === null
+          ? null
+          : typeof streamRecord.sidechainId === 'string' && streamRecord.sidechainId.trim().length > 0
+            ? streamRecord.sidechainId.trim()
+            : undefined;
+        if (!threadId || sidechainId === undefined) return null;
+        const discoveredFrom = (() => {
+          if (!streamRecord.discoveredFrom || typeof streamRecord.discoveredFrom !== 'object'
+              || Array.isArray(streamRecord.discoveredFrom)) return undefined;
+          const discovery = streamRecord.discoveredFrom as Record<string, unknown>;
+          const parentFileRelPath = typeof discovery.fileRelPath === 'string' ? discovery.fileRelPath.trim() : '';
+          const lineStartOffsetBytes = typeof discovery.lineStartOffsetBytes === 'number'
+            && Number.isFinite(discovery.lineStartOffsetBytes)
+            ? Math.trunc(discovery.lineStartOffsetBytes)
+            : NaN;
+          if (!parentFileRelPath || !Number.isSafeInteger(lineStartOffsetBytes) || lineStartOffsetBytes < 0) return null;
+          return { fileRelPath: parentFileRelPath, lineStartOffsetBytes };
+        })();
+        if (streamRecord.discoveredFrom !== undefined && !discoveredFrom) return null;
+        return { fileRelPath, endOffsetBytes, threadId, sidechainId, ...(discoveredFrom ? { discoveredFrom } : {}) };
       })
-      .filter((entry): entry is { fileRelPath: string; endOffsetBytes: number } => entry !== null);
-    return { v: 3, kind: 'codexBackwardStreamVector', streams };
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+    if (streams.length !== rawStreams.length) return null;
+    if (record.v === 3) {
+      const legacyStreams = streams.map((entry) => ({
+        fileRelPath: entry.fileRelPath,
+        endOffsetBytes: entry.endOffsetBytes,
+      }));
+      return { v: 3, kind: 'codexBackwardStreamVector', streams: legacyStreams };
+    }
+    const durableStreams = streams.filter((entry): entry is Extract<typeof entry, { threadId: string }> => (
+      'threadId' in entry && typeof entry.threadId === 'string'
+    ));
+    if (durableStreams.length !== streams.length) return null;
+    return { v: 4, kind: 'codexBackwardStreamVector', streams: durableStreams };
   } catch {
     return null;
   }

--- a/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptBackwardCursor.ts
+++ b/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptBackwardCursor.ts
@@ -14,7 +14,6 @@ type CodexBackwardStreamCursorV4 = Readonly<{
     fileRelPath: string;
     endOffsetBytes: number;
     threadId: string;
-    sidechainId: string | null;
     discoveredFrom?: Readonly<{
       fileRelPath: string;
       lineStartOffsetBytes: number;
@@ -47,12 +46,7 @@ export function decodeCodexDirectBackwardCursor(raw: string | undefined): CodexD
         if (!fileRelPath || !Number.isFinite(endOffsetBytes) || endOffsetBytes < 0) return null;
         if (record.v === 3) return { fileRelPath, endOffsetBytes };
         const threadId = typeof streamRecord.threadId === 'string' ? streamRecord.threadId.trim() : '';
-        const sidechainId = streamRecord.sidechainId === null
-          ? null
-          : typeof streamRecord.sidechainId === 'string' && streamRecord.sidechainId.trim().length > 0
-            ? streamRecord.sidechainId.trim()
-            : undefined;
-        if (!threadId || sidechainId === undefined) return null;
+        if (!threadId) return null;
         const discoveredFrom = (() => {
           if (!streamRecord.discoveredFrom || typeof streamRecord.discoveredFrom !== 'object'
               || Array.isArray(streamRecord.discoveredFrom)) return undefined;
@@ -66,10 +60,11 @@ export function decodeCodexDirectBackwardCursor(raw: string | undefined): CodexD
           return { fileRelPath: parentFileRelPath, lineStartOffsetBytes };
         })();
         if (streamRecord.discoveredFrom !== undefined && !discoveredFrom) return null;
-        return { fileRelPath, endOffsetBytes, threadId, sidechainId, ...(discoveredFrom ? { discoveredFrom } : {}) };
+        return { fileRelPath, endOffsetBytes, threadId, ...(discoveredFrom ? { discoveredFrom } : {}) };
       })
       .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
     if (streams.length !== rawStreams.length) return null;
+    if (new Set(streams.map((entry) => entry.fileRelPath)).size !== streams.length) return null;
     if (record.v === 3) {
       const legacyStreams = streams.map((entry) => ({
         fileRelPath: entry.fileRelPath,

--- a/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptStreamPaging.ts
+++ b/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptStreamPaging.ts
@@ -37,6 +37,36 @@ async function statFileSize(filePath: string): Promise<number> {
   return stat(filePath).then((s) => Math.max(0, Math.trunc(s.size))).catch(() => 0);
 }
 
+type CodexStreamDiscovery = Readonly<{
+  fileRelPath: string;
+  lineStartOffsetBytes: number;
+}>;
+
+async function validatesDiscoveredChildStream(params: Readonly<{
+  streams: readonly CodexDirectTranscriptRolloutStream[];
+  childThreadId: string;
+  discovery: CodexStreamDiscovery;
+}>): Promise<boolean> {
+  const parent = params.streams.find((stream) => stream.fileRelPath === params.discovery.fileRelPath);
+  if (!parent) return false;
+  const page = await readJsonlFileForward({
+    filePath: parent.filePath,
+    offsetBytes: params.discovery.lineStartOffsetBytes,
+    maxBytes: 1024,
+    maxItems: 1,
+  });
+  const line = page.items.find((candidate) => candidate.startOffsetBytes === params.discovery.lineStartOffsetBytes);
+  if (!line) return false;
+  const projected = projectCodexRolloutLineToTranscriptRecords({
+    stream: parent,
+    lineStartOffsetBytes: line.startOffsetBytes,
+    lineNextOffsetBytes: line.endOffsetBytes + 1,
+    lineValue: line.value,
+    semanticTracker: createCodexRolloutSemanticTracker(),
+  });
+  return projected.discoveredChildThreadIds.includes(params.childThreadId);
+}
+
 function normalizeOffsetBytes(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
 }
@@ -389,18 +419,57 @@ export async function pageCodexRolloutStreams(params: Readonly<{
   hasMore: boolean;
   truncated?: boolean;
 }>> {
-  const streams = await collectCodexDirectTranscriptRolloutStreams({
+  const streams = [...await collectCodexDirectTranscriptRolloutStreams({
     codexHome: params.codexHome,
     remoteSessionId: params.remoteSessionId,
     initialRolloutFiles: params.initialRolloutFiles,
-  });
-  const tailCursor = await buildCodexStreamVectorTailCursor(streams);
+  })];
 
   if (params.direction !== 'older') {
+    const tailCursor = await buildCodexStreamVectorTailCursor(streams);
     return { items: [], nextCursor: null, tailCursor, hasMore: false };
   }
 
   const decoded = decodeCodexDirectBackwardCursor(params.cursor);
+  const knownStreamIds = new Set(streams.map((stream) => stream.fileRelPath));
+  const discoveredThreadIds = new Set(streams.map((stream) => stream.threadId));
+  const discoveryByStreamId = new Map<string, CodexStreamDiscovery>();
+  if (decoded?.v === 4) {
+    let pending = decoded.streams.filter((persisted) => !knownStreamIds.has(persisted.fileRelPath));
+    while (pending.length > 0) {
+      const deferred: typeof pending = [];
+      let restored = 0;
+      for (const persisted of pending) {
+        if (!persisted.discoveredFrom) continue;
+        if (!knownStreamIds.has(persisted.discoveredFrom.fileRelPath)) {
+          deferred.push(persisted);
+          continue;
+        }
+        if (!(await validatesDiscoveredChildStream({
+          streams,
+          childThreadId: persisted.threadId,
+          discovery: persisted.discoveredFrom,
+        }))) continue;
+        const files = await collectCodexSessionRolloutFiles({
+          codexHome: params.codexHome,
+          remoteSessionId: persisted.threadId,
+        });
+        const file = files.find((candidate) => candidate.fileRelPath === persisted.fileRelPath);
+        if (!file) continue;
+        knownStreamIds.add(file.fileRelPath);
+        discoveredThreadIds.add(persisted.threadId);
+        discoveryByStreamId.set(file.fileRelPath, persisted.discoveredFrom);
+        streams.push({
+          ...file,
+          threadId: persisted.threadId,
+          sidechainId: persisted.sidechainId,
+        });
+        restored += 1;
+      }
+      if (restored === 0) break;
+      pending = deferred;
+    }
+  }
   const endByStreamId = new Map(decoded?.streams.map((entry) => [entry.fileRelPath, entry.endOffsetBytes] as const) ?? []);
   const maxBytes = Math.max(1, Math.trunc(params.maxBytes));
   const maxItems = Math.max(1, Math.trunc(params.maxItems));
@@ -410,7 +479,8 @@ export async function pageCodexRolloutStreams(params: Readonly<{
   const pageNextEndByStreamId = new Map<string, number>();
   const hasLoadedCandidateByStreamId = new Map<string, boolean>();
 
-  for (const stream of streams) {
+  for (let streamIndex = 0; streamIndex < streams.length; streamIndex += 1) {
+    const stream = streams[streamIndex]!;
     const fileSize = await statFileSize(stream.filePath);
     const endOffsetBytes = Math.min(fileSize, Math.max(0, Math.trunc(endByStreamId.get(stream.fileRelPath) ?? fileSize)));
     initialEndByStreamId.set(stream.fileRelPath, endOffsetBytes);
@@ -436,8 +506,36 @@ export async function pageCodexRolloutStreams(params: Readonly<{
         hasLoadedCandidateByStreamId.set(stream.fileRelPath, true);
       }
       candidateRecords.push(...projected.records);
+      for (const childThreadId of projected.discoveredChildThreadIds) {
+        if (discoveredThreadIds.has(childThreadId)) continue;
+        discoveredThreadIds.add(childThreadId);
+        const childFiles = await collectCodexSessionRolloutFiles({
+          codexHome: params.codexHome,
+          remoteSessionId: childThreadId,
+        });
+        for (const childFile of childFiles) {
+          if (knownStreamIds.has(childFile.fileRelPath)) continue;
+          knownStreamIds.add(childFile.fileRelPath);
+          discoveryByStreamId.set(childFile.fileRelPath, {
+            fileRelPath: stream.fileRelPath,
+            lineStartOffsetBytes: line.startOffsetBytes,
+          });
+          streams.push({
+            ...childFile,
+            threadId: childThreadId,
+            sidechainId: childThreadId,
+          });
+        }
+      }
     }
   }
+
+  streams.sort((left, right) =>
+    left.sortMs - right.sortMs
+    || left.mtimeMs - right.mtimeMs
+    || left.fileRelPath.localeCompare(right.fileRelPath),
+  );
+  const tailCursor = await buildCodexStreamVectorTailCursor(streams);
 
   candidateRecords.sort(compareCodexProjectedRecordsOldestFirst);
   const selectedReversed: CodexProjectedTranscriptRecord[] = [];
@@ -483,10 +581,18 @@ export async function pageCodexRolloutStreams(params: Readonly<{
   const hasMore = hasUndeliveredLoadedRecord || mayHaveUndeliveredRecordBeforeLoadedWindow;
   const nextCursor = hasMore
     ? encodeCodexDirectBackwardCursor({
-      v: 3,
+      v: 4,
       kind: 'codexBackwardStreamVector',
-      streams: [...nextEndByStreamId.entries()]
-        .map(([fileRelPath, endOffsetBytes]) => ({ fileRelPath, endOffsetBytes }))
+      streams: streams
+        .map((stream) => ({
+          fileRelPath: stream.fileRelPath,
+          endOffsetBytes: nextEndByStreamId.get(stream.fileRelPath) ?? 0,
+          threadId: stream.threadId,
+          sidechainId: stream.sidechainId,
+          ...(discoveryByStreamId.get(stream.fileRelPath)
+            ? { discoveredFrom: discoveryByStreamId.get(stream.fileRelPath)! }
+            : {}),
+        }))
         .sort((left, right) => left.fileRelPath.localeCompare(right.fileRelPath)),
     })
     : null;

--- a/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptStreamPaging.ts
+++ b/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptStreamPaging.ts
@@ -42,13 +42,12 @@ type CodexStreamDiscovery = Readonly<{
   lineStartOffsetBytes: number;
 }>;
 
-async function validatesDiscoveredChildStream(params: Readonly<{
+async function readDiscoveredChildThreadIds(params: Readonly<{
   streams: readonly CodexDirectTranscriptRolloutStream[];
-  childThreadId: string;
   discovery: CodexStreamDiscovery;
-}>): Promise<boolean> {
+}>): Promise<readonly string[]> {
   const parent = params.streams.find((stream) => stream.fileRelPath === params.discovery.fileRelPath);
-  if (!parent) return false;
+  if (!parent) return [];
   const page = await readJsonlFileForward({
     filePath: parent.filePath,
     offsetBytes: params.discovery.lineStartOffsetBytes,
@@ -56,7 +55,7 @@ async function validatesDiscoveredChildStream(params: Readonly<{
     maxItems: 1,
   });
   const line = page.items.find((candidate) => candidate.startOffsetBytes === params.discovery.lineStartOffsetBytes);
-  if (!line) return false;
+  if (!line) return [];
   const projected = projectCodexRolloutLineToTranscriptRecords({
     stream: parent,
     lineStartOffsetBytes: line.startOffsetBytes,
@@ -64,7 +63,7 @@ async function validatesDiscoveredChildStream(params: Readonly<{
     lineValue: line.value,
     semanticTracker: createCodexRolloutSemanticTracker(),
   });
-  return projected.discoveredChildThreadIds.includes(params.childThreadId);
+  return projected.discoveredChildThreadIds;
 }
 
 function normalizeOffsetBytes(value: unknown): number {
@@ -434,6 +433,8 @@ export async function pageCodexRolloutStreams(params: Readonly<{
   const knownStreamIds = new Set(streams.map((stream) => stream.fileRelPath));
   const discoveredThreadIds = new Set(streams.map((stream) => stream.threadId));
   const discoveryByStreamId = new Map<string, CodexStreamDiscovery>();
+  const discoveredChildThreadIdsByProvenance = new Map<string, readonly string[]>();
+  const rolloutFilesByThreadId = new Map<string, readonly CodexRolloutFile[]>();
   if (decoded?.v === 4) {
     let pending = decoded.streams.filter((persisted) => !knownStreamIds.has(persisted.fileRelPath));
     while (pending.length > 0) {
@@ -445,15 +446,27 @@ export async function pageCodexRolloutStreams(params: Readonly<{
           deferred.push(persisted);
           continue;
         }
-        if (!(await validatesDiscoveredChildStream({
-          streams,
-          childThreadId: persisted.threadId,
-          discovery: persisted.discoveredFrom,
-        }))) continue;
-        const files = await collectCodexSessionRolloutFiles({
-          codexHome: params.codexHome,
-          remoteSessionId: persisted.threadId,
-        });
+        const provenanceKey = JSON.stringify([
+          persisted.discoveredFrom.fileRelPath,
+          persisted.discoveredFrom.lineStartOffsetBytes,
+        ]);
+        let validChildThreadIds = discoveredChildThreadIdsByProvenance.get(provenanceKey);
+        if (validChildThreadIds === undefined) {
+          validChildThreadIds = await readDiscoveredChildThreadIds({
+            streams,
+            discovery: persisted.discoveredFrom,
+          });
+          discoveredChildThreadIdsByProvenance.set(provenanceKey, validChildThreadIds);
+        }
+        if (!validChildThreadIds.includes(persisted.threadId)) continue;
+        let files = rolloutFilesByThreadId.get(persisted.threadId);
+        if (files === undefined) {
+          files = await collectCodexSessionRolloutFiles({
+            codexHome: params.codexHome,
+            remoteSessionId: persisted.threadId,
+          });
+          rolloutFilesByThreadId.set(persisted.threadId, files);
+        }
         const file = files.find((candidate) => candidate.fileRelPath === persisted.fileRelPath);
         if (!file) continue;
         knownStreamIds.add(file.fileRelPath);

--- a/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptStreamPaging.ts
+++ b/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptStreamPaging.ts
@@ -462,7 +462,7 @@ export async function pageCodexRolloutStreams(params: Readonly<{
         streams.push({
           ...file,
           threadId: persisted.threadId,
-          sidechainId: persisted.sidechainId,
+          sidechainId: persisted.threadId,
         });
         restored += 1;
       }
@@ -588,7 +588,6 @@ export async function pageCodexRolloutStreams(params: Readonly<{
           fileRelPath: stream.fileRelPath,
           endOffsetBytes: nextEndByStreamId.get(stream.fileRelPath) ?? 0,
           threadId: stream.threadId,
-          sidechainId: stream.sidechainId,
           ...(discoveryByStreamId.get(stream.fileRelPath)
             ? { discoveredFrom: discoveryByStreamId.get(stream.fileRelPath)! }
             : {}),

--- a/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptStreamPaging.ts
+++ b/apps/cli/src/backends/codex/directSessions/codexDirectTranscriptStreamPaging.ts
@@ -42,10 +42,10 @@ type CodexStreamDiscovery = Readonly<{
   lineStartOffsetBytes: number;
 }>;
 
-async function readDiscoveredChildThreadIds(params: Readonly<{
+const readDiscoveredChildThreadIds = async (params: Readonly<{
   streams: readonly CodexDirectTranscriptRolloutStream[];
   discovery: CodexStreamDiscovery;
-}>): Promise<readonly string[]> {
+}>): Promise<readonly string[]> => {
   const parent = params.streams.find((stream) => stream.fileRelPath === params.discovery.fileRelPath);
   if (!parent) return [];
   const page = await readJsonlFileForward({
@@ -64,7 +64,7 @@ async function readDiscoveredChildThreadIds(params: Readonly<{
     semanticTracker: createCodexRolloutSemanticTracker(),
   });
   return projected.discoveredChildThreadIds;
-}
+};
 
 function normalizeOffsetBytes(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;

--- a/apps/cli/src/backends/codex/directSessions/pageCodexTranscript.lateChild.test.ts
+++ b/apps/cli/src/backends/codex/directSessions/pageCodexTranscript.lateChild.test.ts
@@ -1,0 +1,164 @@
+import { mkdir, mkdtemp, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { pageCodexTranscript } from './pageCodexTranscript';
+
+function responseItemLine(text: string, timestamp: string): string {
+  return `${JSON.stringify({
+    type: 'response_item', timestamp,
+    payload: { type: 'message', role: 'assistant', content: [{ type: 'text', text }] },
+  })}\n`;
+}
+
+function sessionMetaLine(id: string, index: number): string {
+  return `${JSON.stringify({
+    type: 'session_meta',
+    payload: {
+      id,
+      timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+      cwd: `/repo/${index}-${'x'.repeat(2_000)}`,
+    },
+  })}\n`;
+}
+
+function spawnLine(parent: string, child: string, timestamp: string): string {
+  return `${JSON.stringify({
+    type: 'event_msg', timestamp,
+    payload: {
+      type: 'collab_agent_spawn_end', sender_thread_id: parent,
+      new_thread_id: child, prompt: `spawn ${child}`,
+    },
+  })}\n`;
+}
+
+async function createLateChildFixture(params: Readonly<{
+  sessionId: string;
+  childThreadId: string;
+  childText: string;
+  childTimestamp: string;
+}>): Promise<Readonly<{ root: string; codexHome: string; parentFileName: string; childFileName: string }>> {
+  const root = await mkdtemp(join(tmpdir(), 'happier-codex-direct-late-child-'));
+  const codexHome = join(root, 'codex-home');
+  const sessionsDir = join(codexHome, 'sessions');
+  await mkdir(sessionsDir, { recursive: true });
+  const parentFileName = `rollout-2026-01-02T00-00-00-${params.sessionId}.jsonl`;
+  const childFileName = `rollout-2026-01-02T00-00-01-${params.childThreadId}.jsonl`;
+  const filler = Array.from({ length: 700 }, (_, index) => sessionMetaLine(params.sessionId, index)).join('');
+  await writeFile(
+    join(sessionsDir, parentFileName),
+    filler + spawnLine(params.sessionId, params.childThreadId, '2026-01-03T00:00:01.000Z'),
+    'utf8',
+  );
+  await writeFile(
+    join(sessionsDir, childFileName),
+    responseItemLine(params.childText, params.childTimestamp),
+    'utf8',
+  );
+  return { root, codexHome, parentFileName, childFileName };
+}
+
+async function page(params: Readonly<{
+  root: string;
+  codexHome: string;
+  sessionId: string;
+  cursor?: string;
+  maxItems?: number;
+}>) {
+  return pageCodexTranscript({
+    source: { kind: 'codexHome', home: 'user' },
+    env: { CODEX_HOME: params.codexHome } as NodeJS.ProcessEnv,
+    activeServerDir: join(params.root, 'servers', 'cloud'),
+    remoteSessionId: params.sessionId,
+    direction: 'older', cursor: params.cursor,
+    maxBytes: 1024 * 1024, maxItems: params.maxItems ?? 30,
+  });
+}
+
+describe('pageCodexTranscript late child rollout discovery', () => {
+  it('includes a child whose spawn event is beyond the bounded discovery window', async () => {
+    const sessionId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    const fixture = await createLateChildFixture({
+      sessionId,
+      childThreadId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      childText: 'late child summary',
+      childTimestamp: '2026-01-03T00:00:02.000Z',
+    });
+
+    expect(JSON.stringify((await page({ ...fixture, sessionId })).items)).toContain('late child summary');
+  });
+
+  it('keeps a late child available across older pages', async () => {
+    const sessionId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const fixture = await createLateChildFixture({
+      sessionId,
+      childThreadId: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+      childText: 'late child older',
+      childTimestamp: '2025-12-31T23:59:58.000Z',
+    });
+
+    const first = await page({ ...fixture, sessionId, maxItems: 1 });
+    expect(JSON.stringify(first.items)).toContain('spawn eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee');
+    const second = await page({ ...fixture, sessionId, cursor: first.nextCursor ?? undefined, maxItems: 1 });
+    expect(JSON.stringify(second.items)).toContain('late child older');
+  });
+
+  it('ignores a forged child identity from an opaque cursor', async () => {
+    const sessionId = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+    const unrelatedThreadId = '12121212-1212-1212-1212-121212121212';
+    const root = await mkdtemp(join(tmpdir(), 'happier-codex-direct-forged-child-'));
+    const codexHome = join(root, 'codex-home');
+    const sessionsDir = join(codexHome, 'sessions');
+    await mkdir(sessionsDir, { recursive: true });
+    const parentFileName = `rollout-2026-01-02T00-00-00-${sessionId}.jsonl`;
+    const unrelatedFileName = `rollout-2026-01-02T00-00-01-${unrelatedThreadId}.jsonl`;
+    await writeFile(join(sessionsDir, parentFileName), sessionMetaLine(sessionId, 0), 'utf8');
+    const unrelatedPath = join(sessionsDir, unrelatedFileName);
+    await writeFile(unrelatedPath, responseItemLine('must stay unrelated', '2026-01-02T00:00:02.000Z'), 'utf8');
+    const forgedCursor = Buffer.from(JSON.stringify({
+      v: 4, kind: 'codexBackwardStreamVector',
+      streams: [{
+        fileRelPath: `sessions/${unrelatedFileName}`,
+        endOffsetBytes: (await stat(unrelatedPath)).size,
+        threadId: unrelatedThreadId,
+        sidechainId: unrelatedThreadId,
+        discoveredFrom: { fileRelPath: `sessions/${parentFileName}`, lineStartOffsetBytes: 0 },
+      }],
+    }), 'utf8').toString('base64url');
+
+    expect(JSON.stringify((await page({ root, codexHome, sessionId, cursor: forgedCursor })).items))
+      .not.toContain('must stay unrelated');
+  });
+
+  it('restores nested children independent of cursor entry ordering', async () => {
+    const rootThreadId = '31313131-3131-3131-3131-313131313131';
+    const childThreadId = 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz';
+    const grandchildThreadId = '11111111-2222-3333-4444-555555555555';
+    const fixture = await createLateChildFixture({
+      sessionId: rootThreadId,
+      childThreadId,
+      childText: '',
+      childTimestamp: '2026-01-01T00:00:00.000Z',
+    });
+    const sessionsDir = join(fixture.codexHome, 'sessions');
+    const childFiller = Array.from({ length: 700 }, (_, index) => sessionMetaLine(childThreadId, index)).join('');
+    await writeFile(
+      join(sessionsDir, fixture.childFileName),
+      childFiller + spawnLine(childThreadId, grandchildThreadId, '2026-01-03T00:00:02.000Z'),
+      'utf8',
+    );
+    await writeFile(
+      join(sessionsDir, `rollout-2026-01-02T00-00-02-${grandchildThreadId}.jsonl`),
+      responseItemLine('nested grandchild history', '2025-12-31T00:00:00.000Z'),
+      'utf8',
+    );
+
+    const first = await page({ ...fixture, sessionId: rootThreadId, maxItems: 1 });
+    const second = await page({ ...fixture, sessionId: rootThreadId, cursor: first.nextCursor ?? undefined, maxItems: 1 });
+    const third = await page({ ...fixture, sessionId: rootThreadId, cursor: second.nextCursor ?? undefined, maxItems: 1 });
+    expect([first, second, third].map((result) => JSON.stringify(result.items)).join('\n'))
+      .toContain('nested grandchild history');
+  });
+});

--- a/apps/cli/src/backends/codex/directSessions/pageCodexTranscript.lateChild.test.ts
+++ b/apps/cli/src/backends/codex/directSessions/pageCodexTranscript.lateChild.test.ts
@@ -77,6 +77,26 @@ async function page(params: Readonly<{
   });
 }
 
+function decodeOpaqueCursor(cursor: string): Readonly<{
+  v: number;
+  kind: string;
+  streams: ReadonlyArray<Record<string, unknown>>;
+}> {
+  return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as Readonly<{
+    v: number;
+    kind: string;
+    streams: ReadonlyArray<Record<string, unknown>>;
+  }>;
+}
+
+function encodeOpaqueCursor(cursor: Readonly<{
+  v: number;
+  kind: string;
+  streams: ReadonlyArray<Record<string, unknown>>;
+}>): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
 describe('pageCodexTranscript late child rollout discovery', () => {
   it('includes a child whose spawn event is beyond the bounded discovery window', async () => {
     const sessionId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
@@ -130,6 +150,58 @@ describe('pageCodexTranscript late child rollout discovery', () => {
 
     expect(JSON.stringify((await page({ root, codexHome, sessionId, cursor: forgedCursor })).items))
       .not.toContain('must stay unrelated');
+  });
+
+  it('derives a restored child sidechain from its validated thread identity', async () => {
+    const sessionId = '14141414-1414-1414-1414-141414141414';
+    const childThreadId = '15151515-1515-1515-1515-151515151515';
+    const fixture = await createLateChildFixture({
+      sessionId,
+      childThreadId,
+      childText: 'validated child identity',
+      childTimestamp: '2025-12-31T23:59:58.000Z',
+    });
+    const first = await page({ ...fixture, sessionId, maxItems: 1 });
+    if (!first.nextCursor) throw new Error('Expected another page');
+    const decoded = decodeOpaqueCursor(first.nextCursor);
+    const forgedCursor = encodeOpaqueCursor({
+      ...decoded,
+      streams: decoded.streams.map((stream) => (
+        stream.threadId === childThreadId
+          ? { ...stream, sidechainId: 'forged-sidechain' }
+          : stream
+      )),
+    });
+
+    const restored = await page({ ...fixture, sessionId, cursor: forgedCursor, maxItems: 1 });
+    const childItem = restored.items.find((item) => JSON.stringify(item).includes('validated child identity'));
+    expect(childItem).toMatchObject({
+      raw: { content: { data: { sidechainId: childThreadId } } },
+    });
+  });
+
+  it('rejects an opaque cursor that repeats the same rollout stream', async () => {
+    const sessionId = '16161616-1616-1616-1616-161616161616';
+    const childThreadId = '17171717-1717-1717-1717-171717171717';
+    const fixture = await createLateChildFixture({
+      sessionId,
+      childThreadId,
+      childText: 'unique child history',
+      childTimestamp: '2025-12-31T23:59:58.000Z',
+    });
+    const first = await page({ ...fixture, sessionId, maxItems: 1 });
+    if (!first.nextCursor) throw new Error('Expected another page');
+    const decoded = decodeOpaqueCursor(first.nextCursor);
+    const childStream = decoded.streams.find((stream) => stream.threadId === childThreadId);
+    if (!childStream) throw new Error('Expected child stream in cursor');
+    const duplicateCursor = encodeOpaqueCursor({
+      ...decoded,
+      streams: [...decoded.streams, childStream],
+    });
+
+    const restored = await page({ ...fixture, sessionId, cursor: duplicateCursor, maxItems: 10 });
+    expect(restored.truncated).toBe(true);
+    expect(restored.items.filter((item) => JSON.stringify(item).includes('unique child history'))).toHaveLength(1);
   });
 
   it('restores nested children independent of cursor entry ordering', async () => {

--- a/apps/cli/src/backends/codex/directSessions/pageCodexTranscript.lateChild.test.ts
+++ b/apps/cli/src/backends/codex/directSessions/pageCodexTranscript.lateChild.test.ts
@@ -1,3 +1,4 @@
+import { createHook } from 'node:async_hooks';
 import { mkdir, mkdtemp, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -95,6 +96,24 @@ function encodeOpaqueCursor(cursor: Readonly<{
   streams: ReadonlyArray<Record<string, unknown>>;
 }>): string {
   return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+async function countFsPromiseResources<T>(work: () => Promise<T>): Promise<Readonly<{
+  result: T;
+  count: number;
+}>> {
+  let count = 0;
+  const hook = createHook({
+    init: (_asyncId, type) => {
+      if (type === 'FSREQPROMISE') count += 1;
+    },
+  });
+  hook.enable();
+  try {
+    return { result: await work(), count };
+  } finally {
+    hook.disable();
+  }
 }
 
 describe('pageCodexTranscript late child rollout discovery', () => {
@@ -202,6 +221,42 @@ describe('pageCodexTranscript late child rollout discovery', () => {
     const restored = await page({ ...fixture, sessionId, cursor: duplicateCursor, maxItems: 10 });
     expect(restored.truncated).toBe(true);
     expect(restored.items.filter((item) => JSON.stringify(item).includes('unique child history'))).toHaveLength(1);
+  });
+
+  it('does not repeat filesystem discovery for forged paths sharing one validated child', async () => {
+    const sessionId = '18181818-1818-1818-1818-181818181818';
+    const childThreadId = '19191919-1919-1919-1919-191919191919';
+    const fixture = await createLateChildFixture({
+      sessionId,
+      childThreadId,
+      childText: 'bounded child restoration',
+      childTimestamp: '2025-12-31T23:59:58.000Z',
+    });
+    const first = await page({ ...fixture, sessionId, maxItems: 1 });
+    if (!first.nextCursor) throw new Error('Expected another page');
+    const decoded = decodeOpaqueCursor(first.nextCursor);
+    const childStream = decoded.streams.find((stream) => stream.threadId === childThreadId);
+    if (!childStream) throw new Error('Expected child stream in cursor');
+    const forgedCursor = encodeOpaqueCursor({
+      ...decoded,
+      streams: [
+        ...decoded.streams,
+        ...Array.from({ length: 10 }, (_, index) => ({
+          ...childStream,
+          fileRelPath: `sessions/forged-child-${index}.jsonl`,
+        })),
+      ],
+    });
+
+    const baseline = await countFsPromiseResources(
+      async () => await page({ ...fixture, sessionId, cursor: first.nextCursor ?? undefined, maxItems: 10 }),
+    );
+    const forged = await countFsPromiseResources(
+      async () => await page({ ...fixture, sessionId, cursor: forgedCursor, maxItems: 10 }),
+    );
+
+    expect(JSON.stringify(forged.result.items)).toContain('bounded child restoration');
+    expect(forged.count).toBeLessThanOrEqual(baseline.count + 2);
   });
 
   it('restores nested children independent of cursor entry ordering', async () => {

--- a/apps/cli/src/backends/codex/directSessions/pageCodexTranscript.lateChild.test.ts
+++ b/apps/cli/src/backends/codex/directSessions/pageCodexTranscript.lateChild.test.ts
@@ -98,10 +98,10 @@ function encodeOpaqueCursor(cursor: Readonly<{
   return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
 }
 
-async function countFsPromiseResources<T>(work: () => Promise<T>): Promise<Readonly<{
+const countFsPromiseResources = async <T>(work: () => Promise<T>): Promise<Readonly<{
   result: T;
   count: number;
-}>> {
+}>> => {
   let count = 0;
   const hook = createHook({
     init: (_asyncId, type) => {
@@ -114,7 +114,7 @@ async function countFsPromiseResources<T>(work: () => Promise<T>): Promise<Reado
   } finally {
     hook.disable();
   }
-}
+};
 
 describe('pageCodexTranscript late child rollout discovery', () => {
   it('includes a child whose spawn event is beyond the bounded discovery window', async () => {


### PR DESCRIPTION
## Summary

- add child rollout streams when backward paging reaches a SubAgent spawn beyond the initial bounded discovery window
- preserve late-discovered and nested child streams across older-page cursors
- validate exact parent rollout provenance before trusting child identities carried by opaque cursors

## Why

Fixes #324.

Current `dev` already avoids whole-file Codex transcript materialization by using bounded byte-offset paging. Child discovery is intentionally bounded to the first 1 MiB / 512 entries, though, so a SubAgent spawned later in a long session gets a synthetic tool row without its child rollout ever joining the Direct transcript.

I reproduced this with a >1 MiB parent fixture and also observed real spawn events beyond 13 MiB in a 239 MiB / 100,750-line Codex rollout.

## How to test

1. `yarn workspace @happier-dev/cli vitest run src/backends/codex/directSessions/pageCodexTranscript.test.ts src/backends/codex/directSessions/readAfterCodexTranscript.test.ts src/backends/codex/directSessions/codexDirectTranscriptHistoryBoundary.test.ts src/api/directSessions/filePaging/jsonlBackwardPager.test.ts src/api/directSessions/filePaging/jsonlForwardReader.test.ts --config vitest.config.ts`
2. `yarn workspace @happier-dev/cli typecheck`
3. On a real 239 MiB rollout, current `dev` returned the latest 30 items in about 35 ms of the core paging call; this patch preserves that bounded path.

## Notes

- Backward cursor v3 remains readable; new pages emit v4 with stream identity.
- Late-child cursor entries include the exact parent stream and byte offset that declared the child. A later request rereads and verifies that JSONL line before resolving the child rollout, so a forged opaque cursor cannot select an unrelated local thread.
- No server, Relay protocol, or UI changes.

## AI assistance

I used OpenAI Codex to inspect the paging implementation, generate the initial failing fixtures, and iterate on the cursor safety review. I personally verified the real-rollout timing, RED/GREEN behavior, 37 focused tests, CLI typecheck, and the final diff.

## Checklist

- [x] PR targets `dev` (not `main`)
- [x] Linked issue #324
- [x] Added behavior tests
- [x] No docs change required; RPC protocol is unchanged
- [x] AI assistance disclosed with personally verified checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790287518&installation_model_id=20481&pr_number=325&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F325&signature=2dead1de1f760f7adf09e9a46b883958138ebec6ad4d2b7d1718a16e461c8342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix codex transcript pagination to discover and restore late child rollouts via v4 cursor
> - Introduces a v4 backward-stream cursor variant (`CodexBackwardStreamCursorV4`) that carries per-stream `threadId` and optional `discoveredFrom` provenance (parent file path + line-start byte offset)
> - `pageCodexRolloutStreams` now dynamically discovers child rollout streams while paging, appends them to the working set, and restores validated child streams referenced by v4 cursors even when they are not initially present
> - `readDiscoveredChildThreadIds` validates that a parent rollout line at the given provenance offset actually lists the claimed child thread ID before restoring it, preventing forged identities from opaque cursors
> - Cursors emitted by pagination are now v4, including thread identity and provenance for each stream; streams are sorted deterministically by `sortMs`, then `mtimeMs`, then `fileRelPath`
> - Adds tests in [pageCodexTranscript.lateChild.test.ts](https://github.com/happier-dev/happier/pull/325/files#diff-643f650e9007ddb20c835b7dce12d7426ea4121882851adaebab2a08ca9b012f) covering cross-page discovery, forged-child rejection, duplicate-stream rejection, and nested restoration
> - Behavioral Change: pagination now emits v4 cursors instead of v3; older clients that only decode v3 will fail to parse the new cursor. `decodeCodexDirectBackwardCursor` still accepts v3 input but returns null on invalid `discoveredFrom`, duplicate `fileRelPath`, or any invalid stream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e19ac8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved backward pagination for Codex transcripts by preserving discovered child threads and nested conversations across pages.
  * Added support for newer pagination cursors with validated thread and discovery metadata.
  * Late-discovered child conversations now appear reliably when browsing older transcript pages.

* **Bug Fixes**
  * Prevented malformed, forged, duplicate, or invalid pagination entries from injecting unauthorized transcript content.
  * Improved restoration of nested conversations and consistent stream ordering across pages.
  * Added safeguards to keep transcript discovery bounded during pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->