### PR TITLE
fix(cli): stabilize remaining nightly CI regressions

### DIFF
--- a/apps/cli/src/backends/claude/claudeLocalLauncher.ts
+++ b/apps/cli/src/backends/claude/claudeLocalLauncher.ts
@@ -203,8 +203,8 @@ export async function claudeLocalLauncher(
             if (observation?.historicalReplay) {
                 await transcriptProjector.observeCommitted(message);
             } else {
-                await transcriptProjector.observe(message);
                 lifecycleTracker.observeTranscript(message);
+                await transcriptProjector.observe(message);
             }
         },
         // Native Claude `/goal` source (plan H7): goal_status attachments + the

--- a/apps/cli/src/daemon/connectedServices/stateSharing/applyConnectedServiceStateSharingDescriptor.destinationRace.test.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/applyConnectedServiceStateSharingDescriptor.destinationRace.test.ts
@@ -43,6 +43,7 @@ async function applyDescriptor(params: Readonly<{
 
 describe('applyConnectedServiceStateSharingDescriptor destination races', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.doUnmock('node:fs/promises');
     vi.resetModules();
   });
@@ -97,6 +98,7 @@ describe('applyConnectedServiceStateSharingDescriptor destination races', () => 
   );
 
   it('throws after exactly three destination races and removes the prepared temporary link', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
     const root = await mkdtemp(join(tmpdir(), 'happier-state-link-race-exhausted-'));
     const sourceRoot = join(root, 'source');
     const targetRoot = join(root, 'target');

--- a/apps/cli/src/daemon/connectedServices/stateSharing/connectedServiceHomeEntrySync.ts
+++ b/apps/cli/src/daemon/connectedServices/stateSharing/connectedServiceHomeEntrySync.ts
@@ -42,6 +42,8 @@ export async function moveConnectedServiceHomeEntryAside(path: string): Promise<
     } catch (error) {
       const err = error as NodeJS.ErrnoException;
       if (err?.code === 'ENOENT') return;
+      // A same-timestamp sibling collision can report EEXIST, ENOTEMPTY, or EISDIR
+      // depending on whether the existing backup is a file or directory and the host OS.
       if (err?.code === 'EEXIST' || err?.code === 'ENOTEMPTY' || err?.code === 'EISDIR') continue;
       throw error;
     }

--- a/apps/cli/src/daemon/service/readBackgroundServiceHealth.test.ts
+++ b/apps/cli/src/daemon/service/readBackgroundServiceHealth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { spawnSyncMock } = vi.hoisted(() => ({
   spawnSyncMock: vi.fn<typeof import('node:child_process').spawnSync>(),
@@ -14,8 +14,14 @@ vi.mock('node:child_process', async (importOriginal) => {
 
 import { readBackgroundServiceHealth } from './readBackgroundServiceHealth';
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe('readBackgroundServiceHealth', () => {
   it('classifies a failed restarting systemd user service as crash-looping', () => {
+    vi.stubEnv('XDG_RUNTIME_DIR', '');
+    vi.stubEnv('DBUS_SESSION_BUS_ADDRESS', '');
     spawnSyncMock.mockImplementation((cmd, args) => {
       if (cmd === 'systemctl') {
         return {


### PR DESCRIPTION
## Summary

- preserve local Claude active-turn visibility while exact transcript persistence is pending, so UI-triggered remote switches cannot abort a turn before lifecycle tracking sees it
- make connected-service backup collision coverage deterministic and document the cross-platform collision error variants handled by the canonical owner
- isolate background-service health coverage from inherited systemd runtime environment variables

## Validation

- `yarn -s vitest run --config vitest.config.ts src/daemon/connectedServices/stateSharing/applyConnectedServiceStateSharingDescriptor.destinationRace.test.ts src/daemon/service/readBackgroundServiceHealth.test.ts` — 7 tests passed
- `HAPPIER_CLI_TEST_SKIP_BUILD=1 yarn -s vitest run --config vitest.integration.config.ts src/backends/claude/claudeLocalLauncher.integration.test.ts` — 35 tests passed; the override skips only the redundant isolated-worktree package build
- `git diff --check origin/dev...fix/nightly-cli-ci-red-tests` — passed
- CLI typecheck was attempted, but the dependency-linked validation worktree resolved Zod through the primary checkout and failed with unrelated TS2883 portability output in `src/session/runtimeActivity/types.ts`; CI will run against a normal install

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/happier-dev/codesmith/happier/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296473&installation_model_id=20481&pr_number=326&repository=happier-dev%2Fhappier&return_to=https%3A%2F%2Fgithub.com%2Fhappier-dev%2Fhappier%2Fpull%2F326&signature=5ea29f01b9a9f500706b80527e99cdeb6e8ce3d61e04ab2f07af39110550ce77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nightly CI regressions in `claudeLocalLauncher` and `moveConnectedServiceHomeEntryAside`
> - Reorders `lifecycleTracker.observeTranscript` to run before `transcriptProjector.observe` in the non-replay branch of `claudeLocalLauncher` onMessage handler, ensuring lifecycle tracking happens before projection for live messages
> - Expands retryable error codes in `moveConnectedServiceHomeEntryAside` to include `ENOTEMPTY` and `EISDIR` in addition to `EEXIST`, so rename retries up to 100 attempts instead of throwing immediately
> - Stabilizes flaky tests: restores mocks in `destinationRace.test.ts`, stubs `Date.now` to a fixed value, and stubs `XDG_RUNTIME_DIR`/`DBUS_SESSION_BUS_ADDRESS` in `readBackgroundServiceHealth.test.ts`
> - Risk: `moveConnectedServiceHomeEntryAside` now silently retries on `ENOTEMPTY`/`EISDIR` up to 100 times, which could mask a persistent directory conflict where an immediate error was previously thrown
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47fadee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live transcript activity is now recorded before messages are displayed, improving lifecycle tracking during active sessions.

* **Tests**
  * Improved test isolation and reliability by resetting mocks, environment variables, and timing values between tests.
  * Added coverage for platform-specific file collision behavior and service health detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->